### PR TITLE
Fix tray icon still visible after birdtray closes on Windows

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -343,7 +343,7 @@ void TrayIcon::actionQuit()
             mWinTools->closeWindow();
     }
 
-    exit( 0 );
+    QApplication::quit();
 }
 
 void TrayIcon::actionSettings()


### PR DESCRIPTION
Previously, Birdtray would leave a "ghost" tray icon behind after closing.