### PR TITLE
Make it harder to accidentally delete files on uninstall

### DIFF
--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -288,29 +288,6 @@ FunctionEnd
     ${endif}
 !macroend
 
-# Confirm the uninstall from a given path.
-# PATH: The path of the installation to uninstall.
-# OUT_VAR: The variable to store the result in: 1 if the user agreed, 0 otherwise.
-!macro ConfirmUninstallPath PATH OUT_VAR
-    MessageBox MB_YESNO|MB_ICONEXCLAMATION \
-        "This will remove ALL of the program files under$\r$\n\
-        $\r$\n\
-        ${PATH}$\r$\n\
-        $\r$\n\
-        and cannot be undone. Are you sure you wish to continue?" \
-        /SD IDYES IDYES yes IDNO no
-
-    yes:
-        StrCpy ${OUT_VAR} 1
-        Goto done
-    no:
-        StrCpy ${OUT_VAR} 0
-        Goto done
-
-    done:
-!macroend
-!define ConfirmUninstallPath '!insertmacro ConfirmUninstallPath'
-
 # Check if a registry key exists.
 # ROOT: The registry root key.
 # KEY: The key to check for.

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -519,8 +519,16 @@ Function DirectoryPageLeave
     ${endif}
     ${IsDirEmpty} $0 $INSTDIR
     ${if} $0 == 0
+        IfFileExists $INSTDIR\${EXE_NAME} 0 DirNotEmptyNoBirdtray
+        IfFileExists $INSTDIR\${UNINSTALL_FILENAME} 0 DirNotEmptyNoBirdtray
+        MessageBox MB_OKCANCEL|MB_ICONINFORMATION \
+                        "The install path contains a previously installed ${PRODUCT_NAME} version, \
+                        which will be replaced." /SD IDOK IDOK Ignore
+        Abort
+        DirNotEmptyNoBirdtray:
         MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-                'The install path is not empty. The content will get overwritten.' \
+                "The install path is not empty, but it doesn't look like it contains a previous \
+                ${PRODUCT_NAME} installation. The content will get overwritten." \
                 /SD IDOK IDOK Ignore
         Abort
         Ignore:

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -80,6 +80,8 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define DEFAULT_INSTALL_PATH "$PROGRAMFILES\${PRODUCT_NAME}"
 !define UNINSTALL_FILENAME "uninstall.exe"
 !define UNINSTALL_BUILDER_FILE "uninstall_builder.exe"
+!define UNINSTALL_LIST_BUILDER_FILE "makeUninstallList.exe"
+!define UNINSTALL_LIST_FILENAME "uninstall_list.nsh"
 !define HEADER_IMG_FILE "assets\header.bmp"
 !define SIDEBAR_IMG_FILE "assets\sidebar.bmp"
 
@@ -220,7 +222,6 @@ VIAddVersionKey LegalCopyright ""
 !insertmacro MUI_UNPAGE_COMPONENTS
 
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW un.ConfirmPageShow
-!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.ConfirmPageLeave
 !insertmacro MUI_UNPAGE_CONFIRM
 
 !insertmacro MUI_UNPAGE_INSTFILES
@@ -379,14 +380,16 @@ SectionEnd
 Section "un.${PRODUCT_NAME}" UNSectionBirdTray
     SectionIn RO # Can't deselect this section
 
-    # TODO: Automate this part, so that new files don't have to be added manually here
     # Try to delete the EXE as the first step - if it's in use, don't remove anything else
     !insertmacro DeleteRetryAbort "$INSTDIR\${EXE_NAME}"
-    !insertmacro DeleteRetryAbort "$INSTDIR\*.dll"
-    RMDir /r "$INSTDIR\translations"
-    RMDir /r "$INSTDIR\imageformats"
-    RMDir /r "$INSTDIR\styles"
-    RMDir /r "$INSTDIR\platforms"
+
+    !makensis '/DDIST_DIR="${DIST_DIR}" /DUNINSTALL_LIST_FILENAME="${UNINSTALL_LIST_FILENAME}" \
+            /DEXE_NAME="${EXE_NAME}" makeUninstallList.nsi' = 0
+    !system "${UNINSTALL_LIST_BUILDER_FILE}" = 0
+    !include "uninstaller\${UNINSTALL_LIST_FILENAME}"
+    !delfile "${UNINSTALL_LIST_BUILDER_FILE}"
+    !delfile "uninstaller\${UNINSTALL_LIST_FILENAME}"
+
     !ifdef LICENSE_FILE
         !insertmacro DeleteRetryAbort "$INSTDIR\${LICENSE_FILE}"
     !endif
