### PR TITLE
Enable "Warning as errors" when compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ install:
 script:
   - mkdir build
   - cd build
-  - cmake -A "${PLATFORM}" .. || (code=$?; echo "Error log (CMakeOutput.log):"; cat ./CMakeFiles/CMakeOutput.log; echo "Error log (CMakeError.log):"; cat ./CMakeFiles/CMakeError.log; (exit $code););
+  - cmake -A "${PLATFORM}" .. -D COMPILER_WARNINGS_AS_ERRORS=ON || (code=$?; echo "Error log (CMakeOutput.log):"; cat ./CMakeFiles/CMakeOutput.log; echo "Error log (CMakeError.log):"; cat ./CMakeFiles/CMakeError.log; (exit $code););
   - cmake --build . --config Release --target birdtray
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ install:
 script:
   - mkdir build
   - cd build
-  - cmake -A "${PLATFORM}" .. -D COMPILER_WARNINGS_AS_ERRORS=ON || (code=$?; echo "Error log (CMakeOutput.log):"; cat ./CMakeFiles/CMakeOutput.log; echo "Error log (CMakeError.log):"; cat ./CMakeFiles/CMakeError.log; (exit $code););
+  - cmake -D COMPILER_WARNINGS_AS_ERRORS=ON -A "${PLATFORM}" .. || (code=$?; echo "Error log (CMakeOutput.log):"; cat ./CMakeFiles/CMakeOutput.log; echo "Error log (CMakeError.log):"; cat ./CMakeFiles/CMakeError.log; (exit $code););
   - cmake --build . --config Release --target birdtray
 
 before_deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ add_executable(birdtray ${EXECUTABLE_OPTIONS}
 target_link_libraries(birdtray ${REQUIRED_MODULES})
 
 if(MSVC)
-    target_compile_options(birdtray PRIVATE /Wall /WX)
+    target_compile_options(birdtray PRIVATE /W4 /WX)
 else()
     target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ else()
     set(PLATFORM_SOURCES src/windowtools_x11.cpp)
     set(PLATFORM_HEADERS src/windowtools_x11.h)
 endif(WIN32)
+if(MSVC)
+    target_compile_options(birdtray PRIVATE /utf-8)
+endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -122,10 +125,13 @@ add_executable(birdtray ${EXECUTABLE_OPTIONS}
         ${HEADERS} ${PLATFORM_HEADERS})
 target_link_libraries(birdtray ${REQUIRED_MODULES})
 
-if(MSVC)
-    target_compile_options(birdtray PRIVATE /W4 /WX /utf-8)
-else()
-    target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
+option(COMPILER_WARNINGS_AS_ERRORS "Fail the build on compiler warnings" OFF)
+if(COMPILER_WARNINGS_AS_ERRORS)
+    if(MSVC)
+        target_compile_options(birdtray PRIVATE /W4 /WX)
+    else()
+        target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    endif()
 endif()
 
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ add_executable(birdtray ${EXECUTABLE_OPTIONS}
 target_link_libraries(birdtray ${REQUIRED_MODULES})
 
 if(MSVC)
-    target_compile_options(birdtray PRIVATE /W4 /WX)
+    target_compile_options(birdtray PRIVATE /W4 /WX /utf-8)
 else()
     target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,12 @@ add_executable(birdtray ${EXECUTABLE_OPTIONS}
         ${HEADERS} ${PLATFORM_HEADERS})
 target_link_libraries(birdtray ${REQUIRED_MODULES})
 
+if(MSVC)
+    target_compile_options(birdtray PRIVATE /Wall /WX)
+else()
+    target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()
+
 # Installation
 if(WIN32)
     # Find ssl libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ else()
     set(PLATFORM_SOURCES src/windowtools_x11.cpp)
     set(PLATFORM_HEADERS src/windowtools_x11.h)
 endif(WIN32)
-if(MSVC)
-    target_compile_options(birdtray PRIVATE /utf-8)
-endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -124,6 +121,9 @@ add_executable(birdtray ${EXECUTABLE_OPTIONS}
         ${SOURCES} ${PLATFORM_SOURCES} ${RESOURCES_SOURCES} ${GEN_TRANSLATION_FILES}
         ${HEADERS} ${PLATFORM_HEADERS})
 target_link_libraries(birdtray ${REQUIRED_MODULES})
+if(MSVC)
+    target_compile_options(birdtray PRIVATE /utf-8)
+endif()
 
 option(COMPILER_WARNINGS_AS_ERRORS "Fail the build on compiler warnings" OFF)
 if(COMPILER_WARNINGS_AS_ERRORS)

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -170,6 +170,8 @@ qulonglong AutoUpdater::parseDownloadUrl(const QJsonArray &assets, const QString
             }
         }
     }
