### PR TITLE
Feature/installer config auto updater

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -412,6 +412,7 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
         !insertmacro DeleteRetryAbort "$INSTDIR\${LICENSE_FILE}"
     !endif
 
+    # Clean up "Auto Update-Check"
     ${UnStrCase} $0 "${COMPANY_NAME}" "L"
     ${UnStrCase} $1 "${PRODUCT_NAME}" "L"
     !insertmacro DeleteRetryAbort "$LOCALAPPDATA\$0\$1\${INSTALL_CONFIG_FILE}"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -59,6 +59,8 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define BIRDTRAY_SECTION_DESCRIPTION "A free system tray notification for new mail for Thunderbird."
 !define WIN_INTEGRATION_GROUP_DESCRIPTION "Select how to integrate the program in Windows."
 !define AUTO_RUN_DESCRIPTION "Automatically start ${PRODUCT_NAME} after login."
+!define AUTO_CHECK_UPDATE_DESCRIPTION \
+        "Automatically search for updates of ${PRODUCT_NAME} at startup."
 !define PROGRAM_GROUP_DESCRIPTION \
         "Create a ${PRODUCT_NAME} program group under Start Menu > Programs."
 !define DESKTOP_ENTRY_DESCRIPTION "Create a ${PRODUCT_NAME} icon on the Desktop."
@@ -84,6 +86,7 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define UNINSTALL_LIST_FILENAME "uninstall_list.nsh"
 !define HEADER_IMG_FILE "assets\header.bmp"
 !define SIDEBAR_IMG_FILE "assets\sidebar.bmp"
+!define INSTALL_CONFIG_FILE ".installConfig.ini"
 
 # Other
 !define BAD_PATH_CHARS '?%*:|"<>!;'
@@ -359,6 +362,12 @@ Section /o "AutoRun" SectionAutoRun
 SectionEnd
 SectionGroupEnd
 
+Section "Auto Update-Check" SectionAutoCheckUpdate
+    FileOpen $4 "$INSTDIR\${INSTALL_CONFIG_FILE}" a
+    FileSeek $4 0 END
+    FileWrite $4 "updateOnStartup = true$\r$\n"
+SectionEnd
+
 Section "-Write Install Size" # Hidden section, write install size as the final step
     !insertmacro MULTIUSER_RegistryAddInstallSizeInfo
 SectionEnd
@@ -366,6 +375,7 @@ SectionEnd
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionBirdTray} "${BIRDTRAY_SECTION_DESCRIPTION}"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoRun} "${AUTO_RUN_DESCRIPTION}"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoCheckUpdate} "${AUTO_CHECK_UPDATE_DESCRIPTION}"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupWinIntegration} \
             "${WIN_INTEGRATION_GROUP_DESCRIPTION}"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionProgramGroup} "${PROGRAM_GROUP_DESCRIPTION}"
@@ -393,6 +403,8 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
     !ifdef LICENSE_FILE
         !insertmacro DeleteRetryAbort "$INSTDIR\${LICENSE_FILE}"
     !endif
+
+    !insertmacro DeleteRetryAbort "$INSTDIR\${INSTALL_CONFIG_FILE}"
 
     # Clean up "AutoRun"
     DeleteRegValue SHCTX "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -33,6 +33,9 @@ SetCompressor /SOLID lzma
 ${StrRep}
 !ifdef UNINSTALL_BUILDER
 ${UnStrRep}
+${UnStrCase}
+!else
+${StrCase}
 !endif # UNINSTALL_BUILDER
 
 # Variables
@@ -363,9 +366,14 @@ SectionEnd
 SectionGroupEnd
 
 Section "Auto Update-Check" SectionAutoCheckUpdate
-    FileOpen $4 "$INSTDIR\${INSTALL_CONFIG_FILE}" a
-    FileSeek $4 0 END
-    FileWrite $4 "updateOnStartup = true$\r$\n"
+    ${StrCase} $0 "${COMPANY_NAME}" "L"
+    ${StrCase} $1 "${PRODUCT_NAME}" "L"
+    DeleteRegValue HKCU "${USER_SETTINGS_REG_PATH}" "hasReadInstallConfig"
+    CreateDirectory "$LOCALAPPDATA\$0"
+    CreateDirectory "$LOCALAPPDATA\$0\$1"
+    FileOpen $2 "$LOCALAPPDATA\$0\$1\${INSTALL_CONFIG_FILE}" a
+    FileSeek $2 0 END
+    FileWrite $2 "updateOnStartup = true$\r$\n"
 SectionEnd
 
 Section "-Write Install Size" # Hidden section, write install size as the final step
@@ -404,7 +412,11 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
         !insertmacro DeleteRetryAbort "$INSTDIR\${LICENSE_FILE}"
     !endif
 
-    !insertmacro DeleteRetryAbort "$INSTDIR\${INSTALL_CONFIG_FILE}"
+    ${UnStrCase} $0 "${COMPANY_NAME}" "L"
+    ${UnStrCase} $1 "${PRODUCT_NAME}" "L"
+    !insertmacro DeleteRetryAbort "$LOCALAPPDATA\$0\$1\${INSTALL_CONFIG_FILE}"
+    RMDir /r "$LOCALAPPDATA\$0\$1"
+    RMDir /r "$LOCALAPPDATA\$0"
 
     # Clean up "AutoRun"
     DeleteRegValue SHCTX "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,9 +1,8 @@
 #include <QBuffer>
 #include <QDir>
+#include <QtCore/QStandardPaths>
 #ifdef Q_OS_WIN
 #include <QCoreApplication>
-#include <QtCore/QStandardPaths>
-
 #endif
 
 #include "settings.h"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -224,6 +224,7 @@ void Settings::load()
         QString entry = "newemail/id" + QString::number( index );
         mNewEmailData.push_back( Setting_NewEmail::fromByteArray( mSettings->value( entry, "" ).toByteArray() ) );
     }
+    loadInstallerConfiguration();
 }
 
 QString Settings::getThunderbirdExecutablePath()
@@ -279,4 +280,17 @@ QPixmap Settings::loadPixmap(const QString &key)
     }
 
     return pix;
+}
+
+void Settings::loadInstallerConfiguration() {
+    QFileInfo installConfigFile(QDir(qApp->applicationDirPath()), ".installConfig.ini");
+    if (installConfigFile.exists()) {
+        QSettings installConfig(installConfigFile.absoluteFilePath(), QSettings::IniFormat);
+        QVariant value;
+        if (!(value = installConfig.value("updateOnStartup")).isNull()) {
+            mUpdateOnStartup = value.toBool();
+        }
+        QFile::remove(installConfigFile.absoluteFilePath());
+        save();
+    }
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -142,6 +142,11 @@ class Settings
     
         void    savePixmap( const QString& key, const QPixmap& pixmap );
         QPixmap loadPixmap( const QString& key );
+    
+        /**
+         * At first start, load the configuration configured during installation of Birdtray.
+         */
+        void loadInstallerConfiguration();
 };
 
 extern Settings * pSettings;


### PR DESCRIPTION
The installer generates an `.installConfig.ini` file that contains  the configuration selected during install.
The file is located at `C:/Users/<USER>/AppData/Local/ulduzsoft/birdtray` if Birdtray is installed fo all users and at `C:/ProgramData/ulduzsoft/birdtray` otherwise.
At the first start of Birdtray, the configuration is loaded and the Birdtray configuration is updated with the new values. The only value changed for now is the auto update-check setting.
![Auto update-check selection in the installer](https://user-images.githubusercontent.com/6966049/67153345-e4b5d600-f2e7-11e9-9524-abdfe1bdb01d.png)
