### PR TITLE
An advanced "Add mail accounts" dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,13 @@ set(SOURCES
         src/autoupdater.cpp
         src/updatedialog.cpp
         src/updatedownloaddialog.cpp
+        src/mailaccountdialog.cpp
         src/dialogaddeditaccount.ui
         src/dialogaddeditnewemail.ui
         src/dialogsettings.ui
         src/updatedialog.ui
-        src/updatedownloaddialog.ui)
+        src/updatedownloaddialog.ui
+        src/mailaccountdialog.ui)
 
 set(HEADERS
         src/colorbutton.h
@@ -86,7 +88,8 @@ set(HEADERS
         src/windowtools.h
         src/autoupdater.h
         src/updatedialog.h
-        src/updatedownloaddialog.h)
+        src/updatedownloaddialog.h
+        src/mailaccountdialog.h)
 
 set(RESOURCES src/resources.qrc)
 source_group("Resources" FILES ${RESOURCES})

--- a/src/birdtray.pro
+++ b/src/birdtray.pro
@@ -36,6 +36,7 @@ SOURCES += \
     databaseunreadfixer.cpp \
     dialogaddeditaccount.cpp \
     dialogsettings.cpp \
+    mailaccountdialog.cpp \
     updatedialog.cpp \
     updatedownloaddialog.cpp \
     windowtools.cpp \
@@ -56,6 +57,7 @@ HEADERS += \
     databaseaccounts.h \
     databaseunreadfixer.h \
     dialogaddeditaccount.h \
+    mailaccountdialog.h \
     dialogsettings.h \
     updatedialog.h \
     updatedownloaddialog.h \
@@ -73,6 +75,7 @@ FORMS += \
     dialogaddeditaccount.ui \
     dialogsettings.ui \
     dialogaddeditnewemail.ui \
+    mailaccountdialog.ui \
     updatedialog.ui \
     updatedownloaddialog.ui
 

--- a/src/colorbutton.cpp
+++ b/src/colorbutton.cpp
@@ -21,25 +21,31 @@
 
 #include "colorbutton.h"
 
-ColorButton::ColorButton( QWidget * parent )
-    : QPushButton( parent ), m_selectedColor( Qt::black )
+ColorButton::ColorButton(QWidget * parent, QColor color)
+    : QPushButton(parent), m_selectedColor(std::move(color))
 {
     m_allowSetAlpha = false;
+    drawBorder = true;
 	connect( this, SIGNAL(clicked()), this, SLOT(btnClicked()) );
 }
 
 void ColorButton::setColor( const QColor& color )
 {
 	// After the constructor is called, UIC-generated code calls setLabel, so we overwrite it here
-	setText( tr("") );
+	setText("");
 
 	m_selectedColor = color;
     update();
+    emit onColorChanged(m_selectedColor);
 }
 
 void ColorButton::allowSetAlpha(bool allow)
 {
     m_allowSetAlpha = allow;
+}
+
+void ColorButton::setBorderlessMode(bool enable) {
+    drawBorder = !enable;
 }
 
 QColor ColorButton::color() const
