### PR TITLE
Return EXIT_SUCCESS for the dump-mork and decode commands

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -31,14 +31,13 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv) {
     
     QString morkPath = parser.value("dump-mork");
     if (!morkPath.isEmpty()) {
-        MorkParser::dumpMorkFile(morkPath);
-        exit(1); // TODO: Why 1? Replace with return code of dumpMorkFile
+        exit(MorkParser::dumpMorkFile(morkPath));
         return;
     }
     QString imapString = parser.value("decode");
     if (!imapString.isEmpty()) {
         printf("Decoded: %s\n", qPrintable(Utils::decodeIMAPutf7(imapString)));
-        exit(1); // TODO: Why 1? Replace with EXIT_SUCCESS
+        exit(EXIT_SUCCESS);
         return;
     }
     


### PR DESCRIPTION
This fixes the TODOs in the `BirdtrayApp` class.
**This is a change in behaviour!**
Previously, both the `dump-mork` and `decode` command would return `1` (`EXIT_FAILURE`).