### PR TITLE
Prevent crash from font boldness exceeding 99

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -146,7 +146,7 @@ void DialogSettings::accept()
     pSettings->mThunderbirdCmdLine = leThunderbirdBinary->text();
     pSettings->mThunderbirdWindowMatch = leThunderbirdWindowMatch->text();
     pSettings->mHideWhenMinimized = boxHideWhenMinimized->isChecked();
-    pSettings->mNotificationFontWeight = notificationFontWeight->value() / 2;
+    pSettings->mNotificationFontWeight = qMin(99, (int) (notificationFontWeight->value() / 2));
     pSettings->mExitThunderbirdWhenQuit = boxStopThunderbirdOnExit->isChecked();
     pSettings->mAllowSuppressingUnreads = boxAllowSuppression->isChecked();
 

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -92,10 +92,10 @@
              <string> %</string>
             </property>
             <property name="maximum">
-             <number>200</number>
+             <number>198</number>
             </property>
             <property name="singleStep">
-             <number>5</number>
+             <number>2</number>
             </property>
             <property name="value">
              <number>100</number>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -130,8 +130,8 @@ void Settings::load()
     mHideWhenMinimized = settings.value("common/hidewhenminimized", mHideWhenMinimized ).toBool();
     mExitThunderbirdWhenQuit = settings.value(
             "common/exitthunderbirdonquit", mExitThunderbirdWhenQuit ).toBool();
-    mNotificationFontWeight = settings.value(
-            "common/notificationfontweight", mNotificationFontWeight ).toInt();
+    mNotificationFontWeight = qMin(99, settings.value(
+            "common/notificationfontweight", mNotificationFontWeight ).toInt());
     mMonitorThunderbirdWindow = settings.value(
             "common/monitorthunderbirdwindow", mMonitorThunderbirdWindow ).toBool();
     mRestartThunderbird = settings.value(

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,7 +25,7 @@ class Settings
         // Font for use in notifications
         QFont   mNotificationFont;
 
-        // Notification font weight
+        // Notification font weight (0 - 99)
         unsigned int mNotificationFontWeight;
 
         // Default notification color


### PR DESCRIPTION
A value greater than 99 will cause a crash.
See https://doc.qt.io/archives/qt-4.8/qfont.html#Weight-enum