### PR TITLE
Add metadata for the Windows executable generated by the Qt project

### DIFF
--- a/src/birdtray.pro
+++ b/src/birdtray.pro
@@ -71,6 +71,8 @@ FORMS += \
 RESOURCES += \
     resources.qrc
 
+RC_FILE = res\birdtray.rc
+
 unix {
      SOURCES += windowtools_x11.cpp
      HEADERS += windowtools_x11.h


### PR DESCRIPTION
Sorry, I forgot to add that to #69.