### PR TITLE
Add an optional border to the unread counter

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -31,6 +31,7 @@ DialogSettings::DialogSettings( QWidget *parent)
 
     connect( btnNotificationIcon, &QPushButton::clicked, this, &DialogSettings::buttonChangeIcon );
     connect( btnNotificationIconUnread, &QPushButton::clicked, this, &DialogSettings::buttonChangeUnreadIcon );
+    connect(borderWidthSlider, &QSlider::valueChanged, this, &DialogSettings::onBorderWidthChanged);
 
     connect( treeAccounts, &QTreeView::doubleClicked, this, &DialogSettings::accountEditIndex  );
     connect( btnAccountAdd, &QPushButton::clicked, this, &DialogSettings::accountAdd );
@@ -51,6 +52,8 @@ DialogSettings::DialogSettings( QWidget *parent)
     // Setup parameters
     leProfilePath->setText( QDir::toNativeSeparators(pSettings->mThunderbirdFolderPath) );
     btnNotificationColor->setColor( pSettings->mNotificationDefaultColor );
+    borderColorButton->setColor(pSettings->mNotificationBorderColor);
+    borderWidthSlider->setValue(static_cast<int>(pSettings->mNotificationBorderWidth) * 2);
     notificationFont->setCurrentFont( pSettings->mNotificationFont );
     notificationFontWeight->setValue( pSettings->mNotificationFontWeight * 2 );
     sliderBlinkingSpeed->setValue( pSettings->mBlinkSpeed );
@@ -146,6 +149,9 @@ void DialogSettings::accept()
 
     pSettings->mThunderbirdFolderPath = leProfilePath->text();
     pSettings->mNotificationDefaultColor = btnNotificationColor->color();
+    pSettings->mNotificationBorderColor = borderColorButton->color();
+    // A width of 100 is way to much, nobody will want to go beyond 50.
+    pSettings->mNotificationBorderWidth = qRound(borderWidthSlider->value() / 2.0);
     pSettings->mNotificationFont = notificationFont->currentFont();
     pSettings->mBlinkSpeed = sliderBlinkingSpeed->value();
     pSettings->mLaunchThunderbird = boxLaunchThunderbirdAtStart->isChecked();
@@ -394,6 +400,10 @@ void DialogSettings::buttonChangeIcon()
 void DialogSettings::buttonChangeUnreadIcon()
 {
     changeIcon( btnNotificationIconUnread );
+}
+
+void DialogSettings::onBorderWidthChanged(int value) {
+    borderWidthLabel->setText(value == 0 ? tr("None") : QString::number(value) + '%');
 }
 
 void DialogSettings::unreadParserChanged(int curr)

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -67,6 +67,12 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         // Icon change
         void    buttonChangeIcon();
         void    buttonChangeUnreadIcon();
+        
+        /**
+         * The unread count border width changed.
+         * @param value The new border width.
+         */
+        void onBorderWidthChanged(int value);
 
         // Parser changed
         void    unreadParserChanged( int curr );

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -37,14 +37,10 @@
           <string>New Mail Notification</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="3" colspan="5">
-           <widget class="ColorButton" name="btnNotificationColor">
-            <property name="text">
-             <string>PushButton</string>
-            </property>
-           </widget>
+          <item row="0" column="1" colspan="2">
+           <widget class="QFontComboBox" name="notificationFont"/>
           </item>
-          <item row="2" column="3" colspan="5">
+          <item row="3" column="2" colspan="3">
            <widget class="QSlider" name="sliderBlinkingSpeed">
             <property name="maximum">
              <number>30</number>
@@ -63,82 +59,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="6">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Bold:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Blinking speed:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="7">
-           <widget class="QSpinBox" name="notificationFontWeight">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> %</string>
-            </property>
-            <property name="maximum">
-             <number>198</number>
-            </property>
-            <property name="singleStep">
-             <number>2</number>
-            </property>
-            <property name="value">
-             <number>100</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Font style:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This notification color will be used when more than one monitored account has unread emails.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Multiple notification color:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3" colspan="3">
-           <widget class="QFontComboBox" name="notificationFont"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Icon (Ctrl-click to reset):</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3" colspan="5">
+          <item row="4" column="1" colspan="5">
            <layout class="QHBoxLayout" name="horizontalLayout_9">
             <item>
              <widget class="QToolButton" name="btnNotificationIcon">
@@ -185,6 +106,158 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="label_15">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Off</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="5">
+           <widget class="QLabel" name="label_16">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Fastest</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Icon (Ctrl-click to reset):</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This notification color will be used when more than one monitored account has unread emails.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Multiple notification color:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="5">
+           <widget class="ColorButton" name="btnNotificationColor">
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4" colspan="2">
+           <widget class="QSpinBox" name="notificationFontWeight">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="suffix">
+             <string> %</string>
+            </property>
+            <property name="maximum">
+             <number>198</number>
+            </property>
+            <property name="singleStep">
+             <number>2</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Blinking speed:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Font style:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Bold:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="text">
+             <string>Notification border color:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="ColorButton" name="borderColorButton">
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Width:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QSlider" name="borderWidthSlider">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QLabel" name="borderWidthLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>None</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -155,8 +155,9 @@ void Settings::load()
             "common/defaultcolor", mNotificationDefaultColor.name() ).toString() );
     mNotificationBorderColor = QColor(mSettings->value(
             BORDER_COLOR_KEY, mNotificationBorderColor.name()).toString());
