### PR TITLE
Update checker and auto updater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(SQLite3 REQUIRED)
 find_package(Qt5Core CONFIG REQUIRED)
 find_package(Qt5Gui CONFIG REQUIRED)
 find_package(Qt5Widgets CONFIG REQUIRED)
-set(REQUIRED_MODULES ${SQLITE3_LIBRARIES} Qt5::Core Qt5::Gui Qt5::Widgets)
+find_package(Qt5Network CONFIG REQUIRED)
+set(REQUIRED_MODULES ${SQLITE3_LIBRARIES} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
 
 set(PLATFORM_SOURCES)
 set(PLATFORM_HEADERS)
@@ -22,8 +23,10 @@ if (WIN32)
     set(PLATFORM_SOURCES src/windowtools_win.cpp src/birdtrayeventfilter.cpp
             src/processhandle.cpp src/res/birdtray.rc)
     set(PLATFORM_HEADERS src/windowtools_win.h src/birdtrayeventfilter.h src/processhandle.h)
+    find_package(Qt5WinExtras CONFIG REQUIRED)
+    list(APPEND REQUIRED_MODULES Qt5::WinExtras)
 else()
-    find_package(Qt5X11Extras QUIET)
+    find_package(Qt5X11Extras REQUIRED)
     find_library(X11 X11)
     list(APPEND REQUIRED_MODULES Qt5::X11Extras ${X11})
     set(PLATFORM_SOURCES src/windowtools_x11.cpp)
@@ -54,9 +57,14 @@ set(SOURCES
         src/unreadcounter.cpp
         src/utils.cpp
         src/windowtools.cpp
+        src/autoupdater.cpp
+        src/updatedialog.cpp
+        src/updatedownloaddialog.cpp
         src/dialogaddeditaccount.ui
         src/dialogaddeditnewemail.ui
-        src/dialogsettings.ui)
+        src/dialogsettings.ui
+        src/updatedialog.ui
+        src/updatedownloaddialog.ui)
 
 set(HEADERS
         src/colorbutton.h
@@ -75,7 +83,10 @@ set(HEADERS
         src/unreadcounter.h
         src/utils.h
         src/version.h
-        src/windowtools.h)
+        src/windowtools.h
+        src/autoupdater.h
+        src/updatedialog.h
+        src/updatedownloaddialog.h)
 
 set(RESOURCES src/resources.qrc)
 source_group("Resources" FILES ${RESOURCES})

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -42,6 +42,10 @@ AutoUpdater::~AutoUpdater() {
         downloadProcessDialog->deleteLater();
         downloadProcessDialog = nullptr;
     }
+    if (installerFile.isOpen()) {
+        // We quit in the middle of downloading
+        installerFile.remove();
+    }
 }
 
 void AutoUpdater::checkForUpdates() {

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -109,7 +109,6 @@ void AutoUpdater::startDownload() {
     if (!downloadUrl.isValid()) {
         return;
     }
-#ifdef Q_OS_WIN
     if (haveActualInstallerDownloadUrl) {
         if (downloadProcessDialog == nullptr) {
             downloadProcessDialog = new UpdateDownloadDialog();
@@ -124,7 +123,6 @@ void AutoUpdater::startDownload() {
                 });
         return;
     }
-#endif /* Q_OS_WIN */
     QDesktopServices::openUrl(downloadUrl);
 }
 
@@ -188,7 +186,6 @@ void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
                     nullptr, tr("Installer download failed"),
                     tr("Failed to download the Birdtray installer:\nInvalid redirect: ")
                     + redirectionTarget.toString(), QMessageBox::StandardButton::Abort);
