### PR TITLE
Fix displaying the error message twice in the Add/Edit "New Email" entries dialog

### DIFF
--- a/src/dialogaddeditnewemail.cpp
+++ b/src/dialogaddeditnewemail.cpp
@@ -2,24 +2,17 @@
 #include "dialogaddeditnewemail.h"
 
 DialogAddEditNewEmail::DialogAddEditNewEmail()
-    : QDialog(), Ui::DialogAddEditNewEmail()
-{
-    setupUi( this );
-
-    connect( buttonBox, &QDialogButtonBox::accepted, this, &DialogAddEditNewEmail::accept );
-    connect( buttonBox, &QDialogButtonBox::rejected, this, &DialogAddEditNewEmail::reject );
+        : QDialog(), Ui::DialogAddEditNewEmail() {
+    setupUi(this);
 }
 
-void DialogAddEditNewEmail::accept()
-{
-    if ( leMenuEntry->text().isEmpty() )
-    {
-        QMessageBox::critical( 0,
-                               tr("Empty menu entry"),
-                               tr("Menu entry cannot be empty") );
+void DialogAddEditNewEmail::accept() {
+    if (leMenuEntry->text().isEmpty()) {
+        QMessageBox::critical(nullptr,
+                              tr("Empty menu entry"),
+                              tr("Menu entry cannot be empty"));
         leMenuEntry->setFocus();
         return;
     }
-
     QDialog::accept();
 }

--- a/src/dialogaddeditnewemail.h
+++ b/src/dialogaddeditnewemail.h
@@ -1,18 +1,21 @@
-#ifndef DIALOGADDEDITNEWEMAIL_H
-#define DIALOGADDEDITNEWEMAIL_H
+#ifndef DIALOG_ADD_EDIT_NEW_EMAIL_H
+#define DIALOG_ADD_EDIT_NEW_EMAIL_H
 
 #include <QDialog>
 #include "ui_dialogaddeditnewemail.h"
 
-class DialogAddEditNewEmail : public QDialog, public Ui::DialogAddEditNewEmail
-{
-    Q_OBJECT
+/**
+ * A dialog that allows editing of the "New Email" entries.
+ */
+class DialogAddEditNewEmail : public QDialog, public Ui::DialogAddEditNewEmail {
+Q_OBJECT
 
-    public:
-        DialogAddEditNewEmail();
+public:
+    DialogAddEditNewEmail();
 
-    public slots:
-        void    accept();
+public slots:
+    
+    void accept() override;
 };
 
-#endif // DIALOGADDEDITNEWEMAIL_H
+#endif // DIALOG_ADD_EDIT_NEW_EMAIL_H


### PR DESCRIPTION
The `DialogAddEditNewEmail::accept` was called twice, once because of the connected `QDialogButtonBox::accepted` and once because it overwrites `QDialogButtonBox::accept`.