### PR TITLE
Use the correct default thunderbird path on Windows

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -3,6 +3,13 @@
 #include <QDir>
 
 #include "settings.h"
+#include "utils.h"
+
+#ifdef Q_OS_WIN
+#  define THUNDERBIRD_EXE_PATH "\"%ProgramFiles(x86)%\\Mozilla Thunderbird\\thunderbird.exe\""
+#else
+#  define THUNDERBIRD_EXE_PATH "/usr/bin/thunderbird"
+#endif
 
 Settings * pSettings;
 
@@ -105,7 +112,7 @@ void Settings::load()
     mLaunchThunderbirdDelay = settings.value("common/launchthunderbirddelay", 0 ).toInt();
     mShowUnreadEmailCount = settings.value("common/showunreademailcount", true ).toBool();
 
-    mThunderbirdCmdLine = settings.value("advanced/tbcmdline", "/usr/bin/thunderbird" ).toString();
+    mThunderbirdCmdLine = settings.value("advanced/tbcmdline", THUNDERBIRD_EXE_PATH).toString();
     mThunderbirdWindowMatch = settings.value("advanced/tbwindowmatch", "- Mozilla Thunderbird" ).toString();
     mNotificationMinimumFontSize = settings.value("advanced/notificationfontminsize", 4 ).toInt();
     mNotificationMaximumFontSize = settings.value("advanced/notificationfontmaxsize", 512 ).toInt();
@@ -138,6 +145,15 @@ void Settings::load()
         QString entry = "newemail/id" + QString::number( index );
         mNewEmailData.push_back( Setting_NewEmail::fromByteArray( settings.value( entry, "" ).toByteArray() ) );
     }
+}
+
+QString Settings::getThunderbirdExecutablePath() {
+    QString path = mThunderbirdCmdLine;
+    if (path.startsWith('"')) {
+        path = path.section('"', 1, 1);
+    }
+    path = Utils::expandPath(path);
+    return '"' + QFileInfo(path).absoluteFilePath() + '"';
 }
 
 void Settings::savePixmap(QSettings &settings, const QString &key, const QPixmap &pixmap)

--- a/src/settings.h
+++ b/src/settings.h
@@ -110,6 +110,11 @@ class Settings
         // Load and save them
         void    save();
         void    load();
+        
+        /**
+         * @return The absolute path to the thunderbird executable.
+         */
+        QString getThunderbirdExecutablePath();
 
     private:
         void    savePixmap( QSettings& settings, const QString& key, const QPixmap& pixmap );

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -423,7 +423,7 @@ void TrayIcon::actionNewEmail()
         args << pSettings->mNewEmailData[index].asArgs();
     }
 
-    QProcess::startDetached( pSettings->mThunderbirdCmdLine, args );
+    QProcess::startDetached( pSettings->getThunderbirdExecutablePath(), args );
 }
 
 void TrayIcon::actionIgnoreEmails()
@@ -552,7 +552,8 @@ void TrayIcon::createUnreadCounterThread()
 
 void TrayIcon::startThunderbird()
 {
-    Utils::debug("Starting Thunderbird as '%s'", qPrintable( pSettings->mThunderbirdCmdLine ) );
+    QString thunderbirdExePath = pSettings->getThunderbirdExecutablePath();
+    Utils::debug("Starting Thunderbird as '%s'", qPrintable( thunderbirdExePath ) );
 
     if ( mThunderbirdProcess )
         mThunderbirdProcess->deleteLater();
@@ -564,7 +565,7 @@ void TrayIcon::startThunderbird()
     connect( mThunderbirdProcess, &QProcess::errorOccurred, this, &TrayIcon::tbProcessError );
 #endif
 
-    mThunderbirdProcess->start( pSettings->mThunderbirdCmdLine );
+    mThunderbirdProcess->start( thunderbirdExePath );
 }
 
 void TrayIcon::tbProcessError(QProcess::ProcessError )
@@ -572,7 +573,7 @@ void TrayIcon::tbProcessError(QProcess::ProcessError )
     QMessageBox::critical( 0,
                            tr("Cannot start Thunderbird"),
                            tr("Error starting Thunderbird as %1:\n\n%2")
-                                .arg( pSettings->mThunderbirdCmdLine )
+                                .arg( pSettings->getThunderbirdExecutablePath() )
                                 .arg( mThunderbirdProcess->errorString() ) );
 
     // We keep the mThunderbirdProcess pointer, so the process is not restarted again

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,6 +8,14 @@ class Utils
     public:
         // Decodes IMAP UTF7 data
         static QString  decodeIMAPutf7( const QString& param );
+    
+        /**
+         * Expand the path as a shell would do. This will expand variables and ~/
+         *
+         * @param path The path.
+         * @return The expanded path.
+         */
+        static QString expandPath(const QString& path);
 
         static void debug( const char * fmt, ... );
 };


### PR DESCRIPTION
Previously on first start, Birdtray would fail to start Thunderbird on Windows.

This also adds support for shell like expansion of the path, which expands variables and `~`.
Additionally, paths which contain spaces are handled as well.