### PR TITLE
Fix building the project with the QtCreator in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build*/
 cmake-build-*/
-src/birdtray.pro.user
+src/birdtray.pro.user*
 
 installer/uninstaller/*
 installer/winDeploy/**

--- a/src/birdtray.pro
+++ b/src/birdtray.pro
@@ -70,7 +70,7 @@ FORMS += \
 
 RESOURCES += \
     resources.qrc
-
+RC_INCLUDEPATH += $$PWD
 RC_FILE = res\birdtray.rc
 
 unix {


### PR DESCRIPTION
When processing the resource file the `version.h` was not found.

This also excludes `birdtray.pro.user*` from git which are created by the QtCreator.