### PR TITLE
Add windows installer with the Qt installer framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 build*/
 cmake-build-*/
 src/birdtray.pro.user
+installer/birdTray-*
+installer/**/*.xml
+installer/packages/com.ulduzsoft.birdtray.main/data/**
+installer/packages/com.ulduzsoft.birdtray.main/meta/LICENSE
 
 .idea/*
 !.idea/codeStyles

--- a/installer/buildInstaller.py
+++ b/installer/buildInstaller.py
@@ -1,0 +1,86 @@
+import os
+import logging
+import platform
+import sys
+
+from argparse import ArgumentParser
+from time import strftime
+from shutil import copy2, which
+from subprocess import check_call
+
+
+def fillTemplates(path, newPath, templateVariables):
+    with open(path) as templateFile:
+        with open(newPath, 'w') as outputFile:
+            for line in templateFile.readlines():
+                outputFile.write(line.format(**templateVariables))
+
+
+def copyPrerequisites(exePath):
+    destination = os.path.join('packages', 'com.ulduzsoft.birdtray.main', 'meta')
+    os.makedirs(destination, exist_ok=True)
+    copy2(os.path.join('..', 'LICENSE'), destination)
+    destination = os.path.join('packages', 'com.ulduzsoft.birdtray.main', 'data')
+    os.makedirs(destination, exist_ok=True)
+    copy2(exePath, destination)
+
+
+def createDeploy(winDeployPath):
+    logging.getLogger('deploy').info('Creating deployment...')
+    exePath = os.path.join('packages', 'com.ulduzsoft.birdtray.main', 'data', 'birdtray.exe')
+    check_call([winDeployPath, '--release', '--no-plugins', '--no-system-d3d-compiler',
+                '--no-quick-import', '--no-webkit2', '--no-angle', '--no-opengl-sw', '--no-patchqt',
+                '-no-svg', exePath])
+
+
+def createInstaller(binaryCreatorPath, version, arch):
+    logging.getLogger('installer').info('Creating installer...')
+    installerName = 'birdTray-{version}-{platform}-{arch}.exe'.format(
+        version=version, platform=platform.system().lower(), arch=arch)
+    check_call([binaryCreatorPath, '-c', os.path.join('config', 'config.xml'),
+                '-p', os.path.join('packages'), installerName])
+
+
+def main():
+    parser = ArgumentParser(description='Script to create the birdtray executable.')
+    parser.add_argument('-v', '--version', required=True, help='The BirdTray version')
+    parser.add_argument('--winDeployPath', required=True, help='Path to the windeployqt executable')
+    parser.add_argument('--binaryCreatorPath', required=True,
+                        help='Path to the binarycreator executable')
+    parser.add_argument('--exePath', required=True, help='Path to the BirdTray executable')
+    parser.add_argument('--compilerPath', required=False, help='Path to the g++ executable')
+    parser.add_argument('-a', '--arch', required=True,
+                        help='Architecture of the BirdTray executable')
+    parser.add_argument('-d', '--debug', required=True, default=False, action='store_true',
+                        help='Display debugging output')
+    arguments = parser.parse_args()
+
+    logging.basicConfig(format='[%(levelname)-5s] %(name)-10s: %(message)s',
+                        level=logging.DEBUG if arguments.debug else logging.INFO)
+    logger = logging.getLogger('main')
+
+    if which('g++.exe') is None:
+        if arguments.compilerPath is None:
+            logging.error('g++.exe must be in the path.')
+            sys.exit(1)
+        os.environ['Path'] += os.path.pathsep + os.path.dirname(arguments.compilerPath)
+
+    templateVariables = {
+        'version': arguments.version,
+        'date': strftime('%Y-%m-%d'),
+    }
+    for root, dirs, files in os.walk('.'):
+        for file in files:
+            if file.endswith('.template'):
+                path = os.path.join(root, file)
+                logger.debug('Filling template {path}'.format(path=path))
+                fillTemplates(path, path[:-9], templateVariables)
+
+    copyPrerequisites(arguments.exePath)
+    createDeploy(arguments.winDeployPath)
+    createInstaller(arguments.binaryCreatorPath, arguments.version, arguments.arch)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/installer/config/config.xml.template
+++ b/installer/config/config.xml.template
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Installer>
+    <Name>BirdTray</Name>
+    <Version>{version}</Version>
+    <Title>BirdTray</Title>
+    <Publisher>Ulduzsoft</Publisher>
+    <ProductUrl>ulduzsoft.com</ProductUrl>
+    <StartMenuDir>BirdTray</StartMenuDir>
+    <TargetDir>@ApplicationsDir@/BirdTray</TargetDir>
+    <RemoveTargetDir>true</RemoveTargetDir>
+    <RunProgram>@ApplicationsDir@/BirdTray/birdtray.exe</RunProgram>
+    <RunProgramDescription>Run BirdTray</RunProgramDescription>
+</Installer>

--- a/installer/packages/com.ulduzsoft.birdtray.autorun/meta/installScript.qs
+++ b/installer/packages/com.ulduzsoft.birdtray.autorun/meta/installScript.qs
@@ -1,0 +1,23 @@
+function Component() {
+    // constructor
+    if (installer.isInstaller()) {
+        installer.setValue("AllUsers", true);
+    }
+}
+
+Component.prototype.createOperations = function() {
+    component.createOperations();
+    try {
+        var reg = installer.environmentVariable("SystemRoot") + "\\System32\\reg.exe";
+        var cmd = installer.environmentVariable("SystemRoot") + "\\System32\\cmd.exe";
+
+        component.addOperation(
+            "Execute", reg, "add", "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+                "/v", "BirdTray", "/t", "REG_SZ", "/d",
+                 installer.value("TargetDir") + "\\birdtray.exe",
+            "UNDOEXECUTE", reg, "delete", "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+                "/f", "/v", "BirdTray");
+    } catch (e) {
+        print(e);
+    }
+}

--- a/installer/packages/com.ulduzsoft.birdtray.autorun/meta/package.xml.template
+++ b/installer/packages/com.ulduzsoft.birdtray.autorun/meta/package.xml.template
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+    <DisplayName>Autorun entry</DisplayName>
+    <Description>Automatically start BirdTray on logon.</Description>
+    <Version>1.0.0</Version>
+    <ReleaseDate>{date}</ReleaseDate>
+    <RequiresAdminRights>true</RequiresAdminRights>
+    <Dependencies>com.ulduzsoft.birdtray.main</Dependencies>
+    <Script>installScript.qs</Script>
+    <Default>false</Default>
+</Package>

--- a/installer/packages/com.ulduzsoft.birdtray.main/meta/package.xml.template
+++ b/installer/packages/com.ulduzsoft.birdtray.main/meta/package.xml.template
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+    <DisplayName>BirdTray application</DisplayName>
+    <Description>The BirdTray application.</Description>
+    <Version>{version}</Version>
+    <ReleaseDate>{date}</ReleaseDate>
+    <Licenses>
+        <License name="GNU General Public License v3.0" file="LICENSE" />
+    </Licenses>
+    <ForcedInstallation>true</ForcedInstallation>
+    <RequiresAdminRights>true</RequiresAdminRights>
+    <Checkable>false</Checkable>
+</Package>


### PR DESCRIPTION
This adds a script that creates a windows installer for BirdTray.
The installer has an option to add an autostart entry for BirdTray.

## WIP
This is not finished yet and I mostly want to get your opinion on this.
I'm using the Qt installer framework, because the project is written with Qt, but in my opinion the installer has several issues:

* No back button during the installation.
* Unable to overwrite/update a previous installation.
* Unable to repair the installation. The maintenance tool in the installation directory also can't do it, even though it gives the option to update/modify on the first page.
* The installation is taking up a lot of space (43 Mb on my machine, when only 21 Mb are technically needed). To be fair, 3 Mb are used for translations, but the rest is mostly used by the maintenance tool, which is a lot for a tool that is only able to uninstall the application.

Currently, `windeployqt` also does not copy the sqlite3 dll to the deploy directory, but that might just be because of my complicated compiler setup (I use [MSYS2](https://www.msys2.org/)).

I'm also using a Python script to automate the creation of the installer. The idea is to be able to run the script from Jenkins and then deploy the installer to Github. If you don't want to use Python, I can rewrite the script in another language.

So, what are your thoughts on this?