-            
         }
     } else {
         QFile installerFile(QDir::temp().filePath("birdtrayInstaller.exe"));

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -64,7 +64,7 @@ void AutoUpdater::onRequestFinished(QNetworkReply* result) {
                                + installerFile.errorString();
             } else {
                 errorMessage = tr("Failed to download the Birdtray installer:\n")
-                        + result->errorString();
+                               + result->errorString();
             }
             installerFile.remove();
             bool wasCanceled = false;
@@ -217,12 +217,12 @@ void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
         }
     } else if (installerFile.write(result->readAll()) == -1) {
         QString errorMessage(tr("Failed to save the Birdtray installer:\n")
-                           + installerFile.errorString());
+                             + installerFile.errorString());
         installerFile.remove();
         if (QMessageBox::critical(
                 nullptr, tr("Installer download failed"), errorMessage,
                 QMessageBox::StandardButton::Retry | QMessageBox::StandardButton::Cancel)
-                == QMessageBox::StandardButton::Retry) {
+            == QMessageBox::StandardButton::Retry) {
             startDownload();
             return;
         }

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -1,0 +1,258 @@
+#include "autoupdater.h"
+#include "utils.h"
+
+#if defined(_WIN32) && !defined(_WIN64)
+#  include <windows.h>
+#endif
+
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <version.h>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QMessageBox>
+#include <QFile>
+#include <QDir>
+#include <QApplication>
+#include <QtCore/QProcess>
+#include <QtGui/QDesktopServices>
+
+#define LATEST_VERSION_INFO_URL "https://api.github.com/repos/gyunaev/birdtray/releases/latest"
+#define GENERIC_DOWNLOAD_URL "https://github.com/gyunaev/birdtray/releases/latest"
+#define VERSION_TAG_REGEX "^(RELEASE_)?(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
+
+AutoUpdater* autoUpdaterSingleton = nullptr;
+
+AutoUpdater::AutoUpdater(QObject* parent) :
+        networkAccessManager(new QNetworkAccessManager(this)),
+        versionRe(VERSION_TAG_REGEX, QRegularExpression::CaseInsensitiveOption), QObject(parent) {
+    connect(networkAccessManager, &QNetworkAccessManager::finished,
+            this, &AutoUpdater::onRequestFinished);
+    connect(&updateDialog, &UpdateDialog::onDownloadButtonClicked,
+            this, &AutoUpdater::startDownload);
+}
+
+AutoUpdater::~AutoUpdater() {
+    networkAccessManager->deleteLater();
+    updateDialog.deleteLater();
+    if (downloadProcessDialog != nullptr) {
+        downloadProcessDialog->deleteLater();
+        downloadProcessDialog = nullptr;
+    }
+}
+
+void AutoUpdater::checkForUpdates() {
+    networkAccessManager->get(QNetworkRequest(QUrl(LATEST_VERSION_INFO_URL)));
+}
+
+void AutoUpdater::onRequestFinished(QNetworkReply* result) {
+    bool isVersionInfoResult = result->url() == QUrl(LATEST_VERSION_INFO_URL);
+    if (result->error()) {
+        if (isVersionInfoResult) {
+            QMessageBox::warning(
+                    nullptr, tr("Version check failed"),
+                    tr("Failed to check for a new Birdtray version:\n") + result->errorString(),
+                    QMessageBox::StandardButton::Ok);
+        } else {
+            bool wasCanceled = false;
+            if (downloadProcessDialog != nullptr) {
+                wasCanceled = downloadProcessDialog->wasCanceled();
+                downloadProcessDialog->close();
+                downloadProcessDialog->deleteLater();
+                downloadProcessDialog = nullptr;
+            }
+            if (!wasCanceled && QMessageBox::critical(
+                    nullptr, tr("Installer download failed"),
+                    tr("Failed to download the Birdtray installer:\n") + result->errorString(),
+                    QMessageBox::StandardButton::Retry | QMessageBox::StandardButton::Cancel)
+                                == QMessageBox::StandardButton::Retry) {
+                startDownload();
+            }
+        }
+    } else if (isVersionInfoResult) {
+        onReleaseInfoRequestFinished(result);
+    } else {
+        onInstallerDownloadFinished(result);
+    }
+    result->deleteLater();
+}
+
+bool AutoUpdater::parseReleaseTag(int (&version)[3], const QString &releaseTag) {
+    const QRegularExpressionMatch &match = versionRe.match(releaseTag);
+    if (!match.hasMatch()) {
+        return false;
+    }
+    const QString versionParts[] = {"major", "minor", "patch"};
+    for (int i = 0; i < 3; i++) {
+        QString partStr = match.captured(versionParts[i]);
+        int versionPart;
+        if (partStr.isNull()) {
+            if (i != 2) {
+                return false;
+            }
+            versionPart = 0; // Allow missing patch version
+        } else {
+            bool parseOk = true;
+            versionPart = partStr.toInt(&parseOk);
+            if (!parseOk) {
+                return false;
+            }
+        }
+        version[i] = versionPart;
+    }
+    return true;
+}
+
+void AutoUpdater::startDownload() {
+    if (!downloadUrl.isValid()) {
+        return;
+    }
+#ifdef Q_OS_WIN
+    if (haveActualInstallerDownloadUrl) {
+        if (downloadProcessDialog == nullptr) {
+            downloadProcessDialog = new UpdateDownloadDialog();
+        } else {
+            downloadProcessDialog->reset();
+        }
+        downloadProcessDialog->show();
+        QNetworkReply* reply = networkAccessManager->get(QNetworkRequest(downloadUrl));
+        connect(reply, &QNetworkReply::downloadProgress, this,
+                [=](qint64 bytesReceived, qint64 bytesTotal) {
+                    AutoUpdater::onDownloadProgress(reply, bytesReceived, bytesTotal);
+                });
+        return;
+    }
+#endif /* Q_OS_WIN */
+    QDesktopServices::openUrl(downloadUrl);
+}
+
+qulonglong AutoUpdater::parseDownloadUrl(const QJsonArray &assets, const QString &defaultUrl) {
+#ifdef Q_OS_WIN
+#ifdef _WIN64
+    const QString fileEnding = "x64.exe";
+#elif defined(_WIN32)
+    BOOL is64Bit = FALSE;
+    is64Bit = IsWow64Process(GetCurrentProcess(), &is64Bit) && is64Bit;
+    const QString fileEnding = is64Bit ? "x64.exe" : "x86.exe";
+#endif
+    for (auto assetInfo : assets) {
+        QString name = assetInfo["name"].toString();
+        if (!name.isNull() && name.endsWith(fileEnding)) {
+            downloadUrl = assetInfo["browser_download_url"].toString();
+            if (downloadUrl.isValid()) {
+                return assetInfo["size"].toVariant().toULongLong();
+            }
+        }
+    }
+#endif /* Q_OS_WIN */
+    if (defaultUrl.isNull()) {
+        downloadUrl = GENERIC_DOWNLOAD_URL;  // Last resort
+    } else {
+        downloadUrl = defaultUrl;
+    }
+    return (qulonglong) -1;
+}
+
+void AutoUpdater::onReleaseInfoRequestFinished(QNetworkReply* result) {
+    haveActualInstallerDownloadUrl = false;
+    QByteArray buffer = result->readAll();
+    QJsonDocument responseDocument = QJsonDocument::fromJson(buffer);
+    QJsonObject response = responseDocument.object();
+    QString releaseTag = response["tag_name"].toString();
+    int version[3];
+    if (!updateDialog.isVisible() && parseReleaseTag(version, releaseTag) &&
+        versionGrater(version, {VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH})) {
+        qulonglong downloadSize = parseDownloadUrl(
+                response["assets"].toArray(), response["html_url"].toString());
+        if (downloadUrl.isValid()) {
+            haveActualInstallerDownloadUrl = downloadSize != (qulonglong) -1;
+            updateDialog.show(QString("%1.%2.%3").arg(version[0]).arg(version[1]).arg(version[2]),
+                              response["body"].toString(), downloadSize);
+        }
+    }
+    emit onCheckUpdateFinished();
+}
+
+void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
+    QVariant redirectionTarget = result->attribute(QNetworkRequest::RedirectionTargetAttribute);
+    if (!redirectionTarget.isNull()) {
+        QUrl newUrl = resolveRedirectDownloadUrl(redirectionTarget.toUrl());
+        if (newUrl.isValid()) {
+            downloadUrl = newUrl;
+            startDownload();
+            return;
+        } else {
+            QMessageBox::critical(
+                    nullptr, tr("Installer download failed"),
+                    tr("Failed to download the Birdtray installer:\nInvalid redirect: ")
+                    + redirectionTarget.toString(), QMessageBox::StandardButton::Abort);
+            
+        }
+    } else {
+        QFile installerFile(QDir::temp().filePath("birdtrayInstaller.exe"));
+        if (!installerFile.open(QFile::WriteOnly)) {
+            if (QMessageBox::critical(
+                    nullptr, tr("Installer download failed"),
+                    tr("Failed to save the Birdtray installer:\n") + installerFile.errorString(),
+                    QMessageBox::StandardButton::Retry | QMessageBox::StandardButton::Cancel)
+                == QMessageBox::StandardButton::Retry) {
+                startDownload();
+                return;
+            }
+        } else {
+            installerFile.write(result->readAll());
+            installerFile.close();
+            if (downloadProcessDialog != nullptr && !downloadProcessDialog->wasCanceled()) {
+                downloadProcessDialog->onDownloadComplete();
+                downloadProcessDialog->exec();
+                if (downloadProcessDialog->wasCanceled()) {
+                    installerFile.remove();
+                } else if (!QProcess::startDetached(installerFile.fileName())) {
+                    QMessageBox::critical(
+                            nullptr, tr("Update failed"),
+                            tr("Failed to start the Birdtray installer."),
+                            QMessageBox::StandardButton::Abort);
+                    installerFile.remove();
+                } else {
+                    QApplication::quit();
+                }
+            }
+        }
+    }
+    if (downloadProcessDialog != nullptr) {
+        downloadProcessDialog->close();
+        downloadProcessDialog->deleteLater();
+        downloadProcessDialog = nullptr;
+    }
+}
+
+void AutoUpdater::onDownloadProgress(QNetworkReply* result, qint64 bytesReceived,
+                                     qint64 bytesTotal) {
+    if (downloadProcessDialog != nullptr) {
+        if (downloadProcessDialog->wasCanceled()) {
+            result->close();
+        } else {
+            downloadProcessDialog->onDownloadProgress(bytesReceived, bytesTotal);
+        }
+    }
+}
+
+QUrl AutoUpdater::resolveRedirectDownloadUrl(const QUrl &redirectUrl) const {
+    QUrl newUrl;
+    if (redirectUrl.isRelative()) {
+        newUrl = downloadUrl.resolved(redirectUrl);
+    } else {
+        newUrl = redirectUrl;
+    }
+    if (!newUrl.isEmpty() && newUrl != downloadUrl) {
+        return newUrl;
+    }
+    return QUrl();
+}
+
+bool AutoUpdater::versionGrater(const int (&version)[3], const int (&other)[3]) {
+    return version[0] > other[0] || (version[0] == other[0] && (
+            version[1] > other[1] || (version[1] == other[1] && version[2] > other[2])));
+}

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -212,8 +212,8 @@ void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
         installerFile.close();
         if (downloadProcessDialog != nullptr && !downloadProcessDialog->wasCanceled()) {
             downloadProcessDialog->onDownloadComplete();
-            downloadProcessDialog->exec();
-            if (downloadProcessDialog->wasCanceled()) {
+            if (downloadProcessDialog->exec() == QDialog::Rejected
+                || downloadProcessDialog->wasCanceled()) {
                 installerFile.remove();
             } else if (!QProcess::startDetached(installerFile.fileName())) {
                 QMessageBox::critical(

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -1,5 +1,6 @@
 #include "autoupdater.h"
 #include "utils.h"
+#include "settings.h"
 
 #if defined(_WIN32) && !defined(_WIN64)
 #  include <windows.h>
@@ -165,9 +166,12 @@ void AutoUpdater::onReleaseInfoRequestFinished(QNetworkReply* result) {
         qulonglong downloadSize = parseDownloadUrl(
                 response["assets"].toArray(), response["html_url"].toString());
         if (downloadUrl.isValid()) {
-            haveActualInstallerDownloadUrl = downloadSize != (qulonglong) -1;
-            updateDialog.show(QString("%1.%2.%3").arg(version[0]).arg(version[1]).arg(version[2]),
-                              response["body"].toString(), downloadSize);
+            QString versionString = QString("%1.%2.%3")
+                    .arg(version[0]).arg(version[1]).arg(version[2]);
+            if (versionString != pSettings->mIgnoreUpdateVersion) {
+                haveActualInstallerDownloadUrl = downloadSize != (qulonglong) -1;
+                updateDialog.show(versionString, response["body"].toString(), downloadSize);
+            }
         }
     }
     emit onCheckUpdateFinished();

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -56,10 +56,7 @@ void AutoUpdater::onRequestFinished(QNetworkReply* result) {
     bool isVersionInfoResult = result->url() == QUrl(LATEST_VERSION_INFO_URL);
     if (result->error()) {
         if (isVersionInfoResult) {
-            QMessageBox::warning(
-                    nullptr, tr("Version check failed"),
-                    tr("Failed to check for a new Birdtray version:\n") + result->errorString(),
-                    QMessageBox::StandardButton::Ok);
+            emit onCheckUpdateFinished(result->errorString());
         } else {
             installerFile.remove();
             bool wasCanceled = false;
@@ -193,7 +190,7 @@ void AutoUpdater::onReleaseInfoRequestFinished(QNetworkReply* result) {
             }
         }
     }
-    emit onCheckUpdateFinished();
+    emit onCheckUpdateFinished(QString());
 }
 
 void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -5,6 +5,7 @@
 #include <QRegularExpression>
 #include <QtWidgets/QProgressDialog>
 #include <QUrl>
+#include <QFile>
 #include "updatedialog.h"
 #include "updatedownloaddialog.h"
 
@@ -115,6 +116,11 @@ private:
      * points to the actual installer file or just a download page.
      */
     bool haveActualInstallerDownloadUrl = false;
+    
+    /**
+     * The destination to save the downloaded installer to.
+     */
+    QFile installerFile;
     
     /**
      * A regular expression to parse a version from a release tag.

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -1,0 +1,132 @@
+#ifndef AUTO_UPDATER_H
+#define AUTO_UPDATER_H
+
+#include <QNetworkAccessManager>
+#include <QRegularExpression>
+#include <QtWidgets/QProgressDialog>
+#include "updatedialog.h"
+#include "updatedownloaddialog.h"
+
+
+/**
+ * Allows to check, download (and, if the platform is supported, install) new updates for Birdtray.
+ */
+class AutoUpdater: public QObject {
+Q_OBJECT
+public:
+    explicit AutoUpdater(QObject* parent = nullptr);
+    ~AutoUpdater() override;
+    
+    /**
+     * Check if there is a newer version of Birdtray available.
+     * Once the check finished, onCheckUpdateFinished() will be signaled.
+     */
+    void checkForUpdates();
+
+Q_SIGNALS:
+    /**
+     * Indicates that an update check finished.
+     */
+    void onCheckUpdateFinished();
+    
+public slots:
+    void onRequestFinished(QNetworkReply* result);
+    void onDownloadProgress(QNetworkReply* result, qint64 bytesReceived, qint64 bytesTotal);
+    
+    /**
+     * Start the download of the installer.
+     * On supported systems, this will download the installer file and execute it.
+     * On all other systems, the download url will be opened in the standard browser.
+     */
+    void startDownload();
+
+private:
+    /**
+     * The network manager used to make network requests.
+     */
+    QNetworkAccessManager* networkAccessManager;
+    
+    /**
+     * Parse a release tag and try to extract the major, minor and patch version from it.
+     *
+     * @param version A place to store the parsed version.
+     * @param releaseTag The release tag to parse.
+     * @return true, if a valid version has been parsed from the tag.
+     */
+    bool parseReleaseTag(int (&version)[3], const QString& releaseTag);
+    
+    /**
+     * Parse the download url from the json assets array
+     * received from the Github api for the latest release.
+     *
+     * @param assets The assets list.
+     * @param defaultUrl A default download url to use when
+     *                   no asset for the current platform is found.
+     * @return The estimated download size, 0 if the size is unknown,
+     *         or -1 of no url to an actual installer file could be found.
+     */
+    qulonglong parseDownloadUrl(const QJsonArray &assets, const QString &defaultUrl);
+    
+    /**
+     * Handle the result from a release info request.
+     *
+     * @param result The network result from the release info request.
+     */
+    void onReleaseInfoRequestFinished(QNetworkReply* result);
+    
+    /**
+     * Handle the completion of the download of the Birdtray installer.
+     *
+     * @param result The network result from the download.
+     */
+    void onInstallerDownloadFinished(QNetworkReply* result);
+    
+    /**
+     * Resolve a redirect url while downloading the installer.
+     * Blocks redirect loops.
+     *
+     * @param redirectUrl The new redirect url.
+     * @return The resolved url to redirect to or an invalid url, if the redirect is not valid.
+     */
+    QUrl resolveRedirectDownloadUrl(const QUrl &redirectUrl) const;
+    
+    /**
+     * Check if the first version is greater than the second version
+     * according to semantic versioning.
+     *
+     * @param version The first version.
+     * @param other The second version to compare with the first version.
+     * @return true, if the first version is greater than the second version.
+     */
+    static bool versionGrater(const int (&version)[3], const int (&other)[3]);
+    
+    /**
+     * The download url to the Birdtray installer or a download site.
+     */
+    QUrl downloadUrl;
+    
+    /**
+     * Indicates whether or not the current ::downloadUrl
+     * points to the actual installer file or just a download page.
+     */
+    bool haveActualInstallerDownloadUrl = false;
+    
+    /**
+     * A regular expression to parse a version from a release tag.
+     */
+    QRegularExpression versionRe;
+    
+    /**
+     * A dialog that notifies the user about a new Birdtray version.
+     */
+    UpdateDialog updateDialog;
+    
+    /**
+     * A dialog that lets the user see the process during download of the installer.
+     */
+    UpdateDownloadDialog* downloadProcessDialog = nullptr;
+};
+
+extern AutoUpdater* autoUpdaterSingleton;
+
+#endif /* AUTO_UPDATER_H */

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -12,10 +12,11 @@
 /**
  * Allows to check, download (and, if the platform is supported, install) new updates for Birdtray.
  */
-class AutoUpdater: public QObject {
+class AutoUpdater : public QObject {
 Q_OBJECT
 public:
     explicit AutoUpdater(QObject* parent = nullptr);
+    
     ~AutoUpdater() override;
     
     /**
@@ -25,13 +26,16 @@ public:
     void checkForUpdates();
 
 Q_SIGNALS:
+    
     /**
      * Indicates that an update check finished.
      */
     void onCheckUpdateFinished();
-    
+
 public slots:
+    
     void onRequestFinished(QNetworkReply* result);
+    
     void onDownloadProgress(QNetworkReply* result, qint64 bytesReceived, qint64 bytesTotal);
     
     /**
@@ -54,7 +58,7 @@ private:
      * @param releaseTag The release tag to parse.
      * @return true, if a valid version has been parsed from the tag.
      */
-    bool parseReleaseTag(int (&version)[3], const QString& releaseTag);
+    bool parseReleaseTag(int (&version)[3], const QString &releaseTag);
     
     /**
      * Parse the download url from the json assets array

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -30,8 +30,10 @@ Q_SIGNALS:
     
     /**
      * Indicates that an update check finished.
+     *
+     * @param errorString An error String of the request failed, else a null string.
      */
-    void onCheckUpdateFinished();
+    void onCheckUpdateFinished(const QString &errorString);
 
 public slots:
     

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -4,6 +4,7 @@
 #include <QNetworkAccessManager>
 #include <QRegularExpression>
 #include <QtWidgets/QProgressDialog>
+#include <QUrl>
 #include "updatedialog.h"
 #include "updatedownloaddialog.h"
 

--- a/src/birdtray.pro
+++ b/src/birdtray.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui network
 CONFIG += c++11
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -36,13 +36,16 @@ SOURCES += \
     databaseunreadfixer.cpp \
     dialogaddeditaccount.cpp \
     dialogsettings.cpp \
+    updatedialog.cpp \
+    updatedownloaddialog.cpp \
     windowtools.cpp \
     dialogaddeditnewemail.cpp \
     setting_newemail.cpp \
     modelnewemails.cpp \
     modelaccounttree.cpp \
     morkparser.cpp \
-    utils.cpp
+    utils.cpp \
+    autoupdater.cpp
 
 HEADERS += \
     trayicon.h \
@@ -54,6 +57,8 @@ HEADERS += \
     databaseunreadfixer.h \
     dialogaddeditaccount.h \
     dialogsettings.h \
+    updatedialog.h \
+    updatedownloaddialog.h \
     version.h \
     windowtools.h \
     dialogaddeditnewemail.h \
@@ -61,12 +66,15 @@ HEADERS += \
     modelnewemails.h \
     modelaccounttree.h \
     morkparser.h \
-    utils.h
+    utils.h \
+    autoupdater.h
 
 FORMS += \
     dialogaddeditaccount.ui \
     dialogsettings.ui \
-    dialogaddeditnewemail.ui
+    dialogaddeditnewemail.ui \
+    updatedialog.ui \
+    updatedownloaddialog.ui
 
 RESOURCES += \
     resources.qrc
@@ -104,4 +112,5 @@ win32 {
      SOURCES += windowtools_win.cpp birdtrayeventfilter.cpp processhandle.cpp
      HEADERS += windowtools_win.h birdtrayeventfilter.h processhandle.h
      LIBS += user32.lib
+     QT += winextras
 }

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -221,9 +221,15 @@ void DialogSettings::profilePathChanged()
 
 }
 
-void DialogSettings::onCheckUpdateFinished() {
+void DialogSettings::onCheckUpdateFinished(const QString &errorString) {
     checkUpdateButton->setText(tr("Check now"));
     checkUpdateButton->setEnabled(true);
+    if (!errorString.isNull()) {
+        QMessageBox::warning(
+                nullptr, tr("Version check failed"),
+                tr("Failed to check for a new Birdtray version:\n") + errorString,
+                QMessageBox::StandardButton::Ok);
+    }
 }
 
 void DialogSettings::fixDatabaseUnreads()

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -11,6 +11,7 @@
 #include "dialogaddeditaccount.h"
 #include "databaseunreadfixer.h"
 #include "utils.h"
+#include "autoupdater.h"
 
 DialogSettings::DialogSettings( QWidget *parent)
     : QDialog(parent), Ui::DialogSettings()
@@ -41,6 +42,11 @@ DialogSettings::DialogSettings( QWidget *parent)
     connect( btnNewEmailAdd, &QPushButton::clicked, this, &DialogSettings::newEmailAdd );
     connect( btnNewEmailEdit, &QPushButton::clicked, this, &DialogSettings::newEmailEdit );
     connect( btnNewEmailDelete, &QPushButton::clicked, this, &DialogSettings::newEmailRemove );
+    
+    connect( checkUpdateButton, &QPushButton::clicked,
+            this, &DialogSettings::onCheckUpdateButton );
+    connect( autoUpdaterSingleton, &AutoUpdater::onCheckUpdateFinished,
+            this, &DialogSettings::onCheckUpdateFinished );
 
     // Setup parameters
     leProfilePath->setText( QDir::toNativeSeparators(pSettings->mThunderbirdFolderPath) );
@@ -61,6 +67,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     boxHideWindowAtRestart->setChecked( pSettings->mHideWhenRestarted );
     boxEnableNewEmail->setChecked( pSettings->mNewEmailMenuEnabled );
     boxBlinkingUsesAlpha->setChecked( pSettings->mBlinkingUseAlphaTransition );
+    checkUpdateOnStartup->setChecked( pSettings->mUpdateOnStartup );
     boxAllowSuppression->setChecked( pSettings->mAllowSuppressingUnreads );
     spinUnreadOpacityLevel->setValue( pSettings->mUnreadOpacityLevel * 100 );
     spinThunderbirdStartDelay->setValue( pSettings->mLaunchThunderbirdDelay );
@@ -157,6 +164,7 @@ void DialogSettings::accept()
     pSettings->mHideWhenRestarted = boxHideWindowAtRestart->isChecked();
     pSettings->mNewEmailMenuEnabled = boxEnableNewEmail->isChecked();
     pSettings->mBlinkingUseAlphaTransition = boxBlinkingUsesAlpha->isChecked();
+    pSettings->mUpdateOnStartup = checkUpdateOnStartup->isChecked();
     pSettings->mUseMorkParser = isMorkParserSelected();
     pSettings->mUnreadOpacityLevel = (double) spinUnreadOpacityLevel->value() / 100.0;
     pSettings->mLaunchThunderbirdDelay = spinThunderbirdStartDelay->value();
@@ -211,6 +219,11 @@ void DialogSettings::profilePathChanged()
         mAccounts.clear();
     }
 
+}
+
+void DialogSettings::onCheckUpdateFinished() {
+    checkUpdateButton->setText(tr("Check now"));
+    checkUpdateButton->setEnabled(true);
 }
 
 void DialogSettings::fixDatabaseUnreads()
@@ -345,6 +358,12 @@ void DialogSettings::newEmailEditIndex(const QModelIndex &index)
 void DialogSettings::newEmailRemove()
 {
     mModelNewEmails->remove( treeNewEmails->currentIndex() );
+}
+
+void DialogSettings::onCheckUpdateButton() {
+    checkUpdateButton->setText(tr("Checking..."));
+    checkUpdateButton->setEnabled(false);
+    autoUpdaterSingleton->checkForUpdates();
 }
 
 void DialogSettings::buttonChangeIcon()

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -33,7 +33,7 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         /**
          * Called once the update check finished.
          */
-        void    onCheckUpdateFinished();
+        void    onCheckUpdateFinished(const QString &errorString);
 
         // Calls the database fixer running in a DatabaseFixer thread
         // Receives databaseUnreadsFixed() once fixed

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -29,6 +29,11 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    accept() override;
         void    browsePath();
         void    profilePathChanged();
+        
+        /**
+         * Called once the update check finished.
+         */
+        void    onCheckUpdateFinished();
 
         // Calls the database fixer running in a DatabaseFixer thread
         // Receives databaseUnreadsFixed() once fixed
@@ -55,6 +60,9 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    newEmailEdit();
         void    newEmailEditIndex( const QModelIndex& index );
         void    newEmailRemove();
+        
+        // Advanced buttons
+        void    onCheckUpdateButton();
 
         // Icon change
         void    buttonChangeIcon();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -772,6 +772,43 @@
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+             <widget class="QCheckBox" name="checkUpdateOnStartup">
+              <property name="toolTip">
+               <string>Check for new updates when Birdtray starts</string>
+              </property>
+              <property name="text">
+               <string>Check for new updates on startup</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="checkUpdateButton">
+              <property name="toolTip">
+               <string>Check for a new Birdtray version</string>
+              </property>
+              <property name="text">
+               <string>Check now</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,14 +83,9 @@ int main(int argc, char *argv[])
     } else {
         pSettings->load();
     }
+    autoUpdaterSingleton = new AutoUpdater();
 
     TrayIcon trayIcon(parser.isSet("settings"));
-    
-    // Update check
-    autoUpdaterSingleton = new AutoUpdater();
-    if (pSettings->mUpdateOnStartup) {
-        autoUpdaterSingleton->checkForUpdates();
-    }
     int result = QApplication::exec();
 
     delete pSettings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include "settings.h"
 #include "morkparser.h"
 #include "utils.h"
-
+#include "autoupdater.h"
 
 
 void ensureSystemTrayAvailable() {
@@ -85,9 +85,16 @@ int main(int argc, char *argv[])
     }
 
     TrayIcon trayIcon(parser.isSet("settings"));
+    
+    // Update check
+    autoUpdaterSingleton = new AutoUpdater();
+    if (pSettings->mUpdateOnStartup) {
+        autoUpdaterSingleton->checkForUpdates();
+    }
     int result = QApplication::exec();
 
-    delete(pSettings);
+    delete pSettings;
+    delete autoUpdaterSingleton;
 
     return result;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,3 @@
-#include <QStandardPaths>
 #include <QBuffer>
 #include <QDir>
 #ifdef Q_OS_WIN
@@ -55,6 +54,7 @@ Settings::Settings(bool verboseOutput)
     mUseMorkParser = true;
     mWatchFileTimeout = 150;
     mBlinkingUseAlphaTransition = false;
+    mUpdateOnStartup = true;
     mUnreadOpacityLevel = 0.75;
     mNewEmailMenuEnabled = false;
 }
@@ -91,6 +91,7 @@ void Settings::save()
     mSettings->setValue("advanced/watchfiletimeout", mWatchFileTimeout );
     mSettings->setValue("advanced/blinkingusealpha", mBlinkingUseAlphaTransition );
     mSettings->setValue("advanced/unreadopacitylevel", mUnreadOpacityLevel );
+    mSettings->setValue("advanced/updateOnStartup", mUpdateOnStartup );
 
     // Convert the map into settings
     mSettings->setValue("accounts/count", mFolderNotificationColors.size() );
@@ -178,6 +179,7 @@ void Settings::load()
             "advanced/blinkingusealpha", mBlinkingUseAlphaTransition ).toBool();
     mUnreadOpacityLevel = mSettings->value(
             "advanced/unreadopacitylevel", mUnreadOpacityLevel ).toDouble();
+    mUpdateOnStartup = mSettings->value("advanced/updateOnStartup", mUpdateOnStartup ).toBool();
 
     mFolderNotificationColors.clear();
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -54,7 +54,7 @@ Settings::Settings(bool verboseOutput)
     mUseMorkParser = true;
     mWatchFileTimeout = 150;
     mBlinkingUseAlphaTransition = false;
-    mUpdateOnStartup = true;
+    mUpdateOnStartup = false;
     mUnreadOpacityLevel = 0.75;
     mNewEmailMenuEnabled = false;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -92,6 +92,7 @@ void Settings::save()
     mSettings->setValue("advanced/blinkingusealpha", mBlinkingUseAlphaTransition );
     mSettings->setValue("advanced/unreadopacitylevel", mUnreadOpacityLevel );
     mSettings->setValue("advanced/updateOnStartup", mUpdateOnStartup );
+    mSettings->setValue("advanced/ignoreUpdateVersion", mIgnoreUpdateVersion );
 
     // Convert the map into settings
     mSettings->setValue("accounts/count", mFolderNotificationColors.size() );
@@ -180,6 +181,8 @@ void Settings::load()
     mUnreadOpacityLevel = mSettings->value(
             "advanced/unreadopacitylevel", mUnreadOpacityLevel ).toDouble();
     mUpdateOnStartup = mSettings->value("advanced/updateOnStartup", mUpdateOnStartup ).toBool();
+    mIgnoreUpdateVersion = mSettings->value(
+            "advanced/ignoreUpdateVersion", mIgnoreUpdateVersion ).toString();
 
     mFolderNotificationColors.clear();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -81,6 +81,9 @@ class Settings
 
         // Whether to use alpha transition when blinking
         bool    mBlinkingUseAlphaTransition;
+        
+        // Whether to check for a new Birdtray version on startup or not.
+        bool    mUpdateOnStartup;
 
         // Whether to allow suppression of unread emails
         bool    mAllowSuppressingUnreads;

--- a/src/settings.h
+++ b/src/settings.h
@@ -84,6 +84,9 @@ class Settings
         
         // Whether to check for a new Birdtray version on startup or not.
         bool    mUpdateOnStartup;
+        
+        // The new Birdtray version that the user selected to ignore.
+        QString mIgnoreUpdateVersion;
 
         // Whether to allow suppression of unread emails
         bool    mAllowSuppressingUnreads;

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -5,12 +5,14 @@
 #include <QProcess>
 #include <QMessageBox>
 #include <QFontMetrics>
+#include <QtNetwork/QNetworkSession>
 
 #include "settings.h"
 #include "trayicon.h"
 #include "unreadcounter.h"
 #include "windowtools.h"
 #include "utils.h"
+#include "autoupdater.h"
 
 TrayIcon::TrayIcon(bool showSettings)
 {
@@ -67,6 +69,10 @@ TrayIcon::TrayIcon(bool showSettings)
     updateState();
     updateIcon();
     show();
+    
+    if (pSettings->mUpdateOnStartup) {
+        doAutoUpdateCheck();
+    }
 }
 
 TrayIcon::~TrayIcon() {
@@ -76,6 +82,10 @@ TrayIcon::~TrayIcon() {
 #ifdef Q_OS_WIN
     mThunderbirdUpdaterProcess->deleteLater();
 #endif /* Q_OS_WIN */
+    if (networkConnectivityManager != nullptr) {
+        networkConnectivityManager->deleteLater();
+        networkConnectivityManager = nullptr;
+    }
 }
 
 void TrayIcon::unreadCounterUpdate( unsigned int total, QColor color )
@@ -648,6 +658,29 @@ void TrayIcon::onQuit() {
     }
 }
 
+void TrayIcon::onAutoUpdateCheckFinished(const QString &errorMessage) {
+    if (errorMessage.isNull()) {
+        disconnect(autoUpdaterSingleton, &AutoUpdater::onCheckUpdateFinished,
+                   this, &TrayIcon::onAutoUpdateCheckFinished);
+    } else if (networkConnectivityManager == nullptr) {
+        networkConnectivityManager = new QNetworkConfigurationManager();
+        networkConnectivityManager->updateConfigurations();
+        auto callback = [=](const QNetworkConfiguration &config) {
+            if (config.state() == QNetworkConfiguration::Active) {
+                if (networkConnectivityManager != nullptr) {
+                    networkConnectivityManager->deleteLater();
+                    networkConnectivityManager = nullptr;
+                }
+                autoUpdaterSingleton->checkForUpdates();
+            }
+        };
+        connect(networkConnectivityManager, &QNetworkConfigurationManager::configurationChanged,
+                this, callback);
+        connect(networkConnectivityManager, &QNetworkConfigurationManager::configurationAdded,
+                this, callback);
+    }
+}
+
 void TrayIcon::hideThunderbird()
 {
     mMenuShowHideThunderbird->setText( tr("Show Thunderbird") );
@@ -669,4 +702,10 @@ void TrayIcon::updateIgnoredUnreads()
         else
             mMenuIgnoreUnreads->setText( tr("Ignore unread emails") );
     }
+}
+
+void TrayIcon::doAutoUpdateCheck() {
+    connect(autoUpdaterSingleton, &AutoUpdater::onCheckUpdateFinished,
+            this, &TrayIcon::onAutoUpdateCheckFinished);
+    autoUpdaterSingleton->checkForUpdates();
 }

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -7,6 +7,7 @@
 #include <QImage>
 #include <QProcess>
 #include <QSystemTrayIcon>
