### PR TITLE
Fix sqlite-db handler not updating the account list when first selected

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -199,10 +199,13 @@ void DialogSettings::profilePathChanged()
         btnFixUnreadCount->setEnabled( valid );
     }
 
-    if ( valid )
+    if ( valid ) {
         leProfilePath->setPalette( mPaletteOk );
-    else
+        updateAccountList();
+    } else {
         leProfilePath->setPalette( mPaletteErrror );
+        mAccounts.clear();
+    }
 
 }
 
@@ -428,16 +431,23 @@ void DialogSettings::changeIcon(QToolButton *button)
     button->setIcon( test );
 }
 
+
+void DialogSettings::updateAccountList() {
+    if (isMorkParserSelected()) {
+        return;
+    }
+    DatabaseAccounts * dba = new DatabaseAccounts(
+            DatabaseAccounts::getDatabasePath(leProfilePath->text()));
+    connect( dba, &DatabaseAccounts::done, this, &DialogSettings::accountsAvailable );
+    dba->start();
+}
+
 void DialogSettings::activateTab(int tab)
 {
     // #1 is the Accounts tab
-    if ( tab == 1 && !isMorkParserSelected() )
+    if ( tab == 1 )
     {
-        // Get the account list
-        DatabaseAccounts * dba = new DatabaseAccounts(
-                DatabaseAccounts::getDatabasePath(leProfilePath->text()));
-        connect( dba, &DatabaseAccounts::done, this, &DialogSettings::accountsAvailable );
-        dba->start();
+        updateAccountList();
     }
 }
 

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -60,6 +60,11 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    changeIcon(QToolButton * button );
         
         /**
+         * Update the account list from the selected sql database.
+         */
+        void    updateAccountList();
+        
+        /**
          * Validate the profile path.
          *
          * @param profilePath The profile path.


### PR DESCRIPTION
This caused the accounts list of the Add-/Edit-dialog to be empty, when the user first selected the profile path.
The user would have to close the settings dialog and reopen it again to see the list of available accounts.