@@ -657,18 +660,6 @@ Function un.ConfirmPageShow
         # Show/hide the Back button
         GetDlgItem $0 $HWNDPARENT 3
         ShowWindow $0 $UninstallShowBackButton
-    ${endif}
-FunctionEnd
-
-# Called when leaving the "Confirm Uninstall" page
-Function un.ConfirmPageLeave
-    ${ConfirmUninstallPath} $INSTDIR $R0
-    ${if} $R0 == 0
-        ${if} $SemiSilentMode == 1
-            Quit
-        ${else}
-            Abort
-        ${endif}
     ${endif}
 FunctionEnd
 

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -52,7 +52,7 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define COMPANY_NAME "UlduzSoft"
 !define HELP_URL "https://github.com/gyunaev/birdtray/wiki" # "Support Information" link
 !define UPDATE_URL "https://github.com/gyunaev/birdtray/releases" # "Product Updates" link
-!define ABOUT_URL "http://www.ulduzsoft.com/" # "Publisher" link
+!define ABOUT_URL "https://www.ulduzsoft.com/" # "Publisher" link
 !define MIN_WINDOWS_VER "XP"
 
 # Section descriptions

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -259,9 +259,14 @@ Section "${PRODUCT_NAME}" SectionBirdTray
             !insertmacro UAC_AsUser_Call Function RunUninstaller ${UAC_SYNCREGISTERS}
         ${endif}
         ${if} ${errors} # Stay in installer
+            MessageBox MB_OKCANCEL|MB_ICONSTOP \
+                            "Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing \
+                            will delete EVERYTHING in $3." /SD IDCANCEL IDOK Ignore
             SetErrorLevel 2 # Installation aborted by script
             BringToFront
             Abort "Error executing uninstaller."
+            Ignore:
+            RMDir /r "$3"
         ${else}
             ${Switch} $0
                 ${case} 0 # Uninstaller completed successfully - continue with installation

