### PR TITLE
Add support for the message in mail templates and escape the command line

### DIFF
--- a/src/setting_newemail.cpp
+++ b/src/setting_newemail.cpp
@@ -82,20 +82,16 @@ QString Setting_NewEmail::menuentry() const
     return mName;
 }
 
-QString Setting_NewEmail::asArgs()
-{
+QString Setting_NewEmail::asArgs() {
     QStringList args;
-
-    if ( !mRecipient.isEmpty() )
-        args.push_back( "to='" + mRecipient + "'" );
-
-    if ( !mSubject.isEmpty() )
-        args.push_back( "subject='" + mSubject + "'" );
-
-    if ( !mMessage.isEmpty() )
-    {
-        //FIXME
+    if (!mRecipient.isEmpty()) {
+        args.push_back("to='" + mRecipient.replace('\'', "\u2032") + "'");
     }
-
-    return args.join( "," );
+    if (!mSubject.isEmpty()) {
+        args.push_back("subject='" + mSubject.replace('\'', "\u2032") + "'");
+    }
+    if (!mMessage.isEmpty()) {
+        args.push_back("body='" + mMessage.replace('\'', "\u2032") + "'");
+    }
+    return args.join(",");
 }


### PR DESCRIPTION
This prevents the user from specifying other command line options.
For example, you could write `',subject='test` as the email text to set `test` as the subject.

This replaces all occurrences of single quotes (`'`) with the [unicode prime character](https://www.compart.com/en/unicode/U+2032) (`U2032`, `′`). This solution isn't ideal, because the characters don't look exactly alike, and anybody receiving the mail in a mail client without utf-8 support will see a tofu or question mark symbol. But according to [Mozillas command line syntax rules](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#Syntax_Rules) there is no way to escape a single quote in the argument values.