### PR TITLE
Fix: MorkParser crashes on `\\\n\\)` (5C 0A 5C 29), unread count incorrect

### DIFF
--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -342,13 +342,8 @@ void MorkParser::parseCell()
 			break;
 		case '\\':
 			{
-				// Get next two chars
-				char NextChar= nextChar();
-				if ( '\r' != NextChar && '\n' != NextChar )
-				{
-					Text += NextChar;
-				}
-				else nextChar();
+				// Get next char
+				Text += nextChar();
 			}
 			break;
 		case '$':


### PR DESCRIPTION
The MorkParser crashes for some of my msf files.
This makes the counter not update for these files (exception is thrown) and generates a SIGABRT when `--dump-mork` is used.

I am not sure why that `if` was added in the first place and why another character is skipped (line 351), but it cannot parse an escaped newline followed by another escaped character.