### PR TITLE
Search for email accounts in any *Mail sub directory of the profile

### DIFF
--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -161,14 +161,10 @@ void MailAccountDialog::initializeTbProfilesPage() {
     ui->profileSelector->clear();
     for (const QString &profileDirName : profileDirs) {
         QDir profileDir(profilesDir->absoluteFilePath(profileDirName));
-        QStringList mailFolders;
-        for (const char* mailFolder : {"ImapMail", "Mail"}) {
-            QFileInfo mailFolderInfo(profileDir, mailFolder);
-            if (mailFolderInfo.isDir()) {
-                mailFolders.append(mailFolderInfo.absoluteFilePath());
-            }
-        }
+        QStringList mailFolders = profileDir.entryList({"*Mail"}, QDir::Dirs);
         if (!mailFolders.isEmpty()) {
+            std::transform(mailFolders.begin(), mailFolders.end(), mailFolders.begin(),
+                    [=](const QString& folder) { return profileDir.absoluteFilePath(folder); });
             ui->profileSelector->addItem(
                     profileDirName.mid(profileDirName.indexOf('.') + 1), mailFolders);
         }


### PR DESCRIPTION
When I read #166 I noticed that the new mail account dialog won't find the email accounts in the `webaccountMail` folder. This fixes that and assumes that any folders ending in `Mail` in the profiles directory can contain email accounts.