### PR TITLE
Add --settings and --reset-settings as command line options

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -89,7 +89,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     browserAbout->setText( origabout );
 
     // Icon
-    btnNotificationIcon->setIcon( pSettings->mNotificationIcon );
+    btnNotificationIcon->setIcon( pSettings->getNotificationIcon() );
 
     if ( !pSettings->mNotificationIconUnread.isNull() )
     {
@@ -163,7 +163,7 @@ void DialogSettings::accept()
     pSettings->mLaunchThunderbirdDelay = spinThunderbirdStartDelay->value();
     pSettings->mShowUnreadEmailCount = boxShowUnreadCount->isChecked();
 
-    pSettings->mNotificationIcon = btnNotificationIcon->icon().pixmap( pSettings->mIconSize );
+    pSettings->setNotificationIcon(btnNotificationIcon->icon().pixmap( pSettings->mIconSize ));
 
     if ( boxNotificationIconUnread->isChecked() )
         pSettings->mNotificationIconUnread = btnNotificationIconUnread->icon().pixmap( pSettings->mIconSize );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char *argv[])
         {"dump-mork", QApplication::tr("Display the contents of the given mork database."),
          QApplication::tr("databaseFile")},
         {"decode", QApplication::tr("Decode an IMAP Utf7 string."), QApplication::tr("string")},
+        {"settings", QApplication::tr("Show the settings.")},
+        {{"r", "reset-settings"}, QApplication::tr("Reset the settings to the defaults.")},
         {{"d", "debug"}, QApplication::tr("Enable debugging output.")},
     });
     parser.process(app);
@@ -76,8 +78,12 @@ int main(int argc, char *argv[])
 
     // Load settings
     pSettings = new Settings(parser.isSet("debug"));
-    pSettings->load();
+    if (parser.isSet("reset-settings")) {
+        pSettings->save(); // Saving without loading will reset the values
+    } else {
+        pSettings->load();
+    }
 
-    TrayIcon trayIcon;
+    TrayIcon trayIcon(parser.isSet("settings"));
     return QApplication::exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QtCore/QCommandLineParser>
 
 #ifdef Q_OS_WIN
 #include "birdtrayeventfilter.h"
@@ -8,65 +9,75 @@
 #include "settings.h"
 #include "morkparser.h"
 #include "utils.h"
+#include "version.h"
+
+
+void ensureSystemTrayAvailable() {
+    // If system tray is not yet available, wait up to 60 seconds
+    int passed = 0;
+    while ( !QSystemTrayIcon::isSystemTrayAvailable() ) {
+        if ( passed == 0 ) {
+            qDebug("Waiting for system tray to become available");
+        }
+        passed++;
+        if ( passed > 120 ) {
+            Utils::fatal("Sorry, system tray cannot be controlled "
+                         "through this addon on your operating system");
+        }
+        QThread::usleep( 500 );
+    }
+}
 
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
+    QApplication app(argc, argv);
     QApplication::setWindowIcon(QIcon(QString::fromUtf8(":/res/birdtray.ico")));
-#ifdef Q_OS_WIN
-    BirdtrayEventFilter filter;
-    a.installNativeEventFilter(&filter);
-#endif /* Q_OS_WIN */
-
-    if ( argc == 3 && !strcmp( argv[1], "--dumpmork" ) )
-    {
-        MorkParser::dumpMorkFile( argv[2] );
-        return 1;
-    }
-
-    if ( argc == 3 && !strcmp( argv[1], "--decode" ) )
-    {
-        printf( "Decoded: %s\n", qPrintable( Utils::decodeIMAPutf7( argv[2] )));
-        return 1;
-    }
-
-    // If system tray is not yet available, wait up to 60 seconds
-    int passed = 0;
-
-    while ( true )
-    {
-        if ( QSystemTrayIcon::isSystemTrayAvailable() )
-            break;
-
-        if ( passed == 0 )
-            qDebug("Waiting for system tray to become available");
-
-        passed++;
-
-        if ( passed > 120 )
-            Utils::fatal("Sorry, system tray cannot be controlled "
-                         "through this addon on your operating system");
-
-        QThread::usleep( 500 );
-    }
-
-
-    // This prevents exiting the application when the dialogs are closed on Gnome/XFCE
-    a.setQuitOnLastWindowClosed( false );
-
-    // Set data for QSettings
     QCoreApplication::setOrganizationName("ulduzsoft");
     QCoreApplication::setOrganizationDomain("ulduzsoft.com");
     QCoreApplication::setApplicationName("birdtray");