@@ -62,16 +68,21 @@ void ColorButton::btnClicked()
 
 void ColorButton::paintEvent( QPaintEvent * event )
 {
-	QPushButton::paintEvent( event );
-
-	// Paint a rectangle
-	QPainter painter (this);
-
-	// Take 50% of height and 80% of width
-	int rectwidth = width() * 0.8;
-	int rectheight = height() * 0.5;
-
-	QRect rect( (width() - rectwidth) / 2, (height() - rectheight) / 2, rectwidth, rectheight );
+    if (drawBorder) {
+        QPushButton::paintEvent(event);
+    }
+    
+    // Paint a rectangle
+    QPainter painter(this);
+    QRect rect;
+    if (drawBorder) {
+        // Take 50% of height and 80% of width
+        int width = qRound(this->width() * 0.8);
+        int height = qRound(this->height() * 0.5);
+        rect.setRect((this->width() - width) / 2, (this->height() - height) / 2, width, height);
+    } else {
+        rect.setRect(1, 1, width() - 2, height() - 2);
+    }
 
 	if ( isDown() )
 		rect.translate( 1, 1 );

--- a/src/colorbutton.h
+++ b/src/colorbutton.h
@@ -28,14 +28,32 @@ class ColorButton : public QPushButton
 	Q_OBJECT
 
 	public:
-		ColorButton( QWidget * parent );
+        /**
+         * A button that lets the user select a color.
+         * @param parent The parent widget.
+         * @param color The initial selected color.
+         */
+        explicit ColorButton(QWidget* parent, QColor color = Qt::black);
 
 		void	setColor( const QColor& color );
         void    allowSetAlpha( bool allow );
+        
+        /**
+         * Enable or disable drawing the button borders.
+         * @param enable Whether or not to draw the borders.
+         */
+        void    setBorderlessMode(bool enable);
 		QColor	color() const;
 
+    Q_SIGNALS:
+        /**
+         * Called when the chosen color changed.
+         * @param color The new color.
+         */
+        void onColorChanged(const QColor &color);
+		
 	protected:
-		void	paintEvent( QPaintEvent * event );
+		void	paintEvent( QPaintEvent * event ) override;
 
 	private slots:
 		void	btnClicked();
@@ -43,6 +61,11 @@ class ColorButton : public QPushButton
 	private:
 		QColor	m_selectedColor;
         bool    m_allowSetAlpha;
+        
+        /**
+         * Indicated whether or not to draw the button borders.
+         */
+        bool    drawBorder;
 };
 
 #endif // COLORBUTTON_H

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -49,8 +49,10 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    accountsAvailable(QString errorMsg);
 
         // Account buttons
+        /**
+         * Add one or multiple accounts.
+         */
         void    accountAdd();
