### PR TITLE
Fix empty account URIs

### DIFF
--- a/src/dialogaddeditaccount.cpp
+++ b/src/dialogaddeditaccount.cpp
@@ -14,6 +14,8 @@ DialogAddEditAccount::DialogAddEditAccount(bool usemork, QWidget *parent )
     {
         leFolderPath->hide();
         btnBrowse->hide();
+        connect(boxAccounts, &QComboBox::currentTextChanged,
+                this, &DialogAddEditAccount::onAccountSelected);
     }
     else
     {
@@ -32,12 +34,13 @@ void DialogAddEditAccount::setCurrent(const QList<DatabaseAccounts::Account> &ac
     {
         for ( int i = 0; i < accounts.size(); i++ )
             boxAccounts->addItem( accounts[i].uri );
-
-        if ( !account.isEmpty() )
+        buttonBox->button(QDialogButtonBox::Ok)->setDisabled(accounts.isEmpty());
+        if ( !account.isEmpty() ) {
             boxAccounts->setCurrentText( account );
-    }
-    else
+        }
+    } else {
         leFolderPath->setText( account );
+    }
 
     btnColor->setColor( color );
 }
@@ -77,7 +80,14 @@ void DialogAddEditAccount::accept()
             QMessageBox::critical( 0, "Invalid MSF file", tr("You must specify valid, non-empty Thunderbird index file") );
             return;
         }
+    } else if (boxAccounts->currentText().isEmpty()) {
+        QMessageBox::critical(nullptr, tr("No account selected"), tr("You must select an account"));
+        return;
     }
 
     QDialog::accept();
+}
+
+void DialogAddEditAccount::onAccountSelected(const QString &accountUri) {
+    buttonBox->button(QDialogButtonBox::Ok)->setDisabled(accountUri.isEmpty());
 }

--- a/src/dialogaddeditaccount.h
+++ b/src/dialogaddeditaccount.h
@@ -25,6 +25,13 @@ class DialogAddEditAccount : public QDialog, public Ui::DialogAddEditAccount
     public slots:
         void    browse();
         void    accept();
+        
+        /**
+         * Called when an account is selected in the combobox.
+         *
+         * @param accountUri The uri of the account.
+         */
+        void    onAccountSelected(const QString& accountUri);
 
     private:
         bool    mMorkParser;

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -81,6 +81,9 @@ QVariant ModelAccountTree::headerData(int section, Qt::Orientation , int role) c
 
 void ModelAccountTree::addAccount(const QString &uri, const QColor &color)
 {
+    if (uri.isEmpty()) {
+        return;
+    }
     // Only this line changed
     beginInsertRows( QModelIndex(), mColors.size(), mColors.size() + 1 );
 
@@ -92,6 +95,9 @@ void ModelAccountTree::addAccount(const QString &uri, const QColor &color)
 
 void ModelAccountTree::editAccount(const QModelIndex &idx, const QString &uri, const QColor &color)
 {
+    if (uri.isEmpty()) {
+        return;
+    }
     mAccounts[ idx.row() ] = uri;
     mColors[ idx.row() ] = color;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -130,6 +130,22 @@ void Settings::load()
     {
         QString entry = "accounts/account" + QString::number( index );
         QString key = settings.value( entry + "URI", "" ).toString();
+        while (key.isEmpty() && total <= index) {
+            Utils::debug("Removing invalid account %d", index);
+            QString lastEntry = "accounts/account" + QString::number( total - 1 );
+            if (index != total - 1) {
+                key = settings.value(lastEntry + "URI", "").toString();
+                settings.setValue(entry + "URI", key);
+                settings.setValue(entry + "Color",
+                        settings.value(lastEntry + "Color", "").toString());
+            }
+            settings.remove(lastEntry + "URI");
+            settings.remove(lastEntry + "Color");
+            settings.setValue("accounts/count", --total);
+        }
+        if (key.isEmpty()) {
+            break;
+        }
         mFolderNotificationColors[ key ] = QColor( settings.value( entry + "Color", "" ).toString() );
         mFolderNotificationList.push_back( key );
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -130,7 +130,7 @@ void Settings::load()
     {
         QString entry = "accounts/account" + QString::number( index );
         QString key = settings.value( entry + "URI", "" ).toString();
-        while (key.isEmpty() && total <= index) {
+        while (key.isEmpty() && index < total) {
             Utils::debug("Removing invalid account %d", index);
             QString lastEntry = "accounts/account" + QString::number( total - 1 );
             if (index != total - 1) {


### PR DESCRIPTION
If the sqlite parser failed to parse any accounts from the database, it would not fill the combobox in the AddAccountDialog. As a result, if the user hit `Ok`, an account was saved to the settings with an empty URI, which causes problems when trying to search the database for the account (See #77).

This prevents the user from adding an "empty" account and removes such accounts from the settings, when we load them.