### PR TITLE
Improvements to the "New Email" settings UI

### DIFF
--- a/src/dialogaddeditnewemail.cpp
+++ b/src/dialogaddeditnewemail.cpp
@@ -9,8 +9,8 @@ DialogAddEditNewEmail::DialogAddEditNewEmail()
 void DialogAddEditNewEmail::accept() {
     if (leMenuEntry->text().isEmpty()) {
         QMessageBox::critical(nullptr,
-                              tr("Empty menu entry"),
-                              tr("Menu entry cannot be empty"));
+                              tr("No name specified"),
+                              tr("The name cannot be empty"));
         leMenuEntry->setFocus();
         return;
     }

--- a/src/dialogaddeditnewemail.ui
+++ b/src/dialogaddeditnewemail.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>&quot;New Email&quot; Entry</string>
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
@@ -19,41 +19,48 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="leMenuEntry"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Only Menu entry field is mandatory</string>
+      <string>(Optional) Prefilled fields</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Menu entry:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="leMenuEntry"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Email &quot;To:&quot; </string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
+      <item row="4" column="0" colspan="3">
+       <widget class="QTextEdit" name="leMessage"/>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Email &quot;Subject&quot;:</string>
+         <string>Email subject:</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Email message text:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -63,16 +70,13 @@
       <item row="2" column="1" colspan="2">
        <widget class="QLineEdit" name="leSubject"/>
       </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="QTextEdit" name="leMessage"/>
-      </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="QLabel" name="label_4">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Email message text:</string>
+         <string>Email recipient:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -92,6 +92,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     // New emails tab
     mModelNewEmails = new ModelNewEmails( this );
     treeNewEmails->setModel( mModelNewEmails );
+    treeNewEmails->setCurrentIndex(mModelNewEmails->index(0, 0));
 
     // Create the "About" box
     QString origabout = browserAbout->toHtml();
@@ -355,9 +356,10 @@ void DialogSettings::accountRemove()
     mAccountModel->removeAccount( index );
 }
 
-void DialogSettings::newEmailAdd()
-{
-    mModelNewEmails->add();
+void DialogSettings::newEmailAdd() {
+    if (mModelNewEmails->add()) {
+        treeNewEmails->setCurrentIndex(mModelNewEmails->index(mModelNewEmails->rowCount() -1, 0));
+    }
 }
 
 void DialogSettings::newEmailEdit()

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -306,21 +306,22 @@ void DialogSettings::accountAdd()
     if (!isMorkParserSelected()) {
         DialogAddEditAccount dlg(isMorkParserSelected());
         dlg.setCurrent(mAccounts, "", btnNotificationColor->color());
-        if (dlg.exec() == QDialog::Accepted) {
-            mAccountModel->addAccount(dlg.account(), dlg.color());
-            treeAccounts->setCurrentIndex(mAccountModel->index(mAccountModel->rowCount() - 1, 0));
+        if (dlg.exec() != QDialog::Accepted) {
+            return;
         }
+        mAccountModel->addAccount(dlg.account(), dlg.color());
     } else {
         MailAccountDialog accountDialog(this, btnNotificationColor->color());
-        if (accountDialog.exec() == QDialog::Accepted) {
-            QString path;
-            QColor color;
-            QList<std::tuple<QString, QColor>> accountInfoList;
-            accountDialog.getSelectedAccounts(accountInfoList);
-            for (const std::tuple<QString, QColor> &accountInfo : accountInfoList) {
-                std::tie(path, color) = accountInfo;
-                mAccountModel->addAccount(path, color);
-            }
+        if (accountDialog.exec() != QDialog::Accepted) {
+            return;
+        }
+        QString path;
+        QColor color;
+        QList<std::tuple<QString, QColor>> accountInfoList;
+        accountDialog.getSelectedAccounts(accountInfoList);
+        for (const std::tuple<QString, QColor> &accountInfo : accountInfoList) {
+            std::tie(path, color) = accountInfo;
+            mAccountModel->addAccount(path, color);
         }
     }
     treeAccounts->setCurrentIndex(mAccountModel->index(mAccountModel->rowCount() - 1, 0));

--- a/src/modelnewemails.cpp
+++ b/src/modelnewemails.cpp
@@ -59,17 +59,16 @@ QVariant ModelNewEmails::headerData(int section, Qt::Orientation , int role) con
     return QVariant();
 }
 
-void ModelNewEmails::add()
-{
+bool ModelNewEmails::add() {
     Setting_NewEmail item;
-
-    if ( item.edit() )
-    {
-        // Only this line changed
-        beginInsertRows( QModelIndex(), mNewEmailData.size(), mNewEmailData.size() + 1 );
-        mNewEmailData.push_back( item );
-        endInsertRows();
+    if (!item.edit()) {
+        return false;
     }
+    // Only this line changed
+    beginInsertRows(QModelIndex(), mNewEmailData.size(), mNewEmailData.size() + 1);
+    mNewEmailData.push_back(item);
+    endInsertRows();
+    return true;
 }
 
 void ModelNewEmails::edit(const QModelIndex &idx)

--- a/src/modelnewemails.h
+++ b/src/modelnewemails.h
@@ -17,7 +17,12 @@ class ModelNewEmails : public QAbstractItemModel
         virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
         virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-        void    add();
+        /**
+         * Add a new entry.
+         *
+         * @return True, if a new entry was added.
+         */
+        bool    add();
         void    edit( const QModelIndex &idx );
         void    remove( const QModelIndex& idx );
 


### PR DESCRIPTION
This improves two things:

* An entry is now always selected in the `Menu entry item`-list. As a result, the `Edit` and `Remove` buttons now always work.

* Rearranges the `dialogaddeditnewemail` dialog so it is easier to understand.
    <details>
    <summary>Ubuntu (Before vs. after)</summary>
    
    ![ubuntu - Old dialog](https://user-images.githubusercontent.com/6966049/67727773-f9325680-f9ea-11e9-980a-43283be443a7.png)
    ![Ubuntu - New dialog](https://user-images.githubusercontent.com/6966049/67727689-a3f64500-f9ea-11e9-81d2-011c546cf7ae.png)
    </details>
    <details>
    <summary>Windows (Before vs. after)</summary>
    
    ![Windows - Old dialog](https://user-images.githubusercontent.com/6966049/67727799-149d6180-f9eb-11e9-8ad8-622778fb75c0.png)
    ![Windows - New dialog](https://user-images.githubusercontent.com/6966049/67727722-c2f4d700-f9ea-11e9-9efb-d84652f74bf2.png)
    </details>