+#include <QtNetwork/QNetworkConfigurationManager>
 #ifdef Q_OS_WIN
 #  include "processhandle.h"
 #endif /* Q_OS_WIN */
@@ -77,6 +78,13 @@ class TrayIcon : public QSystemTrayIcon
          * Callback that is called when we are about to quit.
          */
         void    onQuit();
+        
+        /**
+         * Called when the auto update finished.
+         *
+         * @param errorMessage A message indicating an error during the check, or a null string.
+         */
+        void    onAutoUpdateCheckFinished(const QString& errorMessage);
 
     private:
         void    createMenu();
@@ -84,6 +92,11 @@ class TrayIcon : public QSystemTrayIcon
         void    hideThunderbird();
         void    showThunderbird();
         void    updateIgnoredUnreads();
+        
+        /**
+         * Do an automatic check for a new version of Birdtray.
+         */
+        void    doAutoUpdateCheck();
 
         // State variables for blinking; mBlinkingTimeout=0 means we are not blinking
         double          mBlinkingIconOpacity;
@@ -156,6 +169,11 @@ class TrayIcon : public QSystemTrayIcon
         // A reference to a Thunderbird updater process.
         ProcessHandle* mThunderbirdUpdaterProcess;
 #endif /* Q_OS_WIN */
+        
+        /**
+         * A manager to check for network connectivity.
+         */
+        QNetworkConfigurationManager* networkConnectivityManager = nullptr;
 };
 
 #endif // TRAYICON_H

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -10,6 +10,7 @@
 #ifdef Q_OS_WIN
 #  include "processhandle.h"
 #endif /* Q_OS_WIN */