+    QCoreApplication::setApplicationVersion(QString("%1.%2").arg(VERSION_MAJOR).arg(VERSION_MINOR));
+#ifdef Q_OS_WIN
+    BirdtrayEventFilter filter;
+    app.installNativeEventFilter(&filter);
+#endif /* Q_OS_WIN */
+    
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QApplication::tr(
+            "A free system tray notification for new mail for Thunderbird"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addOptions({
+        {"dump-mork", QApplication::tr("Display the contents of the given mork database."),
+         QApplication::tr("databaseFile")},
+        {"decode", QApplication::tr("Decode an IMAP Utf7 string."), QApplication::tr("string")},
+        {{"d", "debug"}, QApplication::tr("Enable debugging output.")},
+    });
+    parser.process(app);
+    
+    QString morkPath = parser.value("dump-mork");
+    if ( !morkPath.isEmpty() )
+    {
+        MorkParser::dumpMorkFile( morkPath );
+        return 1;
+    }
+    
+    QString imapString = parser.value("decode");
+    if ( !imapString.isEmpty() )
+    {
+        printf( "Decoded: %s\n", qPrintable( Utils::decodeIMAPutf7( imapString )));
+        return 1;
+    }
+    
+    ensureSystemTrayAvailable();
+    
+    // This prevents exiting the application when the dialogs are closed on Gnome/XFCE
+    QApplication::setQuitOnLastWindowClosed( false );
 
     // Load settings
-    pSettings = new Settings();
+    pSettings = new Settings(parser.isSet("debug"));
     pSettings->load();
 
-    if ( argc == 2 && !strcmp( argv[1], "--debug" ) )
-        pSettings->mVerboseOutput = true;
-
-    TrayIcon trayicon;
-    return a.exec();
+    TrayIcon trayIcon;
+    return QApplication::exec();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -13,10 +13,10 @@
 
 Settings * pSettings;
 
-Settings::Settings()
+Settings::Settings(bool verboseOutput)
 {
     mIconSize = QSize( 128, 128 );
-    mVerboseOutput = false;
+    mVerboseOutput = verboseOutput;
 }
 
 void Settings::save()

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,8 +15,31 @@ Settings * pSettings;
 
 Settings::Settings(bool verboseOutput)
 {
-    mIconSize = QSize( 128, 128 );
     mVerboseOutput = verboseOutput;
+    mIconSize = QSize( 128, 128 );
+    mNotificationDefaultColor = QColor("#00FF00");
+    mBlinkSpeed = 0;
+    mShowHideThunderbird = false;
+    mLaunchThunderbird = false;
+    mHideWhenMinimized = false;
+    mExitThunderbirdWhenQuit = false;
+    mNotificationFontWeight = 50;
+    mMonitorThunderbirdWindow = false;
+    mRestartThunderbird = false;
+    mHideWhenStarted = false;
+    mHideWhenRestarted = false;
+    mAllowSuppressingUnreads = false;
+    mLaunchThunderbirdDelay = 0;
+    mShowUnreadEmailCount = true;
+    mThunderbirdCmdLine = THUNDERBIRD_EXE_PATH;
+    mThunderbirdWindowMatch = "- Mozilla Thunderbird";
+    mNotificationMinimumFontSize = 4;
+    mNotificationMaximumFontSize = 512;
+    mUseMorkParser = true;
+    mWatchFileTimeout = 150;
+    mBlinkingUseAlphaTransition = false;
+    mUnreadOpacityLevel = 0.75;
+    mNewEmailMenuEnabled = false;
 }
 
 void Settings::save()
@@ -96,30 +119,45 @@ void Settings::load()
             Utils::fatal("Cannot load default system tray icon");
     }
 
