### PR TITLE
Improved accounts list

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -1,4 +1,5 @@
 #include <QFileDialog>
+#include <QColorDialog>
 #include <QMessageBox>
 #include <QFile>
 #include <QDir>
@@ -333,19 +334,16 @@ void DialogSettings::accountEdit()
 
 void DialogSettings::accountEditIndex(const QModelIndex &index)
 {
-    if ( !index.isValid() )
+    if (!index.isValid()) {
         return;
-
+    }
     QString uri;
     QColor color;
-
-    mAccountModel->getAccount( index, uri, color );
-
-    DialogAddEditAccount dlg( isMorkParserSelected() );
-    dlg.setCurrent( mAccounts, uri, color );
-
-    if ( dlg.exec() == QDialog::Accepted )
-        mAccountModel->editAccount( index, dlg.account(), dlg.color() );
+    mAccountModel->getAccount(index, uri, color);
+    color = QColorDialog::getColor(color, this);
+    if (color.isValid()) {
+        mAccountModel->editAccount(index, uri, color);
+    }
 }
 
 void DialogSettings::accountRemove()

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -86,6 +86,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     // Accounts tab
     mAccountModel = new ModelAccountTree( this );
     treeAccounts->setModel( mAccountModel );
+    treeAccounts->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
     // New emails tab
     mModelNewEmails = new ModelNewEmails( this );

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -85,8 +85,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     mPaletteErrror.setColor( QPalette::Text, Qt::red );
 
     // Accounts tab
-    mAccountModel = new ModelAccountTree( this );
-    treeAccounts->setModel( mAccountModel );
+    mAccountModel = new ModelAccountTree(this, treeAccounts);
     treeAccounts->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     treeAccounts->setCurrentIndex(mAccountModel->index(0, 0));
 

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -87,6 +87,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     mAccountModel = new ModelAccountTree( this );
     treeAccounts->setModel( mAccountModel );
     treeAccounts->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    treeAccounts->setCurrentIndex(mAccountModel->index(0, 0));
 
     // New emails tab
     mModelNewEmails = new ModelNewEmails( this );
@@ -306,20 +307,22 @@ void DialogSettings::accountAdd()
         dlg.setCurrent(mAccounts, "", btnNotificationColor->color());
         if (dlg.exec() == QDialog::Accepted) {
             mAccountModel->addAccount(dlg.account(), dlg.color());
+            treeAccounts->setCurrentIndex(mAccountModel->index(mAccountModel->rowCount() - 1, 0));
         }
-        return;
-    }
-    MailAccountDialog accountDialog(this, btnNotificationColor->color());
-    if (accountDialog.exec() == QDialog::Accepted) {
-        QString path;
-        QColor color;
-        QList<std::tuple<QString, QColor>> accountInfoList;
-        accountDialog.getSelectedAccounts(accountInfoList);
-        for (const std::tuple<QString, QColor> &accountInfo : accountInfoList) {
-            std::tie(path, color) = accountInfo;
-            mAccountModel->addAccount(path, color);
+    } else {
+        MailAccountDialog accountDialog(this, btnNotificationColor->color());
+        if (accountDialog.exec() == QDialog::Accepted) {
+            QString path;
+            QColor color;
+            QList<std::tuple<QString, QColor>> accountInfoList;
+            accountDialog.getSelectedAccounts(accountInfoList);
+            for (const std::tuple<QString, QColor> &accountInfo : accountInfoList) {
+                std::tie(path, color) = accountInfo;
+                mAccountModel->addAccount(path, color);
+            }
         }
     }
+    treeAccounts->setCurrentIndex(mAccountModel->index(mAccountModel->rowCount() - 1, 0));
 }
 
 void DialogSettings::accountEdit()

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -99,11 +99,6 @@ void ModelAccountTree::paint(QPainter* painter, const QStyleOptionViewItem &opti
     }
 }
 
