### PR TITLE
Add a frame border around the changelog area

### DIFF
--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -55,9 +55,6 @@
    </item>
    <item row="1" column="0" colspan="3">
     <widget class="QScrollArea" name="bodyLabel">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
I think this looks much better than before.

Windows:
![Windows - No border](https://user-images.githubusercontent.com/6966049/67485145-c5ada000-f669-11e9-89c8-964914545db6.png)
![Windows - With border](https://user-images.githubusercontent.com/6966049/67485196-db22ca00-f669-11e9-8080-9f18c1dd2182.png)

Ubuntu:
![Ubuntu - No border](https://user-images.githubusercontent.com/6966049/67485289-00afd380-f66a-11e9-871e-7ef4828f2964.png)
![Ubuntu- With border](https://user-images.githubusercontent.com/6966049/67485510-787dfe00-f66a-11e9-830a-6805bac36089.png)
