### PR TITLE
Show an error dialog when we encountered a fatal error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
         passed++;
 
         if ( passed > 120 )
-            qFatal( "Sorry, system tray cannot be controlled through this addon on your operating system");
+            Utils::fatal("Sorry, system tray cannot be controlled "
+                         "through this addon on your operating system");
 
         QThread::usleep( 500 );
     }

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -731,7 +731,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
     MorkParser p;
 
     if ( !p.open( filename ) )
-		Utils::fatal("Error opening mork file");
+        Utils::fatal("Error opening mork file");
 
     for ( TableScopeMap::iterator tit = p.mork_.begin(); tit != p.mork_.end(); ++tit )
     {

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -27,6 +27,7 @@
 
 
 #include "morkparser.h"
+#include "utils.h"
 #include <QtCore>
 
 
@@ -730,7 +731,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
     MorkParser p;
 
     if ( !p.open( filename ) )
-        qFatal("error opening mork file");
+		Utils::fatal("Error opening mork file");
 
     for ( TableScopeMap::iterator tit = p.mork_.begin(); tit != p.mork_.end(); ++tit )
     {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -93,7 +93,7 @@ void Settings::load()
     if ( mNotificationIcon.isNull() )
     {
         if ( !mNotificationIcon.load( ":res/thunderbird.png" ) )
-            qFatal("cannot load icon");
+            Utils::fatal("Cannot load default system tray icon");
     }
 
     mNotificationDefaultColor = QColor( settings.value( "common/defaultcolor", "#00FF00" ).toString() );

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,6 +2,7 @@
 #include "settings.h"
 
 #include <QTextCodec>
+#include <QtWidgets/QMessageBox>
 
 #if defined (Q_OS_WIN)
 #  include <windows.h>
@@ -166,4 +167,18 @@ void Utils::debug(const char *fmt, ...)
     va_end( vl );
 
     qDebug( "%s", buf );
+}
+
+
+void Utils::fatal(const char *fmt, ...)
+{
+    va_list vl;
+    char buf[8192];
+
+    va_start( vl, fmt );
+    vsnprintf( buf, sizeof(buf) - 1, fmt, vl );
+    va_end( vl );
+
+    QMessageBox::critical(nullptr, "Fatal", buf);
+    qFatal("%s", buf);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@ class Utils
         static QString expandPath(const QString& path);
 
         static void debug( const char * fmt, ... );
+        [[ noreturn ]] static void fatal( const char * fmt, ... );
 };
 
 #endif // UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,8 +17,8 @@ class Utils
          */
         static QString expandPath(const QString& path);
 
-        static void debug( const char * fmt, ... );
-        [[ noreturn ]] static void fatal( const char * fmt, ... );
+        static void debug( const char * fmt, ... ) Q_ATTRIBUTE_FORMAT_PRINTF(1, 2);
+        Q_NORETURN static void fatal( const char * fmt, ... ) Q_ATTRIBUTE_FORMAT_PRINTF(1, 2);
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
Previously, if birdtray was started on a platform where Qt has no system tray support, it would just abort without a message. A user would probably assume, birdtray had crashed.
This adds an error dialog displaying the message before passing it to qFatal.