### PR TITLE
Fix a crash when trying to clear accounts when we have no accounts

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -409,7 +409,7 @@ void DialogSettings::unreadParserChanged(int curr)
     }
 
     // Did we change comparing to settings?
-    if ( mAccountModel->rowCount() && isMorkParserSelected() != pSettings->mUseMorkParser )
+    if ( mAccountModel->rowCount() != 0 && isMorkParserSelected() != pSettings->mUseMorkParser )
     {
         if ( QMessageBox::question( 0,
                                tr("WARNING: Parser changed"),

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -409,7 +409,7 @@ void DialogSettings::unreadParserChanged(int curr)
     }
 
     // Did we change comparing to settings?
-    if (  isMorkParserSelected() != pSettings->mUseMorkParser )
+    if ( mAccountModel->numAccounts() != 0 && isMorkParserSelected() != pSettings->mUseMorkParser )
     {
         if ( QMessageBox::question( 0,
                                tr("WARNING: Parser changed"),

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -409,7 +409,7 @@ void DialogSettings::unreadParserChanged(int curr)
     }
 
     // Did we change comparing to settings?
-    if ( mAccountModel->numAccounts() != 0 && isMorkParserSelected() != pSettings->mUseMorkParser )
+    if ( mAccountModel->rowCount() && isMorkParserSelected() != pSettings->mUseMorkParser )
     {
         if ( QMessageBox::question( 0,
                                tr("WARNING: Parser changed"),

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -57,7 +57,7 @@ QModelIndex ModelAccountTree::parent(const QModelIndex &) const
 
 int ModelAccountTree::rowCount(const QModelIndex &) const
 {
-    return numAccounts();
+    return mAccounts.size();
 }
 
 Qt::ItemFlags ModelAccountTree::flags(const QModelIndex &) const
@@ -112,13 +112,9 @@ void ModelAccountTree::removeAccount(const QModelIndex &idx)
     endRemoveRows();
 }
 
-int ModelAccountTree::numAccounts() const {
-    return mAccounts.size();
-}
-
 void ModelAccountTree::clear()
 {
-    if (mColors.size() <= 0) {
+    if (mColors.isEmpty()) {
         return;
     }
     beginRemoveRows( QModelIndex(), 0, mColors.size() - 1 );

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -57,7 +57,7 @@ QModelIndex ModelAccountTree::parent(const QModelIndex &) const
 
 int ModelAccountTree::rowCount(const QModelIndex &) const
 {
-    return mAccounts.size();
+    return numAccounts();
 }
 
 Qt::ItemFlags ModelAccountTree::flags(const QModelIndex &) const
@@ -112,8 +112,15 @@ void ModelAccountTree::removeAccount(const QModelIndex &idx)
     endRemoveRows();
 }
 
+int ModelAccountTree::numAccounts() const {
+    return mAccounts.size();
+}
+
 void ModelAccountTree::clear()
 {
+    if (mColors.size() <= 0) {
+        return;
+    }
     beginRemoveRows( QModelIndex(), 0, mColors.size() - 1 );
     mAccounts.clear();
     mColors.clear();

--- a/src/modelaccounttree.h
+++ b/src/modelaccounttree.h
@@ -24,11 +24,6 @@ class ModelAccountTree : public QAbstractItemModel
         void    editAccount( const QModelIndex& idx, const QString& uri, const QColor& color );
         void    getAccount( const QModelIndex& idx, QString& uri, QColor& color );
         void    removeAccount( const QModelIndex& idx );
-        
-        /**
-         * @return The number of accounts in the model.
-         */
-        int     numAccounts() const;
         void    clear();
 
         // Moves the current accounts/colors to settings

--- a/src/modelaccounttree.h
+++ b/src/modelaccounttree.h
@@ -24,6 +24,11 @@ class ModelAccountTree : public QAbstractItemModel
         void    editAccount( const QModelIndex& idx, const QString& uri, const QColor& color );
         void    getAccount( const QModelIndex& idx, QString& uri, QColor& color );
         void    removeAccount( const QModelIndex& idx );
+        
+        /**
+         * @return The number of accounts in the model.
+         */
+        int     numAccounts() const;
         void    clear();
 
         // Moves the current accounts/colors to settings


### PR DESCRIPTION
If a user had no accounts configured for monitoring and switched the method to parse unread notifications from Mork to Sqlite, we would display a dialog asking them to delete all old accounts and then crash, after the user clicked continue.
These changes ensure that we don't crash and that we don't show the dialog if we don't have any accounts to delete.