### PR TITLE
Fix account color selection for the sqlite parser

### DIFF
--- a/src/unreadcounter.h
+++ b/src/unreadcounter.h
@@ -70,6 +70,7 @@ class UnreadMonitor : public QThread
 
         // Last reported unread
         int    mLastReportedUnread;
+        QColor mLastColor;
 };
 
 #endif // FOLDERWATCHER_H


### PR DESCRIPTION
It previously always choose the default color.