--- a/installer/makeUninstallList.nsi
+++ b/installer/makeUninstallList.nsi
@@ -1,0 +1,149 @@
+SetCompress off
+Name "makeUninstallList"
+OutFile "makeUninstallList.exe"
+SilentInstall silent
+RequestExecutionLevel user
+
+# Remove all occurrences of a string from the target string.
+# $R0 - SPLITTER: The string to remove.
+# $R1 - STR: The string to remove the occurrences of the splitter from.
+# Returns:
+# $R0 - OUT_STR: The resulting string.
+Function StrStrip
+    Exch $R0  # splitter
+    Exch
+    Exch $R1  # string
+    Push $R2
+    Push $R3
+    Push $R4
+    Push $R5
+    StrLen $R5 $R0
+    StrCpy $R2 -1
+    IntOp $R2 $R2 + 1
+    StrCpy $R3 $R1 $R5 $R2
+    StrCmp $R3 "" +9
+    StrCmp $R3 $R0 0 -3
+    StrCpy $R3 $R1 $R2
+    IntOp $R2 $R2 + $R5
+    StrCpy $R4 $R1 "" $R2
+    StrCpy $R1 $R3$R4
+    IntOp $R2 $R2 - $R5
+    IntOp $R2 $R2 - 1
+    Goto -10
+    StrCpy $R0 $R1
+    Pop $R5
+    Pop $R4
+    Pop $R3
+    Pop $R2
+    Pop $R1
+    Exch $R0
+FunctionEnd
+!macro StrStrip SPLITTER STR OUT_STR
+    Push '${STR}'
+    Push '${SPLITTER}'
+    Call StrStrip
+    Pop '${OUT_STR}'
+!macroend
+!define StrStrip '!insertmacro StrStrip'
+
+
+# Truncate a file, removing all it's content.
+# $R0 - FILE: The path to the file to truncate.
+Function TruncateFile
+    Pop $R0	 # file
+    FileOpen $R1 $R0 w
+    FileClose $R1
+FunctionEnd
+
+
+# Create a file containing NSIS delete commands for a folder structure.
+# The given filter can be used to exclude a file name.
+# $R0 - OUTPUT_FILE: The file to write the delete commands to.
+# $R1 - FILTER: A filename that will be excluded from the resulting command list.
+# $R2 - LOCAL_FOLDER: The current folder relative to the global folder to examine.
+# $R3 - GLOBAL_FOLDER: The global root folder from where the search starts.
+Function MakeRecurrentFileList
+	Pop $R3  # global folder
+	Pop $R2	 # local folder
+	Pop $R1	 # filter
+	Pop $R0	 # output file
+
+	ClearErrors
+	FindFirst $R4 $R5 "$R3\$R2\*.*"
+
+MakeRecurrentFileList_Loop:
+	IfErrors MakeRecurrentFileList_Done
+	# check if it is folder
+	IfFileExists "$R3\$R2\$R5\*.*"  0 MakeRecurrentFileList_file
+	# directory
+	StrCmp $R5 "." MakeRecurrentFileList_next			# skip current folder
+	StrCmp $R5 ".." MakeRecurrentFileList_next			# skip parent folder
+	# go Recurrent
+	# save current variables
+	Push $R5
+	Push $R4
+	Push $R3
+	Push $R2
+	Push $R1
+	Push $R0
+
+	# set parameters
+	Push $R0		# output file
+	Push $R1		# filter
+	Push "$R2\$R5"	# local folder
+	Push $R3		# global folder
+	Call MakeRecurrentFileList
+	# restore current variables
+	Pop $R0
+	Pop $R1
+	Pop $R2
+	Pop $R3
+	Pop $R4
+	Pop $R5
+
+    Push $R1
+	FileOpen $R6 $R0 a
+    FileSeek $R6 0 END
+    ${StrStrip} ".\" "$R2\$R5" $R1
+    FileWrite $R6 "RMDir $\"$$INSTDIR\$R1$\"$\r$\n"
+    FileClose $R6
+    Pop $R1
+	Goto MakeRecurrentFileList_next
+
+MakeRecurrentFileList_file:
+	# use filter
+	StrCmp $R1 $R5 MakeRecurrentFileList_skip
+	# filter found, add file to list
+	Push $R1
+	FileOpen $R6 $R0 a
+	FileSeek $R6 0 END
+	${StrStrip} ".\" "$R2\$R5" $R1
+	FileWrite $R6 "!insertmacro DeleteRetryAbort $\"$$INSTDIR\$R1$\"$\r$\n"
+	FileClose $R6
+	Pop $R1
+
+MakeRecurrentFileList_skip:
+MakeRecurrentFileList_next:
+	ClearErrors
+	FindNext $R4 $R5
+	Goto MakeRecurrentFileList_Loop
+
+MakeRecurrentFileList_Done:
+	FindClose $R4
+FunctionEnd
+
+
+!macro CreateFileList DIR OUTPUT_FILE_PATH FILTER
+    Push ${OUTPUT_FILE_PATH} # output file
+    Call TruncateFile        # delete output file if exist
+    Push ${OUTPUT_FILE_PATH} # output file
+    Push ${FILTER} 	         # filter
+    Push "."                 # local dir
+    Push ${DIR}              # global dir
+    Call MakeRecurrentFileList
+!macroend
+!define CreateFileList '!insertmacro CreateFileList'
+
+Section
+    ${CreateFileList} "${DIST_DIR}" "uninstaller\${UNINSTALL_LIST_FILENAME}" "${EXE_NAME}"
+SectionEnd


### PR DESCRIPTION
This will delete only the files that were installed during installation. If the user manages to save another file into the installation directory of Birdtray, the uninstaller won't delete it.

The installer also now handles replacing an existing installation, if the uninstaller is missing.