### PR TITLE
[Windows] Fix closing Birdtray on window close

### DIFF
--- a/src/birdtrayeventfilter.cpp
+++ b/src/birdtrayeventfilter.cpp
@@ -7,7 +7,7 @@ bool BirdtrayEventFilter::nativeEventFilter(
         const QByteArray &eventType, void *message, long *result) {
     if (eventType == "windows_generic_MSG") {
         MSG* messageEvent = static_cast<MSG*>(message);
-        if (messageEvent->message == WM_CLOSE) {
+        if (messageEvent->message == WM_CLOSE && QApplication::activeWindow() == nullptr) {
             QApplication::quit();
             if (result != nullptr) {
                 *result = 0;

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -30,6 +30,7 @@ TrayIcon::TrayIcon()
     mThunderbirdWindowExists = false;
     mThunderbirdWindowExisted = false;
     mThunderbirdWindowHide = false;
+    connect(QApplication::instance(), &QApplication::aboutToQuit, this, &TrayIcon::onQuit);
 
     mThunderbirdStartTime = QDateTime::currentDateTime().addSecs( pSettings->mLaunchThunderbirdDelay );
 
@@ -333,21 +334,6 @@ void TrayIcon::blinkTimeout()
     updateIcon();
 }
 
-
-void TrayIcon::actionQuit()
-{
-    if ( mWinTools && mWinTools->isHidden() )
-        mWinTools->show();
-
-    if ( pSettings->mExitThunderbirdWhenQuit )
-    {
-        if ( mWinTools )
-            mWinTools->closeWindow();
-    }
-
-    QApplication::quit();
-}
-
 void TrayIcon::actionSettings()
 {
     DialogSettings dlg;
@@ -537,7 +523,7 @@ void TrayIcon::createMenu()
     menu->addSeparator();
 
     // And exit
-    menu->addAction( tr("Quit"), this, SLOT(actionQuit()) );
+    menu->addAction( tr("Quit"), QApplication::instance(), &QApplication::quit );
 
     setContextMenu( menu );
 }
@@ -589,6 +575,17 @@ void TrayIcon::tbProcessFinished(int, QProcess::ExitStatus)
     // Thus we just destroy the process later, to let updateState() make decision
     mThunderbirdProcess->deleteLater();
     mThunderbirdProcess = 0;
+}
+
+void TrayIcon::onQuit() {
+    if ( mWinTools && mWinTools->isHidden() )
+        mWinTools->show();
+    
+    if ( pSettings->mExitThunderbirdWhenQuit )
+    {
+        if ( mWinTools )
+            mWinTools->closeWindow();
+    }
 }
 
 void TrayIcon::hideThunderbird()

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -43,7 +43,6 @@ class TrayIcon : public QSystemTrayIcon
         void    blinkTimeout();
 
         // Context menu actions
-        void    actionQuit();
         void    actionSettings();
         void    actionActivate();
         void    actionSnoozeFor();
@@ -56,6 +55,11 @@ class TrayIcon : public QSystemTrayIcon
         void    startThunderbird();
         void    tbProcessError( QProcess::ProcessError error);
         void    tbProcessFinished( int exitCode, QProcess::ExitStatus exitStatus );
+    
+        /**
+         * Callback that is called when we are about to quit.
+         */
+        void    onQuit();
 
     private:
         void    createMenu();


### PR DESCRIPTION
This fixes a regression for Windows which I introduced in #76, that caused Birdtray to exit, if the user closed a Birdtray-window (e.g. the Settings) with the red X on the window decoration.
We also now properly show and (depending on the settings) close the Thunderbird window when we are asked to quit by the installer (or taskkill).