-        void    accountAddMultiple();
         void    accountEdit();
         void    accountEditIndex( const QModelIndex& index );
         void    accountRemove();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -408,13 +408,6 @@
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="btnAccountAddMultiple">
-                <property name="text">
-                 <string>Add multiple...</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <spacer name="verticalSpacer_10">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -229,7 +229,7 @@ void MailAccountDialog::initializeAccountsPage() {
                 if (isInbox) {
                     name = "Inbox";
                 }
-                auto* folderItem = new QTreeWidgetItem(accountItem, {tr(qPrintable(name))});
+                auto* folderItem = new QTreeWidgetItem(accountItem, {tr(name.toUtf8().data())});
                 if (isInbox) {
                     QFont font = folderItem->font(0);
                     font.setBold(true);

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -229,7 +229,8 @@ void MailAccountDialog::initializeAccountsPage() {
                 if (isInbox) {
                     name = "Inbox";
                 }
-                auto* folderItem = new QTreeWidgetItem(accountItem, {tr(name.toUtf8().data())});
+                auto* folderItem = new QTreeWidgetItem(
+                        accountItem, {tr(name.toUtf8().constData())});
                 if (isInbox) {
                     QFont font = folderItem->font(0);
                     font.setBold(true);

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -225,7 +225,7 @@ void MailAccountDialog::initializeAccountsPage() {
             ui->accountsList->addTopLevelItem(accountItem);
             for (const QFileInfo &folderFile : msfFiles) {
                 QString name = folderFile.baseName();
-                bool isInbox = name == "INBOX";
+                bool isInbox = QString::compare(name, "INBOX", Qt::CaseInsensitive) == 0;
                 if (isInbox) {
                     name = "Inbox";
                 }

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -1,0 +1,257 @@
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QFileDialog>
+#include <utility>
+#include "mailaccountdialog.h"
+#include "ui_mailaccountdialog.h"
+#include "utils.h"
+#include "colorbutton.h"
+
+MailAccountDialog::MailAccountDialog(QWidget* parent, QColor defaultColor) :
+        QWizard(parent),
+        ui(new Ui::MailAccountDialog),
+        defaultColor(std::move(defaultColor)) {
+    ui->setupUi(this);
+    connect(this, &QWizard::currentIdChanged, this, &MailAccountDialog::onCurrentIdChanged);
+    connect(ui->tbProfilesBrowseButton, &QAbstractButton::clicked,
+            this, &MailAccountDialog::onProfilesDirBrowseButtonClicked);
+    connect(ui->tbProfilesPathEdit, &QLineEdit::editingFinished,
+            this, &MailAccountDialog::onProfilesDirEditCommit);
+    connect(ui->profileSelector, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &MailAccountDialog::onProfileSelectionChanged);
+}
+
+MailAccountDialog::~MailAccountDialog() {
+    delete ui;
+    delete profilesDir;
+}
+
+void MailAccountDialog::initializePage(int id) {
+    QWizard::initializePage(id);
+    switch (static_cast<PageId>(id)) {
+    case profilesDirPage:
+        initializeProfilesDirPage();
+        break;
+    case profilePage:
+        initializeTbProfilesPage();
+        break;
+    case accountsPage:
+        initializeAccountsPage();
+        break;
+    case noPage: break;
+    }
+}
+
+bool MailAccountDialog::validateCurrentPage() {
+    switch (static_cast<PageId>(currentId())) {
+    case profilesDirPage: return validateProfilesDirPage();
+    case profilePage: return validateTbProfilesPage();
+    case accountsPage: return validateAccountsPage();
+    case noPage:break;
+    }
+    return QWizard::validateCurrentPage();
+}
+
+void MailAccountDialog::getSelectedAccounts(QList<std::tuple<QString, QColor>> &outList) const {
+    for (QTreeWidgetItem* selectedItem : getCheckedAccountItems()) {
+        QVariant color = selectedItem->data(1, Qt::UserRole);
+        outList.append(std::make_tuple(
+                selectedItem->data(0, Qt::UserRole).toString(),
+                color.isNull() ? defaultColor : color.value<QColor>()));
+    }
+}
+
+void MailAccountDialog::onCurrentIdChanged(int id) {
+    bool skipPage = false;
+    switch (static_cast<PageId>(id)) {
+    case profilesDirPage:
+        skipPage = furthestPage < PageId::profilesDirPage && profilesDir != nullptr;
+        break;
+    case profilePage:
+        skipPage = furthestPage < PageId::profilePage && thunderbirdProfileImapDir != nullptr;
+        break;
+    case accountsPage:
+    case noPage: break;
+    }
+    if (furthestPage < id) {
+        furthestPage = static_cast<PageId>(id);
+    }
+    if (skipPage) {
+        next();
+    }
+}
+
+void MailAccountDialog::onProfilesDirBrowseButtonClicked() {
+    QString directory = QFileDialog::getExistingDirectory(
+            nullptr, tr("Choose the Thunderbird profiles path"),
+            Utils::expandPath(ui->tbProfilesPathEdit->text()), QFileDialog::ShowDirsOnly);
+    if (directory.isEmpty()) {
+        return;
+    }
+    QDir* newProfilesDir = new QDir(directory);
+    if (!newProfilesDir->exists()) {
+        delete newProfilesDir;
+        return;
+    } else {
+        delete profilesDir;
+        profilesDir = newProfilesDir;
+    }
+    ui->tbProfilesPathEdit->setText(QDir::toNativeSeparators(directory));
+}
+
+void MailAccountDialog::onProfilesDirEditCommit() {
+    QDir* newProfilesDir = new QDir(Utils::expandPath(ui->tbProfilesPathEdit->text()));
+    if (!newProfilesDir->exists()) {
+        delete newProfilesDir;
+    } else {
+        delete profilesDir;
+        profilesDir = newProfilesDir;
+    }
+}
+
+void MailAccountDialog::onProfileSelectionChanged(int Q_DECL_UNUSED newProfileIndex) {
+    delete thunderbirdProfileImapDir;
+    thunderbirdProfileImapDir = nullptr;
+}
+
+void MailAccountDialog::initializeProfilesDirPage() {
+    if (profilesDir != nullptr) {
+        return;
+    }
+    QString profilesPath;
+    for (const QString &path : Utils::getThunderbirdProfilesPaths()) {
+        profilesDir = new QDir(Utils::expandPath(path));
+        if (profilesDir->exists()) {
+            profilesPath = path;
+            break;
+        } else {
+            delete profilesDir;
+            profilesDir = nullptr;
+        }
+    }
+    if (profilesDir != nullptr) {
+        ui->tbProfilesPathEdit->setText(profilesPath);
+    }
+}
+
+bool MailAccountDialog::validateProfilesDirPage() {
+    if (profilesDir == nullptr) {
+        QMessageBox::warning(this, tr("Invalid Thunderbird profile directory"),
+                             tr("Please enter the path to a valid directory."),
+                             QMessageBox::StandardButton::Ok);
+        return false;
+    }
+    if (profilesDir->entryList(QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot).isEmpty()) {
+        QMessageBox::warning(this, tr("Invalid Thunderbird profile directory"),
+                             tr("The Thunderbird profile directory contains no profiles."),
+                             QMessageBox::StandardButton::Ok);
+        return false;
+    }
+    return true;
+}
+
+void MailAccountDialog::initializeTbProfilesPage() {
+    if (profilesDir == nullptr) {
+        return;
+    }
+    delete thunderbirdProfileImapDir;
+    thunderbirdProfileImapDir = nullptr;
+    QStringList profileDirs = profilesDir->entryList(
+            QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot);
+    // If we don't block the signals, Qt crashes on clear or addItem.
+    bool oldState = ui->profileSelector->blockSignals(true);
+    ui->profileSelector->clear();
+    for (const QString &profileDir : profileDirs) {
+        QDir imapDir(profilesDir->absoluteFilePath(profileDir) + "/ImapMail");
+        if (imapDir.exists()) {
+            ui->profileSelector->addItem(
+                    profileDir.mid(profileDir.indexOf('.') + 1), imapDir.absolutePath());
+        }
+    }
+    ui->profileSelector->blockSignals(oldState);
+    if (ui->profileSelector->count() == 1) {
+        thunderbirdProfileImapDir = new QDir(ui->profileSelector->itemData(0).toString());
+    }
+}
+
+bool MailAccountDialog::validateTbProfilesPage() {
+    if (thunderbirdProfileImapDir == nullptr) {
+        QVariant selected = ui->profileSelector->itemData(ui->profileSelector->currentIndex());
+        if (selected.isNull()) {
+            QMessageBox::warning(this, tr("Invalid Thunderbird profile"),
+                                 tr("Please select a valid Thunderbird profile."),
+                                 QMessageBox::StandardButton::Ok);
+            return false;
+        }
+        delete thunderbirdProfileImapDir;
+        thunderbirdProfileImapDir = new QDir(selected.toString());
+    }
+    if (!thunderbirdProfileImapDir->exists()) {
+        QMessageBox::warning(this, tr("Invalid Thunderbird profile"),
+                             tr("The selected Thunderbird profile does not exist."),
+                             QMessageBox::StandardButton::Ok);
+        return false;
+    }
+    return true;
+}
+
+void MailAccountDialog::initializeAccountsPage() {
+    if (thunderbirdProfileImapDir == nullptr) {
+        return;
+    }
+    ui->accountsList->clear();
+    for (const QString &mailAccount : thunderbirdProfileImapDir->entryList(
+            QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot)) {
+        QDir mailDirectory(thunderbirdProfileImapDir->absoluteFilePath(mailAccount));
+        mailDirectory.setNameFilters({"*.msf"});
+        mailDirectory.setFilter(QDir::Filter::Files);
+        if (mailDirectory.exists("INBOX.msf")) {
+            auto* accountItem = new QTreeWidgetItem(ui->accountsList, {mailAccount});
+            accountItem->setExpanded(true);
+            ui->accountsList->addTopLevelItem(accountItem);
+            for (const QFileInfo &folderFile : mailDirectory.entryInfoList()) {
+                QString name = folderFile.baseName();
+                bool isInbox = name == "INBOX";
+                if (isInbox) {
+                    name = "Inbox";
+                }
+                auto* folderItem = new QTreeWidgetItem(accountItem, {tr(qPrintable(name))});
+                if (isInbox) {
+                    QFont font = folderItem->font(0);
+                    font.setBold(true);
+                    folderItem->setFont(0, font);
+                }
+                folderItem->setCheckState(0, Qt::Unchecked);
+                folderItem->setData(0, Qt::UserRole, folderFile.absoluteFilePath());
+                auto* colorButton = new ColorButton(ui->accountsList, defaultColor);
+                colorButton->setBorderlessMode(true);
+                connect(colorButton, &ColorButton::onColorChanged, this, [=](const QColor &color) {
+                    folderItem->setData(1, Qt::UserRole, color);
+                });
+                ui->accountsList->setItemWidget(folderItem, 1, colorButton);
+                accountItem->addChild(folderItem);
+            }
+        }
+    }
+}
+
+bool MailAccountDialog::validateAccountsPage() {
+    return !(getCheckedAccountItems().isEmpty() && QMessageBox::warning(
+            this, tr("No folder selected"),
+            tr("No mail folder was selected to monitor.\nDo you want to continue?"),
+            QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel
+    ) == QMessageBox::StandardButton::Cancel);
+}
+
+QList<QTreeWidgetItem*> MailAccountDialog::getCheckedAccountItems() const {
+    QList<QTreeWidgetItem*> checkedItems;
+    for (int i = 0; i < ui->accountsList->topLevelItemCount(); i++) {
+        QTreeWidgetItem* accountItem = ui->accountsList->topLevelItem(i);
+        for (int j = 0; j < accountItem->childCount(); j++) {
+            QTreeWidgetItem* folderItem = accountItem->child(j);
+            if (folderItem->checkState(0) == Qt::Checked) {
+                checkedItems.append(folderItem);
+            }
+        }
+    }
+    return checkedItems;
+}

--- a/src/mailaccountdialog.h
+++ b/src/mailaccountdialog.h
@@ -118,9 +118,9 @@ private:
     QDir* profilesDir = nullptr;
     
     /**
-     * The `ImapMail` directory of the selected Thunderbird profile.
+     * The directories of the selected Thunderbird profile that contain the mail folder msf files.
      */
-    QDir* thunderbirdProfileImapDir = nullptr;
+    QList<QDir> thunderbirdProfileMailDirs;
 };
 
 #endif // MAIL_ACCOUNT_DIALOG_H

--- a/src/mailaccountdialog.h
+++ b/src/mailaccountdialog.h
@@ -1,0 +1,126 @@
+#ifndef MAIL_ACCOUNT_DIALOG_H
+#define MAIL_ACCOUNT_DIALOG_H
+
+#include <tuple>
+#include <QWizard>
+#include <QtCore/QDir>
+#include <QtWidgets/QTreeWidgetItem>
+
+namespace Ui {
+    class MailAccountDialog;
+}
+
+class MailAccountDialog : public QWizard {
+public:
+    enum PageId : int {
+        noPage = -1,
+        profilesDirPage,
+        profilePage,
+        accountsPage,
+    };
+
+Q_OBJECT
+protected:
+    void initializePage(int id) override;
+
+public:
+    explicit MailAccountDialog(QWidget* parent = nullptr, QColor defaultColor = Qt::black);
+    
+    ~MailAccountDialog() override;
+    
+    /**
+     * @return True if the values selected on the current page are valid.
+     */
+    bool validateCurrentPage() override;
+    
+    /**
+     * Returns the list of paths to the selected msf files as well as the optional selected color.
+     *
+     * @param outList: The list of paths to the selected msf files and the selected color.
+     */
+    void getSelectedAccounts(QList<std::tuple<QString, QColor>> &outList) const;
+
+private Q_SLOTS:
+    
+    /**
+     * Called when the current page id of the wizard changes.
+     * @param id The new page id.
+     */
+    void onCurrentIdChanged(int id);
+    
+    /**
+     * Called when the user clicks on th button to browse for the Thunderbird profiles directory.
+     */
+    void onProfilesDirBrowseButtonClicked();
+    
+    /**
+     * Called when the user presses enter on the Thunderbird profiles directory path text editor.
+     */
+    void onProfilesDirEditCommit();
+    
+    /**
+     * Called when the profile selection changes.
+     * @param newProfileIndex The index of the new selected profile.
+     */
+    void onProfileSelectionChanged(int newProfileIndex);
+
+private:
+    /**
+     * Set up the profiles directory page.
+     */
+    void initializeProfilesDirPage();
+    
+    /**
+     * @return Whether or not the selected profiles directory is valid.
+     */
+    bool validateProfilesDirPage();
+    
+    /**
+     * Set up the Thunderbird profiles page.
+     */
+    void initializeTbProfilesPage();
+    
+    /**
+     * @return Whether or not the selected Thunderbird profile is valid.
+     */
+    bool validateTbProfilesPage();
+    
+    /**
+     * Set up the accounts selection page.
+     */
+    void initializeAccountsPage();
+    
+    /**
+     * @return Whether or not the account selection is valid.
+     */
+    bool validateAccountsPage();
+    
+    /**
+     * @return All checked account items from the accountList.
+     */
+    QList<QTreeWidgetItem*> getCheckedAccountItems() const;
+    
+    Ui::MailAccountDialog* ui;
+    
+    /**
+     * The default notification color.
+     */
+    const QColor defaultColor;
+    
+    /**
+     * The id of the furthest page we have reached;
+     */
+    PageId furthestPage = noPage;
+    
+    /**
+     * The directory containing the Thunderbird profiles.
+     */
+    QDir* profilesDir = nullptr;
+    
+    /**
+     * The `ImapMail` directory of the selected Thunderbird profile.
+     */
+    QDir* thunderbirdProfileImapDir = nullptr;
+};
+
+#endif // MAIL_ACCOUNT_DIALOG_H

--- a/src/mailaccountdialog.ui
+++ b/src/mailaccountdialog.ui
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MailAccountDialog</class>
+ <widget class="QWizard" name="MailAccountDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>580</width>
+    <height>408</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Mail Accounts</string>
+  </property>
+  <property name="wizardStyle">
+   <enum>QWizard::AeroStyle</enum>
+  </property>
+  <widget class="QWizardPage" name="profilesDirPage">
+   <property name="title">
+    <string>Thunderbird Profile Directory</string>
+   </property>
+   <property name="subTitle">
+    <string>Select the directory that contains the Thunderbird profiles.</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">MailAccountDialog::PageId::profilesDirPage</string>
+   </attribute>
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QLineEdit" name="tbProfilesPathEdit">
+      <property name="placeholderText">
+       <string>Thunderbird Profiles Directory</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="tbProfilesBrowseButton">
+      <property name="text">
+       <string>Browse</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="profilePage">
+   <property name="title">
+    <string>Thunderbird Profile</string>
+   </property>
+   <property name="subTitle">
+    <string>Select theThunderbird profile, that contains the mail account which you want to monitor.</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">MailAccountDialog::PageId::profilePage</string>
+   </attribute>
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <item>
+     <widget class="QLabel" name="label_2">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Selected Profile:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeType">
+       <enum>QSizePolicy::Preferred</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QComboBox" name="profileSelector">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="accountsPage">
+   <property name="title">
+    <string>Select Accounts</string>
+   </property>
+   <property name="subTitle">
+    <string>Select the mail accounts you want to monitor.</string>
+   </property>
+   <attribute name="pageId">
+    <string notr="true">MailAccountDialog::PageId::accountsPage</string>
+   </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTreeWidget" name="accountsList">
+      <property name="tabKeyNavigation">
+       <bool>true</bool>
+      </property>
+      <property name="showDropIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="columnCount">
+       <number>2</number>
+      </property>
+      <attribute name="headerVisible">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="headerDefaultSectionSize">
+       <number>300</number>
+      </attribute>
+      <column>
+       <property name="text">
+        <string notr="true">Email Folder</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Notification Color</string>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+</ui>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -212,3 +212,13 @@ void Utils::fatal(const char *fmt, ...)
     QMessageBox::critical(nullptr, "Fatal", buf);
     qFatal("%s", buf);
 }
+
+QStringList Utils::getThunderbirdProfilesPaths() {
+#if defined (Q_OS_WIN)
+    return {"%APPDATA%\\Thunderbird\\Profiles"};
+#elif defined (Q_OS_MAC)
+    return {"~/Library/Thunderbird/Profiles"};
+#else // Linux
+    return {"~/.thunderbird", "~/snap/thunderbird/common/.thunderbird"}
+#endif /* Platform */
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -219,6 +219,6 @@ QStringList Utils::getThunderbirdProfilesPaths() {
 #elif defined (Q_OS_MAC)
     return {"~/Library/Thunderbird/Profiles"};
 #else // Linux
-    return {"~/.thunderbird", "~/snap/thunderbird/common/.thunderbird"}
+    return {"~/.thunderbird", "~/snap/thunderbird/common/.thunderbird"};
 #endif /* Platform */
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -45,6 +45,13 @@ class Utils
 
         static void debug( const char * fmt, ... ) Q_ATTRIBUTE_FORMAT_PRINTF(1, 2);
         Q_NORETURN static void fatal( const char * fmt, ... ) Q_ATTRIBUTE_FORMAT_PRINTF(1, 2);
+
+        /**
+         * @return A list of possible locations of the directory
+         *         that contains the Thunderbird profiles.
+         * @see https://support.mozilla.org/en-US/kb/profiles-where-thunderbird-stores-user-data#w_profile-location-summary
+         */
+        static QStringList getThunderbirdProfilesPaths();
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
For the Mork parser, this replaces the `Add` and `Add multiple...` dialogs.
This new dialog should greatly simplify account selection for the user, and therefore close #125.
The new dialog has three stages:
1. The first stage allow to select the path to the directory, that contains the Thunderbird profiles folders.
2. In the next stage, the user can select a profile from the ones in the selected folder.

The dialog tries to automatically find the correct Thunderbird profiles directory and will select the profile, if there is only one. As a result, the typical user will only ever see the third stage. But there is always the option to go back to these changes and change the auto selected values.

3. The third stage shows a list of mail accounts that were found in the selected profile. For each mail account, thee individual mail folders are shown and can be selected. Here, the user can select one or multiple mail folders, as well as set the notification color for them.

The new dialog will not be used to edit an item in the accounts list. The old dialog is still used for that. The old dialog is also still used for the sqlite parser, because supporting both would greatly increase the complexity of the dialog. I'm also hoping that we can drop support for the sqlite parser altogether soon. When that happens, we can remove the old dialog.

<details>
<summary>Images of the new dialog</summary>

* The first page allows to select the directory to search for Thunderbird profiles. This is automatically skipped, if a directory exists at the default location for the system.
![Ubuntu - Profile directory selection page](https://user-images.githubusercontent.com/6966049/67445717-30c98900-f60e-11e9-9a99-165f31bbce92.png)
![Windows - Profile directory selection page](https://user-images.githubusercontent.com/6966049/67448509-763e8400-f617-11e9-906b-727b34811b40.png)

* The second page allows to select a profile from the list of detected profile. If there is only one, it will automatically get selected and the page will be skipped. To be recognized as a profile directory, a folder needs a subdirectory called `ImapMail` and / or `Mail`.
![Ubuntu - Profile selection page](https://user-images.githubusercontent.com/6966049/67445754-4ccd2a80-f60e-11e9-8a28-fd89c7daeb48.png)
![Windows- Profile selection page](https://user-images.githubusercontent.com/6966049/67448533-8ce4db00-f617-11e9-97e6-cf1f11290ea5.png)

* In the final page, the user can select which mail folders to monitor. The `Inbox` folder is highlighted, because it is the one that anybody who doesn't know which one to pick should pick. If the user clicks `Finish` without selecting an email folder, a warning is displayed.
![Ubuntu - Accounts and mail folders selection page](https://user-images.githubusercontent.com/6966049/67483717-ae20e800-f666-11e9-8015-477b174b75fc.png)
![Windows - Accounts and mail folders selection page](https://user-images.githubusercontent.com/6966049/67448712-20b6a700-f618-11e9-98bc-cb14232d792a.PNG)


</details>