### PR TITLE
Fix open image file dialog

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -442,9 +442,9 @@ void DialogSettings::unreadParserChanged(int curr)
 void DialogSettings::changeIcon(QToolButton *button)
 {
     QString e = QFileDialog::getOpenFileName( 0,
-                                              "Choose the new icon",
+                                              tr("Choose the new icon"),
                                               "",
-                                              "Images(*.png); Images(*.svg)" );
+                                              tr("Images(*.png *.svg)") );
 
     if ( e.isEmpty() )
         return;


### PR DESCRIPTION
With Qt 5.12 the current master doesn't list any files. The problem is that the `filter` parameter is valid and cannot be parsed by Qt ([see reference](https://doc.qt.io/qt-5/qfiledialog.html#getOpenFileName)).

This PR fixes it.