-QSize ModelAccountTree::sizeHint(const QStyleOptionViewItem &option,
-                                 const QModelIndex &index) const {
-    return QItemDelegate::sizeHint(option, index);
-}
-
 void ModelAccountTree::addAccount(const QString &uri, const QColor &color)
 {
     if (uri.isEmpty()) {

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -8,7 +8,7 @@
 #include "utils.h"
 
 ModelAccountTree::ModelAccountTree(QObject *parent, QTreeView* treeView)
-        : QAbstractItemModel( parent ), QItemDelegate(parent)
+        : QAbstractItemModel( parent ), QStyledItemDelegate(parent)
 {
     // Get the current settings in proper(stored) order
     for ( QString uri : pSettings->mFolderNotificationList )
@@ -92,10 +92,9 @@ QVariant ModelAccountTree::headerData(int section, Qt::Orientation , int role) c
 
 void ModelAccountTree::paint(QPainter* painter, const QStyleOptionViewItem &option,
                              const QModelIndex &index) const {
+    QStyledItemDelegate::paint(painter, option, index);
     if (index.column() == 1) {
         painter->fillRect(option.rect.marginsRemoved(QMargins(1, 1, 1, 1)), mColors[index.row()]);
-    } else {
-        QItemDelegate::paint(painter, option, index);
     }
 }
 

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -37,7 +37,7 @@ QVariant ModelAccountTree::data(const QModelIndex &index, int role) const
             if (folderName == "INBOX") {
                 folderName = tr("Inbox");
             } else {
-                folderName = tr(qPrintable(folderName));
+                folderName = tr(folderName.toUtf8().constData());
             }
             QString accountName = fileInfo.dir().dirName();
             return accountName + " [" + folderName + "]";

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -1,4 +1,6 @@
 #include <QBrush>
+#include <QtCore/QFileInfo>
+#include <QtCore/QDir>
 
 #include "settings.h"
 #include "modelaccounttree.h"
@@ -25,12 +27,20 @@ QVariant ModelAccountTree::data(const QModelIndex &index, int role) const
 {
     if ( index.row() >= 0 && index.row() < mAccounts.size() && index.column() < 2 )
     {
-        if ( role == Qt::DisplayRole )
-        {
-            if ( index.column() == 0 )
-                return Utils::decodeIMAPutf7( mAccounts[index.row()] );
-            else
-                return "uses this color";
+        if ( role == Qt::DisplayRole && index.column() == 0) {
+            QString account = mAccounts[index.row()];
+            if (!account.endsWith(".msf")) {
+                return Utils::decodeIMAPutf7(account);
+            }
+            QFileInfo fileInfo(account);
+            QString folderName = fileInfo.baseName();
+            if (folderName == "INBOX") {
+                folderName = tr("Inbox");
+            } else {
+                folderName = tr(qPrintable(folderName));
+            }
+            QString accountName = fileInfo.dir().dirName();
+            return accountName + " [" + folderName + "]";
         }
         else if ( role == Qt::BackgroundRole && index.column() == 1 )
             return QBrush( mColors[index.row()] );

--- a/src/modelaccounttree.h
+++ b/src/modelaccounttree.h
@@ -4,13 +4,20 @@
 #include <QList>
 #include <QColor>
 #include <QAbstractItemModel>
+#include <QtWidgets/QTreeView>
+#include <QtWidgets/QItemDelegate>
 
 #include "databaseaccounts.h"
 
-class ModelAccountTree : public QAbstractItemModel
+class ModelAccountTree : public QAbstractItemModel, public QItemDelegate
 {
     public:
-        ModelAccountTree( QObject *parent = 0 );
+        /**
+         * A model that contains information about mail accounts registered to watch.
+         * @param parent The parent of this widget.
+         * @param treeView The widget that displays this model.
+         */
+        explicit ModelAccountTree(QObject *parent = nullptr, QTreeView* treeView = nullptr);
 
         virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
         virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
@@ -19,6 +26,9 @@ class ModelAccountTree : public QAbstractItemModel
         virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override;
         virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
         virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+        void paint(QPainter* painter, const QStyleOptionViewItem &option,
+                const QModelIndex &index) const override;
+        QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
         void    addAccount( const QString& uri, const QColor& color );
         void    editAccount( const QModelIndex& idx, const QString& uri, const QColor& color );

--- a/src/modelaccounttree.h
+++ b/src/modelaccounttree.h
@@ -27,8 +27,7 @@ class ModelAccountTree : public QAbstractItemModel, public QItemDelegate
         virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
         virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
         void paint(QPainter* painter, const QStyleOptionViewItem &option,
-                const QModelIndex &index) const override;
-        QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+                   const QModelIndex &index) const override;
 
         void    addAccount( const QString& uri, const QColor& color );
         void    editAccount( const QModelIndex& idx, const QString& uri, const QColor& color );

--- a/src/modelaccounttree.h
+++ b/src/modelaccounttree.h
@@ -5,11 +5,11 @@
 #include <QColor>
 #include <QAbstractItemModel>
 #include <QtWidgets/QTreeView>
-#include <QtWidgets/QItemDelegate>
+#include <QtWidgets/QStyledItemDelegate>
 
 #include "databaseaccounts.h"
 
-class ModelAccountTree : public QAbstractItemModel, public QItemDelegate
+class ModelAccountTree : public QAbstractItemModel, public QStyledItemDelegate
 {
     public:
         /**


### PR DESCRIPTION
This improves the accounts list in the `Monitoring` tab.

* If the the Mork parser is selected, the list now longer displays the path to the mork file, but the mail account name and the mail folder.
* The first row now auto resizes to always show the full account name and folder.
* There is now always an element of the selected, so the `Edit` and `Remove` buttons always work.
* Remove the `uses this color` text. It was unnecessary and hard to read or unreadable, if a dark color was selected.
* The selected notification color is now always visible, even when the item is selected.
* Editing an item now only opens a dialog to choose a new color. To change the selected account and folder, remove the item and add a new one.

Images:
<details>
<summary>Ubuntu (Before vs. after):</summary>

![Ubuntu - Before](https://user-images.githubusercontent.com/6966049/67510080-9a8c7600-f694-11e9-8f0b-0f58a951d8ce.png)
![Ubuntu - After](https://user-images.githubusercontent.com/6966049/67510239-d58ea980-f694-11e9-8ed6-31b6b91e949b.png)
</details>

<details>
<summary>Windows (Before vs. after):</summary>

![Windows - before](https://user-images.githubusercontent.com/6966049/67510988-46829100-f696-11e9-992d-6ad4f1df74a1.PNG)
![Windows - After](https://user-images.githubusercontent.com/6966049/67510591-839a5380-f695-11e9-9cda-95667dd0fb01.PNG)
</details>