-    mNotificationDefaultColor = QColor( settings.value( "common/defaultcolor", "#00FF00" ).toString() );
-    mThunderbirdFolderPath = settings.value( "common/profilepath", "" ).toString();
-    mBlinkSpeed = settings.value("common/blinkspeed", 0 ).toInt();
-    mShowHideThunderbird = settings.value("common/showhidethunderbird", false ).toBool();
-    mLaunchThunderbird = settings.value("common/launchthunderbird", false ).toBool();
-    mHideWhenMinimized = settings.value("common/hidewhenminimized", false ).toBool();
-    mExitThunderbirdWhenQuit = settings.value("common/exitthunderbirdonquit", false ).toBool();
-    mNotificationFontWeight = settings.value("common/notificationfontweight", 50 ).toInt();
-    mMonitorThunderbirdWindow = settings.value("common/monitorthunderbirdwindow", false ).toBool();
-    mRestartThunderbird = settings.value("common/restartthunderbird", false ).toBool();
-    mHideWhenStarted = settings.value("common/hidewhenstarted", false ).toBool();
-    mHideWhenRestarted = settings.value("common/hidewhenrestarted", false ).toBool();
-    mAllowSuppressingUnreads = settings.value("common/allowsuppressingunread", false ).toBool();
-    mLaunchThunderbirdDelay = settings.value("common/launchthunderbirddelay", 0 ).toInt();
-    mShowUnreadEmailCount = settings.value("common/showunreademailcount", true ).toBool();
+    mNotificationDefaultColor = QColor( settings.value(
+            "common/defaultcolor", mNotificationDefaultColor.name() ).toString() );
+    mThunderbirdFolderPath = settings.value(
+            "common/profilepath", mThunderbirdFolderPath ).toString();
+    mBlinkSpeed = settings.value("common/blinkspeed", mBlinkSpeed ).toInt();
+    mShowHideThunderbird = settings.value(
+            "common/showhidethunderbird", mShowHideThunderbird ).toBool();
+    mLaunchThunderbird = settings.value("common/launchthunderbird", mLaunchThunderbird ).toBool();
+    mHideWhenMinimized = settings.value("common/hidewhenminimized", mHideWhenMinimized ).toBool();
+    mExitThunderbirdWhenQuit = settings.value(
+            "common/exitthunderbirdonquit", mExitThunderbirdWhenQuit ).toBool();
+    mNotificationFontWeight = settings.value(
+            "common/notificationfontweight", mNotificationFontWeight ).toInt();
+    mMonitorThunderbirdWindow = settings.value(
+            "common/monitorthunderbirdwindow", mMonitorThunderbirdWindow ).toBool();
+    mRestartThunderbird = settings.value(
+            "common/restartthunderbird", mRestartThunderbird ).toBool();
+    mHideWhenStarted = settings.value("common/hidewhenstarted", mHideWhenStarted ).toBool();
+    mHideWhenRestarted = settings.value("common/hidewhenrestarted", mHideWhenRestarted ).toBool();
+    mAllowSuppressingUnreads = settings.value(
+            "common/allowsuppressingunread", mAllowSuppressingUnreads ).toBool();
+    mLaunchThunderbirdDelay = settings.value(
+            "common/launchthunderbirddelay", mLaunchThunderbirdDelay ).toInt();
+    mShowUnreadEmailCount = settings.value(
+            "common/showunreademailcount", mShowUnreadEmailCount ).toBool();
 
-    mThunderbirdCmdLine = settings.value("advanced/tbcmdline", THUNDERBIRD_EXE_PATH).toString();
-    mThunderbirdWindowMatch = settings.value("advanced/tbwindowmatch", "- Mozilla Thunderbird" ).toString();
-    mNotificationMinimumFontSize = settings.value("advanced/notificationfontminsize", 4 ).toInt();
-    mNotificationMaximumFontSize = settings.value("advanced/notificationfontmaxsize", 512 ).toInt();
-    mUseMorkParser = settings.value("advanced/unreadmorkparser", true ).toBool();
-    mWatchFileTimeout = settings.value("advanced/watchfiletimeout", 150 ).toUInt();
-    mBlinkingUseAlphaTransition = settings.value("advanced/blinkingusealpha", false ).toBool();
-    mUnreadOpacityLevel = settings.value("advanced/unreadopacitylevel", 0.75 ).toDouble();
+    mThunderbirdCmdLine = settings.value("advanced/tbcmdline", mThunderbirdCmdLine).toString();
+    mThunderbirdWindowMatch = settings.value(
+            "advanced/tbwindowmatch", mThunderbirdWindowMatch ).toString();
+    mNotificationMinimumFontSize = settings.value(
+            "advanced/notificationfontminsize", mNotificationMinimumFontSize ).toInt();
+    mNotificationMaximumFontSize = settings.value(
+            "advanced/notificationfontmaxsize", mNotificationMaximumFontSize ).toInt();
+    mUseMorkParser = settings.value("advanced/unreadmorkparser", mUseMorkParser ).toBool();
+    mWatchFileTimeout = settings.value("advanced/watchfiletimeout", mWatchFileTimeout ).toUInt();
+    mBlinkingUseAlphaTransition = settings.value(
+            "advanced/blinkingusealpha", mBlinkingUseAlphaTransition ).toBool();
+    mUnreadOpacityLevel = settings.value(
+            "advanced/unreadopacitylevel", mUnreadOpacityLevel ).toDouble();
 
     mFolderNotificationColors.clear();
 
@@ -151,7 +189,7 @@ void Settings::load()
     }
 
     // Load new email data from settings
-    mNewEmailMenuEnabled = settings.value("newemail/enabled", false ).toBool();
+    mNewEmailMenuEnabled = settings.value("newemail/enabled", mNewEmailMenuEnabled ).toBool();
 
     mNewEmailData.clear();
     total = settings.value("newemail/count", 0 ).toInt();
@@ -170,6 +208,19 @@ QString Settings::getThunderbirdExecutablePath() {
     }
     path = Utils::expandPath(path);
     return '"' + QFileInfo(path).absoluteFilePath() + '"';
