### PR TITLE
Fix compilation for Qt5.5

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -528,7 +528,7 @@ void TrayIcon::createMenu()
     menu->addSeparator();
 
     // And exit
-    menu->addAction( tr("Quit"), &TrayIcon::actionQuit );
+    menu->addAction( tr("Quit"), this, SLOT(actionQuit()) );
 
     setContextMenu( menu );
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -334,6 +334,11 @@ void TrayIcon::blinkTimeout()
     updateIcon();
 }
 
+void TrayIcon::actionQuit()
+{
+    QApplication::quit();
+}
+
 void TrayIcon::actionSettings()
 {
     DialogSettings dlg;
@@ -523,7 +528,7 @@ void TrayIcon::createMenu()
     menu->addSeparator();
 
     // And exit
-    menu->addAction( tr("Quit"), QApplication::instance(), &QApplication::quit );
+    menu->addAction( tr("Quit"), &TrayIcon::actionQuit );
 
     setContextMenu( menu );
 }

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -43,6 +43,7 @@ class TrayIcon : public QSystemTrayIcon
         void    blinkTimeout();
 
         // Context menu actions
+        static void actionQuit();
         void    actionSettings();
         void    actionActivate();
         void    actionSnoozeFor();


### PR DESCRIPTION
Looks like older versions of Qt (<= 5.5) don't like connecting QApplication::quit directly to a menu action.

See https://travis-ci.org/gyunaev/birdtray/jobs/521692228