+#else  /* !Q_OS_WIN */
+    Q_UNUSED(assets)
 #endif /* Q_OS_WIN */
     if (defaultUrl.isNull()) {
         downloadUrl = GENERIC_DOWNLOAD_URL;  // Last resort

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -22,9 +22,10 @@
 #define VERSION_TAG_REGEX "^(RELEASE_)?(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
 
 AutoUpdater::AutoUpdater(QObject* parent) :
+        QObject(parent),
         networkAccessManager(new QNetworkAccessManager(this)),
         installerFile(QDir::temp().filePath("birdtrayInstaller.exe")),
-        versionRe(VERSION_TAG_REGEX, QRegularExpression::CaseInsensitiveOption), QObject(parent) {
+        versionRe(VERSION_TAG_REGEX, QRegularExpression::CaseInsensitiveOption) {
     connect(networkAccessManager, &QNetworkAccessManager::finished,
             this, &AutoUpdater::onRequestFinished);
     connect(&updateDialog, &UpdateDialog::onDownloadButtonClicked,

--- a/src/birdtrayapp.h
+++ b/src/birdtrayapp.h
@@ -13,7 +13,7 @@
  * Represents the Birdtray application.
  */
 class BirdtrayApp: public QApplication {
-    Q_OBJECT;
+    Q_OBJECT
 public:
     
     /**

--- a/src/birdtrayapp.h
+++ b/src/birdtrayapp.h
@@ -13,7 +13,7 @@
  * Represents the Birdtray application.
  */
 class BirdtrayApp: public QApplication {
-    Q_OBJECT
+    Q_OBJECT;
 public:
     
     /**

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -493,11 +493,9 @@ void DialogSettings::updateAccountList() {
     dba->start();
 }
 
-void DialogSettings::activateTab(int tab)
-{
+void DialogSettings::activateTab(int tabIndex) {
     // #1 is the Accounts tab
-    if ( tab == 1 )
-    {
+    if (tabIndex == 1) {
         updateAccountList();
     }
 }

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -43,7 +43,7 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
 
         // Tab activation (to refresh accounts)
         // Calls the account query running in a DatabaseAccounts thread
-        void    activateTab(int tab );
+        void    activateTab(int tabIndex );
 
         // Receives accountsAvailable()
         void    accountsAvailable(QString errorMsg);

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -6,11 +6,6 @@
 #include "utils.h"
 #include "colorbutton.h"
 
-#ifdef Q_CC_MSVC
-#  undef Q_DECL_UNUSED
-#  define Q_DECL_UNUSED __pragma(warning(suppress:4100))
-#endif
-
 MailAccountDialog::MailAccountDialog(QWidget* parent, QColor defaultColor) :
         QWizard(parent),
         ui(new Ui::MailAccountDialog),
@@ -114,7 +109,8 @@ void MailAccountDialog::onProfilesDirEditCommit() {
     }
 }
 
-void MailAccountDialog::onProfileSelectionChanged(int Q_DECL_UNUSED newProfileIndex) {
+void MailAccountDialog::onProfileSelectionChanged(int newProfileIndex) {
+    Q_UNUSED(newProfileIndex)
     thunderbirdProfileMailDirs.clear();
 }
 

--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -6,6 +6,11 @@
 #include "utils.h"
 #include "colorbutton.h"
 
+#ifdef Q_CC_MSVC
+#  undef Q_DECL_UNUSED
+#  define Q_DECL_UNUSED __pragma(warning(suppress:4100))
+#endif
+
 MailAccountDialog::MailAccountDialog(QWidget* parent, QColor defaultColor) :
         QWizard(parent),
         ui(new Ui::MailAccountDialog),

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -276,13 +276,12 @@ void MorkParser::parseDict()
 			switch ( cur )
 			{
 			case '<':
-				if ( morkData_.mid( morkPos_ - 1, strlen( MorkDictColumnMeta ) ) 
-					== MorkDictColumnMeta )
-				{
-					nowParsing_ = NPColumns;
-					morkPos_ += strlen( MorkDictColumnMeta ) - 1;
-				}
-				break;
+                if (morkData_.mid(morkPos_ - 1, static_cast<int>(strlen(MorkDictColumnMeta)))
+                    == MorkDictColumnMeta) {
+                    nowParsing_ = NPColumns;
+                    morkPos_ += static_cast<int>(strlen(MorkDictColumnMeta)) - 1;
+                }
+                break;
 			case '(':
                 parseCell();
 				break;

--- a/src/processhandle.h
+++ b/src/processhandle.h
@@ -31,7 +31,7 @@ enum AttachResult {
  * A Handle to a progress, which might or might not be running.
  */
 class ProcessHandle : public QObject {
-Q_OBJECT;
+Q_OBJECT
 public:
     
     /**

--- a/src/updatedownloaddialog.cpp
+++ b/src/updatedownloaddialog.cpp
@@ -7,10 +7,10 @@
 
 UpdateDownloadDialog::UpdateDownloadDialog(QWidget* parent) :
         QDialog(parent),
-#ifdef Q_OS_WIN
-        taskBarButton(this),
-#endif
         ui(new Ui::UpdateDownloadDialog) {
+#ifdef Q_OS_WIN
+    taskBarButton = new QWinTaskbarButton(this);
+#endif
     ui->setupUi(this);
     actionButton = new QPushButton(tr("Background"), this);
     ui->buttonBox->addButton(actionButton, QDialogButtonBox::ButtonRole::ActionRole);
@@ -20,6 +20,9 @@ UpdateDownloadDialog::UpdateDownloadDialog(QWidget* parent) :
 }
 
 UpdateDownloadDialog::~UpdateDownloadDialog() {
+#ifdef Q_OS_WIN
+    delete taskBarButton;
+#endif
     delete ui;
     actionButton->deleteLater();
 }
@@ -31,8 +34,8 @@ void UpdateDownloadDialog::reset() {
     ui->progressBar->setValue(0);
     ui->progressBar->show();
 #ifdef Q_OS_WIN
-    taskBarButton.progress()->reset();
-    taskBarButton.progress()->show();
+    taskBarButton->progress()->reset();
+    taskBarButton->progress()->show();
 #endif
 }
 
@@ -40,8 +43,8 @@ void UpdateDownloadDialog::onDownloadComplete() {
     downloadCompleted = true;
     ui->progressBar->hide();
 #ifdef Q_OS_WIN
-    taskBarButton.progress()->setRange(0, 100);
-    taskBarButton.progress()->setValue(100);
+    taskBarButton->progress()->setRange(0, 100);
+    taskBarButton->progress()->setValue(100);
 #endif
     actionButton->setText(tr("Update and Restart"));
     ui->label->setText(tr("Download finished. Restart and update Birdtray?"));
@@ -55,7 +58,7 @@ void UpdateDownloadDialog::onDownloadProgress(qint64 bytesReceived, qint64 bytes
         ui->label->setText(tr("Downloading Birdtray installer..."));
         ui->progressBar->setRange(0, 0);
 #ifdef Q_OS_WIN
-        taskBarButton.progress()->setRange(0, 0);
+        taskBarButton->progress()->setRange(0, 0);
 #endif
         return;
     }
@@ -67,8 +70,8 @@ void UpdateDownloadDialog::onDownloadProgress(qint64 bytesReceived, qint64 bytes
     ui->progressBar->setRange(0, 100);
     ui->progressBar->setValue(percent);
 #ifdef Q_OS_WIN
-    taskBarButton.progress()->setRange(0, 100);
-    taskBarButton.progress()->setValue(percent);
+    taskBarButton->progress()->setRange(0, 100);
+    taskBarButton->progress()->setValue(percent);
 #endif
 }
 
@@ -87,6 +90,6 @@ void UpdateDownloadDialog::onActionPressed() {
 void UpdateDownloadDialog::showEvent(QShowEvent* event) {
     QDialog::showEvent(event);
 #ifdef Q_OS_WIN
-    taskBarButton.setWindow(windowHandle());
+    taskBarButton->setWindow(windowHandle());
 #endif
 }

--- a/src/updatedownloaddialog.h
+++ b/src/updatedownloaddialog.h
@@ -76,7 +76,7 @@ private:
     /**
      * The windows task-bar button.
      */
-    QWinTaskbarButton taskBarButton;
+    QWinTaskbarButton* taskBarButton = nullptr;
 #endif
 };
 

--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -2,6 +2,11 @@
 #include <tlhelp32.h>
 #include "birdtrayapp.h"
 
+#ifdef Q_CC_MSVC
+#  undef Q_DECL_UNUSED
+#  define Q_DECL_UNUSED __pragma(warning(suppress:4100))
+#endif
+
 
 /**
  * Helper data structure for the findMainWindow function.

--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -2,11 +2,6 @@
 #include <tlhelp32.h>
 #include "birdtrayapp.h"
 
-#ifdef Q_CC_MSVC
-#  undef Q_DECL_UNUSED
-#  define Q_DECL_UNUSED __pragma(warning(suppress:4100))
-#endif
-
 
 /**
  * Helper data structure for the findMainWindow function.
@@ -159,8 +154,11 @@ bool WindowTools_Win::checkWindow() {
 }
 
 void CALLBACK WindowTools_Win::minimizeCallback(
-        Q_DECL_UNUSED HWINEVENTHOOK eventHook, DWORD event, HWND window, LONG idObject,
-        LONG idChild, Q_DECL_UNUSED DWORD idEventThread, Q_DECL_UNUSED DWORD eventTime) {
+        HWINEVENTHOOK eventHook, DWORD event, HWND window, LONG idObject,
+        LONG idChild, DWORD idEventThread, DWORD eventTime) {
+    Q_UNUSED(eventHook)
+    Q_UNUSED(idEventThread)
+    Q_UNUSED(eventTime)
     BirdtrayApp* app = BirdtrayApp::get();
     auto* winTools = dynamic_cast<WindowTools_Win*>(app->getTrayIcon()->getWindowTools());
     if (event == EVENT_SYSTEM_MINIMIZESTART &&


### PR DESCRIPTION
This can prevent possible errors which are indicated by the warnings and keeps the code robust.