-    mNotificationBorderWidth = mSettings->value(
-            BORDER_WIDTH_KEY, mNotificationBorderWidth).toUInt();
+    mNotificationBorderWidth = mSettings->value( // Disable border on existing installations
+            BORDER_WIDTH_KEY, mSettings->value("common/defaultcolor").isNull() ?
+                              0 : mNotificationBorderWidth).toUInt();
     mThunderbirdFolderPath = mSettings->value(
             "common/profilepath", mThunderbirdFolderPath ).toString();
     mBlinkSpeed = mSettings->value("common/blinkspeed", mBlinkSpeed ).toInt();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -14,6 +14,8 @@
 #  define THUNDERBIRD_EXE_PATH "/usr/bin/thunderbird"
 #endif
 
+#define BORDER_COLOR_KEY "common/bordercolor"
+#define BORDER_WIDTH_KEY "common/borderwidth"
 #define UPDATE_ON_STARTUP_KEY "advanced/updateOnStartup"
 #define READ_INSTALL_CONFIG_KEY "hasReadInstallConfig"
 
@@ -37,7 +39,9 @@ Settings::Settings(bool verboseOutput)
 
     mVerboseOutput = verboseOutput;
     mIconSize = QSize( 128, 128 );
-    mNotificationDefaultColor = QColor("#00FF00");
+    mNotificationDefaultColor = QColor("#0000FF");
+    mNotificationBorderColor = QColor("#FFFFFF");
+    mNotificationBorderWidth = 15;
     mBlinkSpeed = 0;
     mShowHideThunderbird = false;
     mLaunchThunderbird = false;
@@ -72,6 +76,8 @@ void Settings::save()
 {
     mSettings->setValue("common/notificationfont", mNotificationFont.toString() );
     mSettings->setValue("common/defaultcolor", mNotificationDefaultColor.name() );
+    mSettings->setValue(BORDER_COLOR_KEY, mNotificationBorderColor.name());
+    mSettings->setValue(BORDER_WIDTH_KEY, mNotificationBorderWidth);
     mSettings->setValue("common/profilepath", mThunderbirdFolderPath );
     mSettings->setValue("common/blinkspeed", mBlinkSpeed );
     mSettings->setValue("common/showhidethunderbird", mShowHideThunderbird );
@@ -147,6 +153,10 @@ void Settings::load()
 
     mNotificationDefaultColor = QColor( mSettings->value(
             "common/defaultcolor", mNotificationDefaultColor.name() ).toString() );
+    mNotificationBorderColor = QColor(mSettings->value(
+            BORDER_COLOR_KEY, mNotificationBorderColor.name()).toString());
+    mNotificationBorderWidth = mSettings->value(
+            BORDER_WIDTH_KEY, mNotificationBorderWidth).toUInt();
     mThunderbirdFolderPath = mSettings->value(
             "common/profilepath", mThunderbirdFolderPath ).toString();
     mBlinkSpeed = mSettings->value("common/blinkspeed", mBlinkSpeed ).toInt();

--- a/src/settings.h
+++ b/src/settings.h
@@ -33,6 +33,16 @@ class Settings
 
         // Default notification color
         QColor  mNotificationDefaultColor;
+        
+        /**
+         * The border color to use when drawing the unread mail counter.
+         */
+        QColor mNotificationBorderColor;
+    
+        /**
+         * The width of the border for the unread mail counter.
+         */
+        unsigned int mNotificationBorderWidth;
 
         // Blinking speed
         unsigned int    mBlinkSpeed;

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -214,14 +214,21 @@ void TrayIcon::updateIcon()
         pSettings->mNotificationFont.setWeight( pSettings->mNotificationFontWeight );
         QFontMetrics fm( pSettings->mNotificationFont );
         p.setOpacity( mBlinkingTimeout ? 1.0 - mBlinkingIconOpacity : 1.0 );
-        p.setPen( mUnreadColor );
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
         int width = fm.horizontalAdvance(countvalue);
 #else
         int width = fm.width(countvalue);
 #endif
-        p.drawText((temp.width() - width) / 2, (temp.height() - fm.height()) / 2 + fm.ascent(),
-                   countvalue);
+        QPainterPath textPath;
+        textPath.addText((temp.width() - width) / 2.0,
+                         (temp.height() - fm.height()) / 2.0 + fm.ascent(),
+                         pSettings->mNotificationFont, countvalue);
+        if (pSettings->mNotificationBorderWidth > 0
+            && pSettings->mNotificationBorderColor.isValid()) {
+            p.strokePath(textPath, QPen(
+                    pSettings->mNotificationBorderColor, pSettings->mNotificationBorderWidth));
+        }
+        p.fillPath(textPath, mUnreadColor);
     }
 
     p.end();


### PR DESCRIPTION
This lets the user add a border around the unread mail number in the system tray. This improves readability, because it increases the contrast of the text to the background image. The user can configure the color and width of the border, as well as disable the border entirely.

Without border:  ![image](https://user-images.githubusercontent.com/6966049/67433583-ab7fad80-f5e8-11e9-8b76-2cb609b0bd35.png)

With border (white, 30% width): ![image](https://user-images.githubusercontent.com/6966049/67433534-986cdd80-f5e8-11e9-80ca-986197c66aae.png)

We also change the default notification color from radioactive green to blue. I don't think anybody kept the green.
Additionally, I added `Off` and `Fastest` labels to the blink speed slider, because it isn't clear at first sight, what the slider does.

The border is **enabled by default**, is that ok with you?

<details>
  <summary>The new settings</summary>

![image](https://user-images.githubusercontent.com/6966049/67433907-5001ef80-f5e9-11e9-98fa-368bb7addb52.png)
</details>