### PR TITLE
Fix the deprecation warning of QFontMetrics::width for Qt >= 5.11

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -215,7 +215,13 @@ void TrayIcon::updateIcon()
         QFontMetrics fm( pSettings->mNotificationFont );
         p.setOpacity( mBlinkingTimeout ? 1.0 - mBlinkingIconOpacity : 1.0 );
         p.setPen( mUnreadColor );
-        p.drawText( (temp.width() - fm.width( countvalue )) / 2, (temp.height() - fm.height()) / 2 + fm.ascent(), countvalue );
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int width = fm.horizontalAdvance(countvalue);
+#else
+        int width = fm.width(countvalue);
+#endif
+        p.drawText((temp.width() - width) / 2, (temp.height() - fm.height()) / 2 + fm.ascent(),
+                   countvalue);
     }
 
     p.end();


### PR DESCRIPTION
[QFontMetrics::width](https://doc.qt.io/qt-5/qfontmetrics-obsolete.html#width) was deprecated in Qt 5.11.