+#include "dialogsettings.h"
 
 class UnreadMonitor;
 class WindowTools;
@@ -145,6 +146,11 @@ class TrayIcon : public QSystemTrayIcon
 
         // System tray context menu. Once set, it remains there, so we have to modify existing one
         QMenu       *   mSystrayMenu;
+    
+        /**
+         * The currently opened settings dialog.
+         */
+        DialogSettings* settingsDialog = nullptr;
 
 #ifdef Q_OS_WIN
         // A reference to a Thunderbird updater process.

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -14,6 +14,7 @@ UpdateDialog::UpdateDialog(QWidget* parent) :
     downloadButton->setAutoDefault(true);
     connect(downloadButton, &QPushButton::clicked, this, &UpdateDialog::onDownloadButtonClicked);
     ui->buttonBox->addButton(downloadButton, QDialogButtonBox::ButtonRole::AcceptRole);
+    ui->buttonBox->addButton(QDialogButtonBox::StandardButton::Cancel);
 }
 
 UpdateDialog::~UpdateDialog() {
@@ -25,12 +26,12 @@ void UpdateDialog::show(const QString &newVersion, const QString &changelog,
                         qulonglong estimatedSize) {
     ui->newVersionLabel->setText(newVersion);
     ui->changelogLabel->setText(changelog);
-    if (estimatedSize == 0 || estimatedSize == (qulonglong) -1) {
-        if (estimatedSize == (qulonglong) -1) {
-            downloadButton->setText(tr("Download"));
-        } else {
-            downloadButton->setText(tr("Update and Restart"));
-        }
+    if (estimatedSize == (qulonglong) -1) {
+        downloadButton->setText(tr("Download"));
+    } else {
+        downloadButton->setText(tr("Update and Restart"));
+    }
+    if (estimatedSize == 0) {
         ui->estimatedSizeDescLabel->hide();
         ui->estimatedSizeLabel->hide();
     } else {

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -1,5 +1,6 @@
 #include "updatedialog.h"
 #include "ui_updatedialog.h"
+#include "settings.h"
 #include <utils.h>
 #include <QPushButton>
 
@@ -13,13 +14,18 @@ UpdateDialog::UpdateDialog(QWidget* parent) :
     downloadButton->setDefault(true);
     downloadButton->setAutoDefault(true);
     connect(downloadButton, &QPushButton::clicked, this, &UpdateDialog::onDownloadButtonClicked);
+    ignoreVersionButton = new QPushButton(tr("Ignore this version"), ui->buttonBox);
+    connect(ignoreVersionButton, &QPushButton::clicked,
+            this, &UpdateDialog::onIgnoreVersionClicked);
     ui->buttonBox->addButton(downloadButton, QDialogButtonBox::ButtonRole::AcceptRole);
+    ui->buttonBox->addButton(ignoreVersionButton, QDialogButtonBox::ButtonRole::RejectRole);
     ui->buttonBox->addButton(QDialogButtonBox::StandardButton::Cancel);
 }
 
 UpdateDialog::~UpdateDialog() {
     delete ui;
     downloadButton->deleteLater();
+    ignoreVersionButton->deleteLater();
 }
 
 void UpdateDialog::show(const QString &newVersion, const QString &changelog,
@@ -40,4 +46,9 @@ void UpdateDialog::show(const QString &newVersion, const QString &changelog,
         ui->estimatedSizeLabel->show();
     }
     QDialog::show();
+}
+
+void UpdateDialog::onIgnoreVersionClicked() {
+    pSettings->mIgnoreUpdateVersion = ui->newVersionLabel->text();
+    pSettings->save();
 }

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -1,0 +1,42 @@
+#include "updatedialog.h"
+#include "ui_updatedialog.h"
+#include <utils.h>
+#include <QPushButton>
+
+UpdateDialog::UpdateDialog(QWidget* parent) :
+        QDialog(parent),
+        ui(new Ui::UpdateDialog) {
+    ui->setupUi(this);
+    ui->currentVersionLabel->setText(Utils::getBirdtrayVersion());
+    
+    downloadButton = new QPushButton(tr("Download"), ui->buttonBox);
+    downloadButton->setDefault(true);
+    downloadButton->setAutoDefault(true);
+    connect(downloadButton, &QPushButton::clicked, this, &UpdateDialog::onDownloadButtonClicked);
+    ui->buttonBox->addButton(downloadButton, QDialogButtonBox::ButtonRole::AcceptRole);
+}
+
+UpdateDialog::~UpdateDialog() {
+    delete ui;
+    downloadButton->deleteLater();
+}
+
+void UpdateDialog::show(const QString &newVersion, const QString &changelog,
+                        qulonglong estimatedSize) {
+    ui->newVersionLabel->setText(newVersion);
+    ui->changelogLabel->setText(changelog);
+    if (estimatedSize == 0 || estimatedSize == (qulonglong) -1) {
+        if (estimatedSize == (qulonglong) -1) {
+            downloadButton->setText(tr("Download"));
+        } else {
+            downloadButton->setText(tr("Update and Restart"));
+        }
+        ui->estimatedSizeDescLabel->hide();
+        ui->estimatedSizeLabel->hide();
+    } else {
+        ui->estimatedSizeLabel->setText(tr("ca. %1 Mb").arg(qRound(estimatedSize / 1000000.0)));
+        ui->estimatedSizeDescLabel->show();
+        ui->estimatedSizeLabel->show();
+    }
+    QDialog::show();
+}

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -31,7 +31,7 @@ void UpdateDialog::show(const QString &newVersion, const QString &changelog,
     } else {
         downloadButton->setText(tr("Update and Restart"));
     }
-    if (estimatedSize == 0) {
+    if (estimatedSize == 0 || estimatedSize == (qulonglong) -1) {
         ui->estimatedSizeDescLabel->hide();
         ui->estimatedSizeLabel->hide();
     } else {

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -1,0 +1,47 @@
+#ifndef UPDATE_DIALOG_H
+#define UPDATE_DIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+    class UpdateDialog;
+}
+
+/**
+ * A dialog that informs the user about a new update, shows the changelog
+ * and allows to download and potentially install the update.
+ */
+class UpdateDialog : public QDialog {
+Q_OBJECT
+
+public:
+    explicit UpdateDialog(QWidget* parent = nullptr);
+    
+    ~UpdateDialog() override;
+    
+    /**
+     * Show the dialog.
+     *
+     * @param newVersion The new version that is available.
+     * @param changelog The changelog for the new version.
+     * @param estimatedSize The estimated download size or 0 if the size is unknown,
+     *                      or -1 if the new version can't be downloaded automatically.
+     */
+    void show(const QString &newVersion, const QString &changelog, qulonglong estimatedSize);
+
+Q_SIGNALS:
+    /**
+     * Signalled when the user clicks on the download button.
+     */
+    void onDownloadButtonClicked();
+
+private:
+    Ui::UpdateDialog* ui;
+    
+    /**
+     * The download or download & update button.
+     */
+    QPushButton* downloadButton;
+};
+
+#endif // UPDATE_DIALOG_H

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -30,6 +30,7 @@ public:
     void show(const QString &newVersion, const QString &changelog, qulonglong estimatedSize);
 
 Q_SIGNALS:
+    
     /**
      * Signalled when the user clicks on the download button.
      */

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -36,6 +36,13 @@ Q_SIGNALS:
      */
     void onDownloadButtonClicked();
 
+public Q_SLOTS:
+    
+    /**
+     * Called when the user clicks on the ::ignoreVersionButton.
+     */
+    void onIgnoreVersionClicked();
+
 private:
     Ui::UpdateDialog* ui;
     
@@ -43,6 +50,11 @@ private:
      * The download or download & update button.
      */
     QPushButton* downloadButton;
+    
+    /**
+     * A button that lets the user ignore this new Birdtray release.
+     */
+    QPushButton* ignoreVersionButton;
 };
 
 #endif // UPDATE_DIALOG_H

--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -119,9 +119,6 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel</set>
-     </property>
     </widget>
    </item>
    <item row="4" column="0">

--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdateDialog</class>
+ <widget class="QDialog" name="UpdateDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Birdtray Update</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>16</number>
+   </property>
+   <property name="topMargin">
+    <number>16</number>
+   </property>
+   <property name="rightMargin">
+    <number>16</number>
+   </property>
+   <property name="bottomMargin">
+    <number>16</number>
+   </property>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Current version:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>A new version of Birdtray is available.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLabel" name="newVersionLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QScrollArea" name="bodyLabel">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>668</width>
+        <height>163</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="changelogLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="currentVersionLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>New version:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="estimatedSizeDescLabel">
+     <property name="text">
+      <string>Download size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLabel" name="estimatedSizeLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>UpdateDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>UpdateDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/updatedownloaddialog.cpp
+++ b/src/updatedownloaddialog.cpp
@@ -1,0 +1,83 @@
+#include "updatedownloaddialog.h"
+#include "ui_updatedownloaddialog.h"
+
+#ifdef Q_OS_WIN
+#  include <QtWinExtras/QWinTaskbarProgress>
+#endif
+
+UpdateDownloadDialog::UpdateDownloadDialog(QWidget* parent) :
+        QDialog(parent),
+#ifdef Q_OS_WIN
+        taskBarButton(this),
+#endif
+        ui(new Ui::UpdateDownloadDialog) {
+    ui->setupUi(this);
+    actionButton = new QPushButton(tr("Background"), this);
+    ui->buttonBox->addButton(actionButton, QDialogButtonBox::ButtonRole::ActionRole);
+    connect(actionButton, &QPushButton::clicked, this, &UpdateDownloadDialog::onActionPressed);
+    QPushButton* cancelButton = ui->buttonBox->addButton(QDialogButtonBox::StandardButton::Cancel);
+    connect(cancelButton, &QPushButton::clicked, this, &UpdateDownloadDialog::onCancelPressed);
+}
+
+UpdateDownloadDialog::~UpdateDownloadDialog() {
+    delete ui;
+    actionButton->deleteLater();
+}
+
+void UpdateDownloadDialog::reset() {
+    downloadCompleted = false;
+    canceled = false;
+    ui->label->setText(tr("Downloading Birdtray installer..."));
+    ui->progressBar->setValue(0);
+    ui->progressBar->show();
+#ifdef Q_OS_WIN
+    taskBarButton.progress()->reset();
+    taskBarButton.progress()->show();
+#endif
+}
+
+void UpdateDownloadDialog::onDownloadComplete() {
+    downloadCompleted = true;
+    ui->progressBar->hide();
+    actionButton->setText(tr("Update and Restart"));
+    ui->label->setText(tr("Download finished. Restart and update Birdtray?"));
+    show();
+    raise();
+    activateWindow();
+}
+
+void UpdateDownloadDialog::onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
+    ui->label->setText(
+            tr("Downloading Birdtray installer... (%1 Mb/ %2 Mb).")
+                    .arg(qRound(bytesReceived / 1000000.0))
+                    .arg(qRound(bytesTotal / 1000000.0)));
+    int percent = qRound((bytesReceived / (double) bytesTotal) * 100.0);
+    ui->progressBar->setValue(percent);
+#ifdef Q_OS_WIN
+    taskBarButton.progress()->setValue(percent);
+#endif
+}
+
+bool UpdateDownloadDialog::wasCanceled() const {
+    return canceled;
+}
+
+void UpdateDownloadDialog::onActionPressed() {
+    if (downloadCompleted) {
+        canceled = false;
+        close();
+    } else {
+        hide();
+    }
+}
+
+void UpdateDownloadDialog::onCancelPressed() {
+    canceled = true;
+}
+
+void UpdateDownloadDialog::showEvent(QShowEvent* event) {
+    QDialog::showEvent(event);
+#ifdef Q_OS_WIN
+    taskBarButton.setWindow(windowHandle());
+#endif
+}

--- a/src/updatedownloaddialog.cpp
+++ b/src/updatedownloaddialog.cpp
@@ -15,8 +15,8 @@ UpdateDownloadDialog::UpdateDownloadDialog(QWidget* parent) :
     actionButton = new QPushButton(tr("Background"), this);
     ui->buttonBox->addButton(actionButton, QDialogButtonBox::ButtonRole::ActionRole);
     connect(actionButton, &QPushButton::clicked, this, &UpdateDownloadDialog::onActionPressed);
-    QPushButton* cancelButton = ui->buttonBox->addButton(QDialogButtonBox::StandardButton::Cancel);
-    connect(cancelButton, &QPushButton::clicked, this, &UpdateDownloadDialog::onCancelPressed);
+    ui->buttonBox->addButton(QDialogButtonBox::StandardButton::Cancel);
+    setResult(Accepted);
 }
 
 UpdateDownloadDialog::~UpdateDownloadDialog() {
@@ -26,7 +26,7 @@ UpdateDownloadDialog::~UpdateDownloadDialog() {
 
 void UpdateDownloadDialog::reset() {
     downloadCompleted = false;
-    canceled = false;
+    setResult(Accepted);
     ui->label->setText(tr("Downloading Birdtray installer..."));
     ui->progressBar->setValue(0);
     ui->progressBar->show();
@@ -73,20 +73,15 @@ void UpdateDownloadDialog::onDownloadProgress(qint64 bytesReceived, qint64 bytes
 }
 
 bool UpdateDownloadDialog::wasCanceled() const {
-    return canceled;
+    return result() == Rejected;
 }
 
 void UpdateDownloadDialog::onActionPressed() {
     if (downloadCompleted) {
-        canceled = false;
-        close();
+        accept();
     } else {
         hide();
     }
-}
-
-void UpdateDownloadDialog::onCancelPressed() {
-    canceled = true;
 }
 
 void UpdateDownloadDialog::showEvent(QShowEvent* event) {

--- a/src/updatedownloaddialog.cpp
+++ b/src/updatedownloaddialog.cpp
@@ -39,6 +39,10 @@ void UpdateDownloadDialog::reset() {
 void UpdateDownloadDialog::onDownloadComplete() {
     downloadCompleted = true;
     ui->progressBar->hide();
+#ifdef Q_OS_WIN
+    taskBarButton.progress()->setRange(0, 100);
+    taskBarButton.progress()->setValue(100);
+#endif
     actionButton->setText(tr("Update and Restart"));
     ui->label->setText(tr("Download finished. Restart and update Birdtray?"));
     show();
@@ -47,13 +51,23 @@ void UpdateDownloadDialog::onDownloadComplete() {
 }
 
 void UpdateDownloadDialog::onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
+    if (bytesTotal <= 0) {
+        ui->label->setText(tr("Downloading Birdtray installer..."));
+        ui->progressBar->setRange(0, 0);
+#ifdef Q_OS_WIN
+        taskBarButton.progress()->setRange(0, 0);
+#endif
+        return;
+    }
     ui->label->setText(
             tr("Downloading Birdtray installer... (%1 Mb/ %2 Mb).")
                     .arg(qRound(bytesReceived / 1000000.0))
                     .arg(qRound(bytesTotal / 1000000.0)));
     int percent = qRound((bytesReceived / (double) bytesTotal) * 100.0);
+    ui->progressBar->setRange(0, 100);
     ui->progressBar->setValue(percent);
 #ifdef Q_OS_WIN
+    taskBarButton.progress()->setRange(0, 100);
     taskBarButton.progress()->setValue(percent);
 #endif
 }

--- a/src/updatedownloaddialog.h
+++ b/src/updatedownloaddialog.h
@@ -1,0 +1,92 @@
+#ifndef UPDATE_DOWNLOAD_DIALOG_H
+#define UPDATE_DOWNLOAD_DIALOG_H
+
+#include <QDialog>
+#include <QPushButton>
+
+#ifdef Q_OS_WIN
+#  include <QtWinExtras/QWinTaskbarButton>
+#endif
+
+namespace Ui {
+    class UpdateDownloadDialog;
+}
+
+/**
+ * A dialog that shows the user the progress while downloading the Birdtray installer
+ * and allows the user to update and restart once the download is complete.
+ */
+class UpdateDownloadDialog : public QDialog {
+Q_OBJECT
+
+public:
+    explicit UpdateDownloadDialog(QWidget* parent = nullptr);
+    
+    ~UpdateDownloadDialog() override;
+    
+    /**
+     * Reset the dialog to the download process UI.
+     */
+    void reset();
+    
+    /**
+     * Switches the dialog to the download completed UI.
+     */
+    void onDownloadComplete();
+    
+    /**
+     * Update the download process.
+     *
+     * @param bytesReceived The number of bytes received so far.
+     * @param bytesTotal The total number of bytes to receive.
+     */
+    void onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
+    
+    /**
+     * @return Whether or not the user has cancelled the download or aborted the installation.
+     */
+    bool wasCanceled() const;
+
+private Q_SLOTS:
+    
+    /**
+     * Called if the user presses the action button.
+     * During download, the dialog is minimized.
+     * Once the download is finished, the button closes the dialog.
+     */
+    void onActionPressed();
+    
+    /**
+     * Called if the user presses the cancel button.
+     */
+    void onCancelPressed();
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    Ui::UpdateDownloadDialog* ui;
+    
+    /**
+     * Whether or not the user has requested to cancel the download or installation.
+     */
+    bool canceled = false;
+    
+    /**
+     * Whether we are in download-complete or downloading UI mode.
+     */
+    bool downloadCompleted = false;
+    
+    /**
+     * The first action button.
+     */
+    QPushButton* actionButton;
+#ifdef Q_OS_WIN
+    /**
+     * The windows task-bar button.
+     */
+    QWinTaskbarButton taskBarButton;
+#endif
+};
+
+#endif // UPDATE_DOWNLOAD_DIALOG_H

--- a/src/updatedownloaddialog.h
+++ b/src/updatedownloaddialog.h
@@ -81,6 +81,7 @@ private:
      * The first action button.
      */
     QPushButton* actionButton;
+
 #ifdef Q_OS_WIN
     /**
      * The windows task-bar button.

--- a/src/updatedownloaddialog.h
+++ b/src/updatedownloaddialog.h
@@ -55,22 +55,12 @@ private Q_SLOTS:
      * Once the download is finished, the button closes the dialog.
      */
     void onActionPressed();
-    
-    /**
-     * Called if the user presses the cancel button.
-     */
-    void onCancelPressed();
 
 protected:
     void showEvent(QShowEvent* event) override;
 
 private:
     Ui::UpdateDownloadDialog* ui;
-    
-    /**
-     * Whether or not the user has requested to cancel the download or installation.
-     */
-    bool canceled = false;
     
     /**
      * Whether we are in download-complete or downloading UI mode.

--- a/src/updatedownloaddialog.ui
+++ b/src/updatedownloaddialog.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdateDownloadDialog</class>
+ <widget class="QDialog" name="UpdateDownloadDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Birdtray Update</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Downloading Birdtray update...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>UpdateDownloadDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>UpdateDownloadDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This adds an update checker that checks for a new version of Birdtray. It can be run manually through the settings or configured to run automatically when Birdtray starts. If a new update is found, a dialog is displayed showing the release notes and a download button.

On non-Windows platforms, a click on the download button opens the [releases page](https://github.com/gyunaev/birdtray/releases).
On Windows, if found the correct installer will be downloaded. Once the installer is downloaded and the user confirms the update, the installer is started and Birdtray closes.


### Technical details
The information about the new releases are fetched via the [Github releases api](https://developer.github.com/v3/repos/releases/). As such, the update checker will only detect a new update, once a Github release is created. The update checker also requires the git tag, with which the release was created, to match the pattern [here](https://github.com/gyunaev/birdtray/compare/master...Abestanis:feature/updater?expand=1#diff-ebef2cd49df15ec9777d8fa2ed5aed3eR24) in order to parse the new version number and determine, if it is newer than the current Birdtray version. This requires you to respect the pattern when creating the git tag, otherwise the version will not be recognized.

### Discussion
* I enabled the update checker on startup by default. Is that ok with you?
* This makes Birdtray require the Qt network module (and the winextras module on Windows). Should I change the install instructions in the README to reflect that?

### Images
<details>
  <summary>Images of the new dialogues</summary>
  
  Note: These images show how the update dialogs would have looked like for the last update.
  * The new setting in the advanced section:
  ![settings](https://user-images.githubusercontent.com/6966049/66866909-911b5380-ef9a-11e9-8beb-de25958902c3.PNG)
  * The dialog that is displayed, when a new update is found (on Windows):
  ![newUpdateDialog](https://user-images.githubusercontent.com/6966049/66867113-e35c7480-ef9a-11e9-84c0-4eae0758b434.PNG)
   * The same dialog on Ubuntu:
   ![ubuntu](https://user-images.githubusercontent.com/6966049/66867139-f4a58100-ef9a-11e9-9f17-963cd88833e7.PNG)
   * The download dialog:
   ![download](https://user-images.githubusercontent.com/6966049/66867169-0424ca00-ef9b-11e9-8507-76afac2d5820.PNG)
   * The update and restart confirm dialog:
   ![restart](https://user-images.githubusercontent.com/6966049/66867195-1272e600-ef9b-11e9-810e-e0dab95146ab.PNG)
</details>