+}
+
+const QPixmap &Settings::getNotificationIcon() {
+    if (mNotificationIcon.isNull()) {
+        if (!mNotificationIcon.load(":res/thunderbird.png")) {
+            Utils::fatal("Cannot load default system tray icon");
+        }
+    }
+    return mNotificationIcon;
+}
+
+void Settings::setNotificationIcon(const QPixmap& icon) {
+    mNotificationIcon = icon;
 }
 
 void Settings::savePixmap(QSettings &settings, const QString &key, const QPixmap &pixmap)

--- a/src/settings.h
+++ b/src/settings.h
@@ -13,7 +13,7 @@
 class Settings
 {
     public:
-        Settings();
+        explicit Settings(bool verboseOutput);
 
         // Desired icon size
         QSize   mIconSize;

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,9 +18,6 @@ class Settings
         // Desired icon size
         QSize   mIconSize;
 
-        // Notification icon
-        QPixmap mNotificationIcon;
-
         // Notification icon for unread emails.
         // If null, the mNotificationIcon is used
         QPixmap mNotificationIconUnread;
@@ -115,8 +112,23 @@ class Settings
          * @return The absolute path to the thunderbird executable.
          */
         QString getThunderbirdExecutablePath();
+        
+        /**
+         * @return The icon to use for the system tray.
+         */
+        const QPixmap& getNotificationIcon();
+        
+        /**
+         * Set the icon to use for the system tray to the new icon.
+         *
+         * @param icon The new icon.
+         */
+        void setNotificationIcon(const QPixmap& icon);
 
     private:
+        // Notification icon
+        QPixmap mNotificationIcon;
+    
         void    savePixmap( QSettings& settings, const QString& key, const QPixmap& pixmap );
         QPixmap loadPixmap( QSettings& settings, const QString& key );
 };

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -13,7 +13,7 @@
 #include "windowtools.h"
 #include "utils.h"
 
-TrayIcon::TrayIcon()
+TrayIcon::TrayIcon(bool showSettings)
 {
     mBlinkingIconOpacity = 1.0;
     mBlinkingDelta = 0.0;
@@ -37,14 +37,11 @@ TrayIcon::TrayIcon()
     mWinTools = WindowTools::create();
 
     // If the settings are not yet configure, pop up the message
-    if ( pSettings->mFolderNotificationColors.isEmpty() )
-    {
-        if ( QMessageBox::question( 0,
-            tr( "Would you like to set up Birdtray?" ),
-            tr( "You have not yet configured any email folders to monitor. Would you like to do it now?") ) == QMessageBox::Yes )
-        {
-            actionSettings();
-        }
+    if ( showSettings || (pSettings->mFolderNotificationColors.isEmpty() && QMessageBox::question(
+            nullptr, tr( "Would you like to set up Birdtray?" ),
+            tr( "You have not yet configured any email folders to monitor. "
+                "Would you like to do it now?") ) == QMessageBox::Yes )) {
+        actionSettings();
     }
 
     createMenu();
@@ -139,7 +136,7 @@ void TrayIcon::updateIcon()
             enableBlinking( false );
     }
 
-    QPixmap temp( pSettings->mNotificationIcon.size() );
+    QPixmap temp( pSettings->getNotificationIcon().size() );
     QPainter p;
 
     temp.fill( Qt::transparent );
@@ -158,7 +155,7 @@ void TrayIcon::updateIcon()
     if ( unread != 0 && !pSettings->mNotificationIconUnread.isNull() )
         p.drawPixmap( pSettings->mNotificationIconUnread.rect(), pSettings->mNotificationIconUnread );
     else
-        p.drawPixmap( pSettings->mNotificationIcon.rect(), pSettings->mNotificationIcon );
+        p.drawPixmap( pSettings->getNotificationIcon().rect(), pSettings->getNotificationIcon() );
 
     p.setFont( pSettings->mNotificationFont );
 

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -16,7 +16,7 @@ class TrayIcon : public QSystemTrayIcon
     Q_OBJECT
 
     public:
-        TrayIcon();
+        explicit TrayIcon(bool showSettings);
 
     signals:
         void    settingsChanged();


### PR DESCRIPTION
This uses the QCommandLineParser and adds the `--settings` and `--reset-settings` or `-r` command line options.
We also get a version and help options for free:
```console
me@myshell:~$ birdtray.exe --version
birdtray 1.5

me@myshell:~$ birdtray.exe --help
Usage: birdtray.exe [options]
A free system tray notification for new mail for Thunderbird

Options:
  -?, -h, --help              Displays this help.
  -v, --version               Displays version information.
  --dump-mork <databaseFile>  Display the contents of the given mork database.
  --decode <string>           Decode an IMAP Utf7 string.
  --settings                  Show the settings.
  -r, --reset-settings        Reset the settings to the defaults.
  -d, --debug                 Enable debugging output.
```
On windows, it will display a dialog box.