### PR TITLE
Bundle the required OpenSSL libraries in the installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,8 +147,9 @@ before_deploy:
   - |
     if [ "$TRAVIS_OS_NAME" == "windows" ]; then
       choco install -y nsis;
+      choco install -y openssl.light;
       cd ../installer;
-      ./buildInstaller.bat "..\build\Release\birdtray.exe" "%USERPROFILE%\sqlite3\sqlite3.dll" || (exit $?);
+      ./buildInstaller.bat "..\build\Release\birdtray.exe" "%USERPROFILE%\sqlite3\sqlite3.dll" "%ProgramFiles%\OpenSSL" || (exit $?);
       cd ..;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ before_deploy:
       choco install -y nsis;
       choco install -y openssl.light;
       cd ../installer;
-      ./buildInstaller.bat "..\build\Release\birdtray.exe" "%USERPROFILE%\sqlite3\sqlite3.dll" "%ProgramFiles%\OpenSSL" || (exit $?);
+      ./buildInstaller.bat "..\build\Release\birdtray.exe" "%USERPROFILE%\sqlite3\sqlite3.dll" "%PROGRAMFILES%\OpenSSL" || (exit $?);
       cd ..;
     fi
 

--- a/installer/buildInstaller.bat
+++ b/installer/buildInstaller.bat
@@ -124,10 +124,11 @@ goto :eof
 
 : Usage
 echo Creates the Birdtray installer. - Usage:
-echo buildInstaller.bat exePath libSqlitePath
+echo buildInstaller.bat exePath libSqlitePath openSSLPath
 echo:
 echo exePath:       The path to the birdtray.exe to include in the installer
 echo libSqlitePath: The path to the libsqlite.dll that was used to compile the Birdtray exe
+echo openSSLPath:   The path to the OpenSSL directory containing libcrypto*.dll and libssl*.ddl
 echo:
 echo The following programs must be on the PATH: windeployqt, makensis and g++.
 goto :eof

--- a/installer/buildInstaller.bat
+++ b/installer/buildInstaller.bat
@@ -21,6 +21,21 @@ if not exist "%libSqlitePath%" (
     exit /b %ERROR_FILE_NOT_FOUND%
 )
 
+for /F "tokens=* USEBACKQ" %%f in (`dir /b "%~3" 2^>nul ^| findstr libcrypto ^| findstr .dll` ) do (
+    set openSSLCryptoPath="%~3\%%f"
+)
+for /F "tokens=* USEBACKQ" %%f in (`dir /b "%~3" 2^>nul ^| findstr libssl ^| findstr .dll`) do (
+    set openSSLPath="%~3\%%f"
+)
+if not exist "%openSSLCryptoPath%" (
+    echo OpenSSL crypto library not found at %~3\libcrypto*.dll 1>&2
+    exit /b %ERROR_FILE_NOT_FOUND%
+)
+if not exist "%openSSLPath%" (
+    echo OpenSSL library not found at %~3\libssl*.dll 1>&2
+    exit /b %ERROR_FILE_NOT_FOUND%
+)
+
 rem  #### Check if required programs are available ####
 for %%x in (windeployqt.exe) do (set winDeployQtExe=%%~$PATH:x)
 if not defined winDeployQtExe (
@@ -68,6 +83,18 @@ if errorLevel 1 (
 xcopy "%libSqlitePath%" "%deploymentFolder%" /q /y 1>nul
 if errorLevel 1 (
     echo Failed to copy the Sqlite library from %libSqlitePath% 1>&2
+    echo to the deployment folder at %deploymentFolder% 1>&2
+    exit /b %errorLevel%
+)
+xcopy "%openSSLCryptoPath%" "%deploymentFolder%" /q /y 1>nul
+if errorLevel 1 (
+    echo Failed to copy the OpenSSL crypto library from %openSSLCryptoPath% 1>&2
+    echo to the deployment folder at %deploymentFolder% 1>&2
+    exit /b %errorLevel%
+)
+xcopy "%openSSLPath%" "%deploymentFolder%" /q /y 1>nul
+if errorLevel 1 (
+    echo Failed to copy the OpenSSL library from %openSSLPath% 1>&2
     echo to the deployment folder at %deploymentFolder% 1>&2
     exit /b %errorLevel%
 )

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -49,7 +49,10 @@ AutoUpdater::~AutoUpdater() {
 }
 
 void AutoUpdater::checkForUpdates() {
-    networkAccessManager->get(QNetworkRequest(QUrl(LATEST_VERSION_INFO_URL)));
+    auto result = networkAccessManager->get(QNetworkRequest(QUrl(LATEST_VERSION_INFO_URL)));
+    if (result != nullptr && result->sslConfiguration().isNull()) {
+        emit onCheckUpdateFinished(tr("No ssl configuration!\nOpenSSL might not be installed."));
+    }
 }
 
 void AutoUpdater::onRequestFinished(QNetworkReply* result) {

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -49,7 +49,8 @@ AutoUpdater::~AutoUpdater() {
 }
 
 void AutoUpdater::checkForUpdates() {
-    auto result = networkAccessManager->get(QNetworkRequest(QUrl(LATEST_VERSION_INFO_URL)));
+    QNetworkReply* result = networkAccessManager->get(
+            QNetworkRequest(QUrl(LATEST_VERSION_INFO_URL)));
     if (result != nullptr && result->sslConfiguration().isNull()) {
         emit onCheckUpdateFinished(tr("No ssl configuration!\nOpenSSL might not be installed."));
     }

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -222,6 +222,9 @@ void DialogSettings::profilePathChanged()
 }
 
 void DialogSettings::onCheckUpdateFinished(const QString &errorString) {
+    if (checkUpdateButton->isEnabled()) {
+        return; // We received an error that was not initiated by us. Ignore it.
+    }
     checkUpdateButton->setText(tr("Check now"));
     checkUpdateButton->setEnabled(true);
     if (!errorString.isNull()) {


### PR DESCRIPTION
The Windows installer now bundles the required OpenSSL libraries.
I also noticed, that when the libraries were missing, only the first network request made would generate an error. All request made after that would just never complete, without sending any signals. We now detect that and display a user friendly message suggesting that OpenSSL might not be installed. Fixes #137