### PR TITLE
Add a "Blank" entry to the "New Mail" submenu

### DIFF
--- a/src/dialogaddeditnewemail.ui
+++ b/src/dialogaddeditnewemail.ui
@@ -95,6 +95,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>leMenuEntry</tabstop>
+  <tabstop>leTo</tabstop>
+  <tabstop>leSubject</tabstop>
+  <tabstop>leMessage</tabstop>
+ </tabstops>
  <resources>
   <include location="resources.qrc"/>
  </resources>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -499,35 +499,26 @@ void TrayIcon::createMenu()
     mSystrayMenu->addSeparator();
 
     // New email could be either a single action, or menu depending on settings
-    if ( pSettings->mNewEmailMenuEnabled )
-    {
-        if ( !pSettings->mNewEmailData.isEmpty() )
-        {
+    if (pSettings->mNewEmailMenuEnabled) {
+        if (!pSettings->mNewEmailData.isEmpty()) {
             // A submenu
-            QMenu * newemails = new QMenu( tr("New Email") );
-
-            // Only add the signal if the menu is empty
-            if ( pSettings->mNewEmailData.isEmpty() )
-                connect( newemails, &QMenu::triggered, this, &TrayIcon::actionNewEmail );
-
-            for ( int index = 0; index < pSettings->mNewEmailData.size(); index++ )
-            {
-                QAction * a = new QAction( pSettings->mNewEmailData[index].menuentry(), this );
-                connect( a, &QAction::triggered, this, &TrayIcon::actionNewEmail );
-
+            auto* newEmails = new QMenu(tr("New Email"));
+            auto* action = new QAction(tr("Blank"), this);
+            connect(action, &QAction::triggered, this, &TrayIcon::actionNewEmail);
+            newEmails->addAction(action);
+            newEmails->addSeparator();
+            for (int index = 0; index < pSettings->mNewEmailData.size(); index++) {
+                action = new QAction(pSettings->mNewEmailData[index].menuentry(), this);
+                connect(action, &QAction::triggered, this, &TrayIcon::actionNewEmail);
                 // Remember the delay in the action itself
-                a->setData( index );
-                newemails->addAction( a );
+                action->setData(index);
+                newEmails->addAction(action);
             }
-
-            mSystrayMenu->addMenu( newemails );
-        }
-        else
-        {
+            mSystrayMenu->addMenu(newEmails);
+        } else {
             // A single action
-            mSystrayMenu->addAction( tr("New Email Message"), this, SLOT( actionNewEmail()) );
+            mSystrayMenu->addAction(tr("New Email Message"), this, SLOT(actionNewEmail()));
         }
-
         mSystrayMenu->addSeparator();
     }
 


### PR DESCRIPTION
This adds a new `Blank` action, that allows to create an empty email even if there are templates defined:
![New blank entry](https://user-images.githubusercontent.com/6966049/68054141-ecb14500-fced-11e9-936b-bea521b64f28.png)


This also fixes the tab ordering in the "New Email" entry dialog. pressing tab no longer directly jumps to the message box, but allows to edit the recipient and subject as well:
![Tab order](https://user-images.githubusercontent.com/6966049/68054087-d30ffd80-fced-11e9-9b89-15c387169b89.png)
