### PR TITLE
Remove unneeded image format dlls

### DIFF
--- a/installer/buildInstaller.bat
+++ b/installer/buildInstaller.bat
@@ -78,6 +78,11 @@ if errorLevel 1 (
     echo Failed to create deployment folder: windeployqt.exe failed 1>&2
     exit /b %errorLevel%
 )
+if exist "%deploymentFolder%\imageformats" (
+    for /f %%F in ('dir "%deploymentFolder%\imageformats" /b /a-d ^| findstr /vile "qico.dll"') do (
+        del "%deploymentFolder%\imageformats\%%F" 1>nul
+    )
+)
 
 rem  #### Create the actual installer ####
 echo Creating the installer...


### PR DESCRIPTION
This removes all dlls needed by Qt to support additional image formats, reducing the size of the installer and the installation. `qico.dll` is excluded, because it is needed to display the birdtray window icons. Png files are still supported, because Qt does not require an additional dll to load them. For additional info, see [here](https://github.com/gyunaev/birdtray/pull/71#issuecomment-475914098).