### PR TITLE
Cleanup sqlite database path handling

### DIFF
--- a/src/databaseaccounts.cpp
+++ b/src/databaseaccounts.cpp
@@ -4,10 +4,10 @@
 #include "sqlite_statement.h"
 #include "sqlite3.h"
 
-DatabaseAccounts::DatabaseAccounts( const QString& dbpath  )
+DatabaseAccounts::DatabaseAccounts( const QString& databasePath  )
 {
     moveToThread( this );
-    mDbPath = dbpath + QDir::separator() + "global-messages-db.sqlite";
+    mDbPath = databasePath;
 }
 
 const QList<DatabaseAccounts::Account> &DatabaseAccounts::accounts() const
@@ -61,4 +61,8 @@ void DatabaseAccounts::queryAccounts()
     }
 
     emit done ( "" );
+}
+
+const QString DatabaseAccounts::getDatabasePath(const QString &directory) {
+    return QDir(directory).filePath("global-messages-db.sqlite");
 }

--- a/src/databaseaccounts.h
+++ b/src/databaseaccounts.h
@@ -15,7 +15,15 @@ class DatabaseAccounts : public QThread
             qint64  id;
         };
 
-        DatabaseAccounts(const QString &dbpath);
+        DatabaseAccounts(const QString &databasePath);
+        
+        /**
+         * Get the path to the database file in the given directory.
+         *
+         * @param directory The directory containing the database file.
+         * @return The path to the database file.
+         */
+        static const QString getDatabasePath(const QString &directory);
 
         const QList<Account>& accounts() const;
 

--- a/src/databaseunreadfixer.cpp
+++ b/src/databaseunreadfixer.cpp
@@ -7,11 +7,11 @@
 #include "sqlite3.h"
 #include "utils.h"
 
-DatabaseUnreadFixer::DatabaseUnreadFixer(const QString &dbpath )
+DatabaseUnreadFixer::DatabaseUnreadFixer(const QString &databasePath )
     : QThread()
 {
     moveToThread( this );
-    mDbPath = dbpath + QDir::separator() + "global-messages-db.sqlite";
+    mDbPath = databasePath;
 }
 
 void DatabaseUnreadFixer::run()

--- a/src/databaseunreadfixer.h
+++ b/src/databaseunreadfixer.h
@@ -8,7 +8,7 @@ class DatabaseUnreadFixer : public QThread
     Q_OBJECT
 
     public:
-        DatabaseUnreadFixer( const QString& dbpath );
+        DatabaseUnreadFixer( const QString& databasePath );
 
     protected:
         virtual void run() override;

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -58,7 +58,22 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
 
     private:
         void    changeIcon(QToolButton * button );
-        bool    isProfilePathValid();
+        
+        /**
+         * Validate the profile path.
+         *
+         * @param profilePath The profile path.
+         * @return true, if the path is valid, false otherwise.
+         */
+        bool    isProfilePathValid(const QString& profilePath) const;
+        
+        /**
+         * Check if the given profile path is valid and display a dialog, if it's not.
+         *
+         * @param profilePath The profile path.
+         * @return true, if the path is valid, false otherwise.
+         */
+        bool    reportIfProfilePathValid(const QString& profilePath) const;
         bool    isMorkParserSelected() const;
 
         QPalette mPaletteOk;

--- a/src/unreadcounter.cpp
+++ b/src/unreadcounter.cpp
@@ -9,6 +9,7 @@
 #include "settings.h"
 #include "trayicon.h"
 #include "utils.h"
+#include "databaseaccounts.h"
 
 UnreadMonitor::UnreadMonitor( TrayIcon * parent )
     : QThread( 0 ), mChangedMSFtimer(this)
@@ -41,7 +42,7 @@ UnreadMonitor::~UnreadMonitor()
 
 void UnreadMonitor::run()
 {
-    mSqliteDbFile = pSettings->mThunderbirdFolderPath + QDir::separator() + "global-messages-db.sqlite";
+    mSqliteDbFile = DatabaseAccounts::getDatabasePath(pSettings->mThunderbirdFolderPath);
 
     // Start it as soon as thread starts its event loop
     QTimer::singleShot( 0, [=](){ updateUnread(); } );


### PR DESCRIPTION
* Prevent appending an additional slash (This is how it was before: `C:/path/to/folder\`).
* Display the path with the native file separators (was always `/` before).
* Centralize the knowledge about `global-messages-db.sqlite` in DatabaseAccounts. This reduces code duplication.