### PR TITLE
Support for starting flatpack Thunderbird

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -563,11 +563,11 @@ bool DialogSettings::isMorkParserSelected() const
 void DialogSettings::onThunderbirdCommandModelChanged(
         const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) {
     if (topLeft.row() != thunderbirdCmdModel->rowCount() - 1
-        && thunderbirdCmdModel->data(topLeft).toString().isEmpty()) {
+        && thunderbirdCmdModel->data(topLeft, Qt::DisplayRole).toString().isEmpty()) {
         thunderbirdCmdModel->removeRow(topLeft.row());
     }
     if (!thunderbirdCmdModel->data(thunderbirdCmdModel->index(
-            thunderbirdCmdModel->rowCount() - 1, 0)).toString().isEmpty()) {
+            thunderbirdCmdModel->rowCount() - 1, 0), Qt::DisplayRole).toString().isEmpty()) {
         thunderbirdCmdModel->insertRow(thunderbirdCmdModel->rowCount());
         thunderbirdCmdModel->setData(
                 thunderbirdCmdModel->index(thunderbirdCmdModel->rowCount() - 1, 0), "");

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -411,7 +411,7 @@ void DialogSettings::editThunderbirdCommand() {
     connect(detectButton, &QPushButton::clicked, this, [&]() {
         commandListView.setEnabled(false);
         QStringList command = searchThunderbird();
-        if (command.isEmpty() || !QFileInfo(command[0]).isExecutable()) {
+        if (command.isEmpty() || !QFileInfo(Utils::expandPath(command[0])).isExecutable()) {
             QMessageBox::warning(&commandDialog, tr("Thunderbird not found"),
                     tr("Unable to detect Thunderbird on your system."));
         } else {
@@ -590,7 +590,8 @@ bool DialogSettings::isMorkParserSelected() const
 
 QStringList DialogSettings::searchThunderbird() const {
     QStringList defaultCommand = Utils::getDefaultThunderbirdCommand();
-    if (defaultCommand.count() == 1 && !QFileInfo(defaultCommand[0]).isExecutable()) {
+    if (defaultCommand.count() == 1
+        && !QFileInfo(Utils::expandPath(defaultCommand[0])).isExecutable()) {
         return defaultCommand;
     }
     QString thunderbirdPath = QStandardPaths::findExecutable("thunderbird");

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -415,7 +415,7 @@ void DialogSettings::editThunderbirdCommand() {
             QMessageBox::warning(&commandDialog, tr("Thunderbird not found"),
                     tr("Unable to detect Thunderbird on your system."));
         } else {
-            thunderbirdCmdModel->setStringList(command);
+            thunderbirdCmdModel->setStringList(command << "");
         }
         commandListView.setEnabled(true);
     });

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -154,15 +154,6 @@ void DialogSettings::accept()
             return;
         }
     }
-
-    if (boxEnableNewEmail->isChecked() && thunderbirdCmdModel->rowCount() <= 1) {
-        QMessageBox::critical(nullptr, tr("Empty Thunderbird command"),
-                              tr("You have enabled New Email menu, "
-                                 "but you did not specify a Thunderbird command."));
-        tabWidget->setCurrentIndex( 4 );
-        thunderbirdCommandEditButton->setFocus();
-        return;
-    }
     
     BirdtrayApp* app = BirdtrayApp::get();
     Settings* settings = app->getSettings();
@@ -415,12 +406,19 @@ void DialogSettings::editThunderbirdCommand() {
     connect(&dialogButtonBox, &QDialogButtonBox::accepted, &commandDialog, &QDialog::accept);
     connect(&dialogButtonBox, &QDialogButtonBox::rejected, &commandDialog, &QDialog::reject);
     commandDialog.setLayout(&layout);
-    if (commandDialog.exec() == QDialog::Accepted) {
-        QStringList thunderbirdCommand = thunderbirdCmdModel->stringList();
-        thunderbirdCommand.removeLast();
-        thunderbirdCommandLabel->setText(thunderbirdCommand.join(' '));
-        thunderbirdCommandLabel->setToolTip(thunderbirdCommand.join('\n'));
+    QStringList thunderbirdCommand = thunderbirdCmdModel->stringList();
+    if (commandDialog.exec() != QDialog::Accepted) {
+        thunderbirdCmdModel->setStringList(thunderbirdCommand);
+        return;
     }
+    thunderbirdCommand = thunderbirdCmdModel->stringList();
+    if (thunderbirdCommand.count() <= 1) {
+        thunderbirdCommand = Utils::getDefaultThunderbirdCommand() << "";
+        thunderbirdCmdModel->setStringList(thunderbirdCommand);
+    }
+    thunderbirdCommand.removeLast();
+    thunderbirdCommandLabel->setText(thunderbirdCommand.join(' '));
+    thunderbirdCommandLabel->setToolTip(thunderbirdCommand.join('\n'));
 }
 
 void DialogSettings::onCheckUpdateButton() {

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -562,6 +562,8 @@ bool DialogSettings::isMorkParserSelected() const
 
 void DialogSettings::onThunderbirdCommandModelChanged(
         const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) {
+    Q_UNUSED(bottomRight)
+    Q_UNUSED(roles)
     if (topLeft.row() != thunderbirdCmdModel->rowCount() - 1
         && thunderbirdCmdModel->data(topLeft, Qt::DisplayRole).toString().isEmpty()) {
         thunderbirdCmdModel->removeRow(topLeft.row());

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -65,7 +65,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     boxHideWhenMinimized->setChecked( settings->mHideWhenMinimized );
     boxMonitorThunderbirdWindow->setChecked( settings->mMonitorThunderbirdWindow );
     boxRestartThunderbird->setChecked( settings->mRestartThunderbird );
-    leThunderbirdBinary->setText( settings->mThunderbirdCmdLine  );
+    leThunderbirdBinary->setText(settings->mThunderbirdCmdLine.join(' '));
     leThunderbirdWindowMatch->setText( settings->mThunderbirdWindowMatch  );
     spinMinimumFontSize->setValue( settings->mNotificationMinimumFontSize );
     spinMinimumFontSize->setMaximum( settings->mNotificationMaximumFontSize - 1 );
@@ -166,7 +166,7 @@ void DialogSettings::accept()
     settings->mBlinkSpeed = sliderBlinkingSpeed->value();
     settings->mLaunchThunderbird = boxLaunchThunderbirdAtStart->isChecked();
     settings->mShowHideThunderbird = boxShowHideThunderbird->isChecked();
-    settings->mThunderbirdCmdLine = leThunderbirdBinary->text();
+    settings->mThunderbirdCmdLine = splitCommandLine(leThunderbirdBinary->text());
     settings->mThunderbirdWindowMatch = leThunderbirdWindowMatch->text();
     settings->mHideWhenMinimized = boxHideWhenMinimized->isChecked();
     settings->mNotificationFontWeight = qMin(99, (int) (notificationFontWeight->value() / 2));
@@ -524,4 +524,17 @@ bool DialogSettings::reportIfProfilePathValid(const QString &profilePath) const 
 bool DialogSettings::isMorkParserSelected() const
 {
     return boxParserSelection->currentIndex() == 1;
+}
+
+QStringList DialogSettings::splitCommandLine(QString commandLine) const {
+    QStringList parts;
+    commandLine = commandLine.trimmed();
+    // TODO
+//    int spaceIndex = -1;
+//    while ((spaceIndex = commandLine.indexOf(' ', spaceIndex + 1)) != -1) {
+//        if (commandLine[spaceIndex - 1] == '')
+//    }
+//    parts << commandLine;
+    parts = commandLine.split(' ');
+    return parts;
 }

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -411,7 +411,7 @@ void DialogSettings::editThunderbirdCommand() {
     connect(detectButton, &QPushButton::clicked, this, [&]() {
         commandListView.setEnabled(false);
         QStringList command = searchThunderbird();
-        if (command.isEmpty()) {
+        if (command.isEmpty() || !QFileInfo(command[0]).isExecutable()) {
             QMessageBox::warning(&commandDialog, tr("Thunderbird not found"),
                     tr("Unable to detect Thunderbird on your system."));
         } else {
@@ -597,14 +597,5 @@ QStringList DialogSettings::searchThunderbird() const {
     if (!thunderbirdPath.isEmpty()) {
         return {thunderbirdPath};
     }
-    if (QApplication::applicationDirPath().contains("flatpak")) { // TODO: Is this the best way to detect if we are installed with flatpak and does it even work?
-        // TODO: Is this really the best way to check for other apps?
-        int result = QProcess::execute("/usr/bin/flatpak-spawn",
-                {"--host", "file", "/usr/bin/thunderbird"});
-        if (result == 0) {
-            return {"/usr/bin/flatpak-spawn", "--host", "thunderbird"};
-        }
-        // TODO: Do this for flatpak and snap Thunderbird
-    }
-    return QStringList();
+    return defaultCommand;
 }

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -103,6 +103,14 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
          */
         bool    reportIfProfilePathValid(const QString& profilePath) const;
         bool    isMorkParserSelected() const;
+        
+        /**
+         * Split the command line string back into its parts.
+         *
+         * @param commandLine The command line string.
+         * @return The parts of the command line.
+         */
+        QStringList splitCommandLine(QString commandLine) const;
 
         QPalette mPaletteOk;
         QPalette mPaletteErrror;

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QProgressDialog>
 #include <QPalette>
+#include <QtCore/QStringListModel>
 
 #include "databaseaccounts.h"
 #include "ui_dialogsettings.h"
@@ -64,6 +65,7 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    newEmailRemove();
         
         // Advanced buttons
+        void    editThunderbirdCommand();
         void    onCheckUpdateButton();
 
         // Icon change
@@ -105,12 +107,15 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         bool    isMorkParserSelected() const;
         
         /**
-         * Split the command line string back into its parts.
+         * Called when the user edited an entry of the Thunderbird command line model.
          *
-         * @param commandLine The command line string.
-         * @return The parts of the command line.
+         * @param topLeft The top left item that was changed.
+         * @param bottomRight The bottom right item that was changed.
+         * @param roles The data roles that have been modified.
          */
-        QStringList splitCommandLine(QString commandLine) const;
+        void onThunderbirdCommandModelChanged(
+                const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                const QVector<int> &roles = QVector<int>());
 
         QPalette mPaletteOk;
         QPalette mPaletteErrror;
@@ -126,6 +131,11 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
 
         // Model to show new emails
         ModelNewEmails      *   mModelNewEmails;
+    
+        /**
+         * Model that contains the Thunderbird command line.
+         */
+        QStringListModel* thunderbirdCmdModel = nullptr;
 
 };
 

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -81,6 +81,17 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         // Parser changed
         void    unreadParserChanged( int curr );
 
+        /**
+         * Called when the user edited an entry of the Thunderbird command line model.
+         *
+         * @param topLeft The top left item that was changed.
+         * @param bottomRight The bottom right item that was changed.
+         * @param roles The data roles that have been modified.
+         */
+        void onThunderbirdCommandModelChanged(
+                const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                const QVector<int> &roles = QVector<int>());
+
     private:
         void    changeIcon(QToolButton * button );
         
@@ -105,17 +116,13 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
          */
         bool    reportIfProfilePathValid(const QString& profilePath) const;
         bool    isMorkParserSelected() const;
-        
+    
         /**
-         * Called when the user edited an entry of the Thunderbird command line model.
+         * Try to find a command to start Thunderbird on the current system.
          *
-         * @param topLeft The top left item that was changed.
-         * @param bottomRight The bottom right item that was changed.
-         * @param roles The data roles that have been modified.
+         * @return The command that was found.
          */
-        void onThunderbirdCommandModelChanged(
-                const QModelIndex &topLeft, const QModelIndex &bottomRight,
-                const QVector<int> &roles = QVector<int>());
+        QStringList searchThunderbird() const;
 
         QPalette mPaletteOk;
         QPalette mPaletteErrror;

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -732,22 +732,34 @@
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="gridLayout_3">
+           <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1,0">
+            <item row="1" column="1" colspan="2">
+             <widget class="QLineEdit" name="leThunderbirdWindowMatch"/>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
-               <string>Path to Thunderbird executable:</string>
+               <string>Thunderbird command:</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="leThunderbirdBinary"/>
-            </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_8">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Thunderbird window name pattern:</string>
               </property>
@@ -756,11 +768,14 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="leThunderbirdWindowMatch"/>
-            </item>
             <item row="2" column="0">
              <widget class="QLabel" name="label_11">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Minimum notification font size:</string>
               </property>
@@ -769,8 +784,14 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="2" column="1" colspan="2">
              <widget class="QSpinBox" name="spinMinimumFontSize">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="suffix">
                <string> points</string>
               </property>
@@ -782,6 +803,32 @@
               </property>
               <property name="value">
                <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="thunderbirdCommandLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string notr="true"/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QToolButton" name="thunderbirdCommandEditButton">
+              <property name="toolTip">
+               <string>Edit the Thunderbird command</string>
+              </property>
+              <property name="text">
+               <string notr="true">...</string>
               </property>
              </widget>
             </item>
@@ -954,6 +1001,50 @@ p, li { white-space: pre-wrap; }
    <header>colorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>notificationFont</tabstop>
+  <tabstop>sliderBlinkingSpeed</tabstop>
+  <tabstop>btnNotificationIcon</tabstop>
+  <tabstop>boxShowUnreadCount</tabstop>
+  <tabstop>boxNotificationIconUnread</tabstop>
+  <tabstop>btnNotificationIconUnread</tabstop>
+  <tabstop>btnNotificationColor</tabstop>
+  <tabstop>notificationFontWeight</tabstop>
+  <tabstop>borderColorButton</tabstop>
+  <tabstop>borderWidthSlider</tabstop>
+  <tabstop>btnFixUnreadCount</tabstop>
+  <tabstop>boxParserSelection</tabstop>
+  <tabstop>leProfilePath</tabstop>
+  <tabstop>btnBrowse</tabstop>
+  <tabstop>treeAccounts</tabstop>
+  <tabstop>btnAccountAdd</tabstop>
+  <tabstop>btnAccountEdit</tabstop>
+  <tabstop>btnAccountRemove</tabstop>
+  <tabstop>boxAllowSuppression</tabstop>
+  <tabstop>boxLaunchThunderbirdAtStart</tabstop>
+  <tabstop>spinThunderbirdStartDelay</tabstop>
+  <tabstop>boxHideWindowAtStart</tabstop>
+  <tabstop>boxStopThunderbirdOnExit</tabstop>
+  <tabstop>boxShowHideThunderbird</tabstop>
+  <tabstop>boxHideWhenMinimized</tabstop>
+  <tabstop>boxMonitorThunderbirdWindow</tabstop>
+  <tabstop>boxRestartThunderbird</tabstop>
+  <tabstop>boxHideWindowAtRestart</tabstop>
+  <tabstop>boxEnableNewEmail</tabstop>
+  <tabstop>treeNewEmails</tabstop>
+  <tabstop>btnNewEmailAdd</tabstop>
+  <tabstop>btnNewEmailEdit</tabstop>
+  <tabstop>btnNewEmailDelete</tabstop>
+  <tabstop>thunderbirdCommandEditButton</tabstop>
+  <tabstop>leThunderbirdWindowMatch</tabstop>
+  <tabstop>spinMinimumFontSize</tabstop>
+  <tabstop>boxBlinkingUsesAlpha</tabstop>
+  <tabstop>spinUnreadOpacityLevel</tabstop>
+  <tabstop>checkUpdateOnStartup</tabstop>
+  <tabstop>checkUpdateButton</tabstop>
+  <tabstop>browserAbout</tabstop>
+ </tabstops>
  <resources>
   <include location="resources.qrc"/>
  </resources>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -242,6 +242,9 @@ void Settings::load()
 }
 
 QString Settings::getThunderbirdCommand(QStringList &arguments) {
+    if (mThunderbirdCmdLine.isEmpty()) {
+        return QString();
+    }
     arguments = mThunderbirdCmdLine;
     QString executable = arguments.takeFirst();
     if (executable.startsWith('"')) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -170,7 +170,7 @@ void Settings::load()
 
     QStringList thunderbirdCommand = mSettings->value(
             "advanced/tbcmdline", mThunderbirdCmdLine).toStringList();
-    if (!thunderbirdCommand.isEmpty()) {
+    if (!thunderbirdCommand.isEmpty() && !thunderbirdCommand[0].isEmpty()) {
         mThunderbirdCmdLine = thunderbirdCommand;
     }
     mThunderbirdWindowMatch = mSettings->value(

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -54,17 +54,7 @@ Settings::Settings(bool verboseOutput)
     mUpdateOnStartup = false;
     mUnreadOpacityLevel = 0.75;
     mNewEmailMenuEnabled = false;
-
-#ifdef Q_OS_WIN
-    mThunderbirdCmdLine << R"("%ProgramFiles(x86)%\Mozilla Thunderbird\thunderbird.exe")";
-#else
-    if (QFileInfo("/usr/bin/thunderbird").isExecutable()) {
-        mThunderbirdCmdLine << "/usr/bin/thunderbird";
-    } else {
-        mThunderbirdCmdLine << "/usr/bin/flatpak-spawn" << "--host" << "flatpak"
-                            << "run" << "org.mozilla.Thunderbird";
-    }
-#endif
+    mThunderbirdCmdLine = Utils::getDefaultThunderbirdCommand();
 }
 
 Settings::~Settings()
@@ -178,8 +168,11 @@ void Settings::load()
     mShowUnreadEmailCount = mSettings->value(
             "common/showunreademailcount", mShowUnreadEmailCount ).toBool();
 
-    mThunderbirdCmdLine = mSettings->value(
+    QStringList thunderbirdCommand = mSettings->value(
             "advanced/tbcmdline", mThunderbirdCmdLine).toStringList();
+    if (!thunderbirdCommand.isEmpty()) {
+        mThunderbirdCmdLine = thunderbirdCommand;
+    }
     mThunderbirdWindowMatch = mSettings->value(
             "advanced/tbwindowmatch", mThunderbirdWindowMatch ).toString();
     mNotificationMinimumFontSize = mSettings->value(

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -251,7 +251,7 @@ QString Settings::getThunderbirdCommand(QStringList &arguments) {
 #if defined (Q_OS_WIN)
     return '"' + QFileInfo(executable).absoluteFilePath() + '"';
 #else
-    return = QFileInfo(executable).absoluteFilePath();
+    return QFileInfo(executable).absoluteFilePath();
 #endif
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -239,11 +239,7 @@ QString Settings::getThunderbirdCommand(QStringList &arguments) {
         return QString();
     }
     arguments = mThunderbirdCmdLine;
-    QString executable = arguments.takeFirst();
-    if (executable.startsWith('"')) {
-        executable = executable.section('"', 1, 1);
-    }
-    executable = Utils::expandPath(executable);
+    QString executable = Utils::expandPath(arguments.takeFirst());
 #if defined (Q_OS_WIN)
     return '"' + QFileInfo(executable).absoluteFilePath() + '"';
 #else

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,8 +53,8 @@ class Settings
         // Path to Thunderbird folder
         QString mThunderbirdFolderPath;
 
-        // Thunderbird binary and command line
-        QString mThunderbirdCmdLine;
+        // The command to start Thunderbird. The first element is the executable to launch.
+        QStringList mThunderbirdCmdLine;
 
         // Thunderbird window match
         QString mThunderbirdWindowMatch;
@@ -128,9 +128,11 @@ class Settings
         void    load();
         
         /**
-         * @return The absolute path to the thunderbird executable.
+         * @note The returned executable might not be the Thunderbird executable.
+         * @param arguments The arguments necessary to start Thunderbird.
+         * @return The executable that starts Thunderbird.
          */
-        QString getThunderbirdExecutablePath();
+        QString getThunderbirdCommand(QStringList &arguments);
         
         /**
          * @return The icon to use for the system tray.

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -546,14 +546,6 @@ Sollen die Informationen über bestehende Konten gelöscht werden?</translation>
         <translation>Ungültiges Thunderbird-Verzeichnis</translation>
     </message>
     <message>
-        <source>Empty Thunderbird command</source>
-        <translation>Kein Thunderbird Befehl</translation>
-    </message>
-    <message>
-        <source>You have enabled New Email menu, but you did not specify a Thunderbird command.</source>
-        <translation>Sie haben das &quot;Neue Email&quot;-Menü aktiviert, aber keinen Befehl zum Starten von Thunderbird festgelegt.</translation>
-    </message>
-    <message>
         <source>Thunderbird Command</source>
         <translation>Thunderbird Befehl</translation>
     </message>
@@ -564,6 +556,18 @@ Sollen die Informationen über bestehende Konten gelöscht werden?</translation>
     <message>
         <source>Edit the Thunderbird command</source>
         <translation>Bearbeite den Thunderbird Befehl</translation>
+    </message>
+    <message>
+        <source>Auto detect</source>
+        <translation>Automatisch erkennen</translation>
+    </message>
+    <message>
+        <source>Thunderbird not found</source>
+        <translation>Thunderbird konnte nicht gefunden werden</translation>
+    </message>
+    <message>
+        <source>Unable to detect Thunderbird on your system.</source>
+        <translation>Thunderbird konnte auf ihrem System nicht gefunden werden.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -801,7 +801,7 @@ Wollen Sie fortfahren?</translation>
         <source>Error starting Thunderbird as %1:
 
 %2</source>
-        <translation>Beim Starten von Thunderbird als %1 ist ein Fehler aufgetreten:
+        <translation type="vanished">Beim Starten von Thunderbird als %1 ist ein Fehler aufgetreten:
 
 %2</translation>
     </message>
@@ -816,6 +816,12 @@ Wollen Sie fortfahren?</translation>
     <message>
         <source>Ignore unread emails (now %1)</source>
         <translation>Ignoriere ungelesene Emails (momentan %1)</translation>
+    </message>
+    <message>
+        <source>Error starting Thunderbird as &apos;%1 %2&apos;:
+
+%3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -364,10 +364,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Bitte ändern Sie diese Einstellungen nur wenn Sie wissen was Sie tun.</translation>
     </message>
     <message>
-        <source>Path to Thunderbird executable:</source>
-        <translation>Pfad zum Thunderbird-Programm:</translation>
-    </message>
-    <message>
         <source>Thunderbird window name pattern:</source>
         <translation>Namensschema des Thunderbird-Fensters:</translation>
     </message>
@@ -452,10 +448,6 @@ p, li { white-space: pre-wrap; }
         <translation>Leeres Thunderbird Verzeichnis</translation>
     </message>
     <message>
-        <source>Empty Thunderbird path</source>
-        <translation>Leerer Thunderbird Pfad</translation>
-    </message>
-    <message>
         <source>Choose the Thunderbird profile path</source>
         <translation>Wähle den Thunderbird Profil-Pfad</translation>
     </message>
@@ -488,10 +480,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>You must specify a Thunderbird directory.</source>
         <translation>Es muss ein Thunderbird-Verzeichnis angegeben werden.</translation>
-    </message>
-    <message>
-        <source>You have enabled New Email menu, but you did not specify Thunderbird path.</source>
-        <translation>Sie haben das &quot;Neue Email&quot;-Menü aktiviert, aber keinen Pfad zur ausführbaren Datei von Thunderbird festgelegt.</translation>
     </message>
     <message>
         <source>Successfully updated the database.</source>
@@ -556,6 +544,26 @@ Sollen die Informationen über bestehende Konten gelöscht werden?</translation>
     <message>
         <source>Invalid Thunderbird directory</source>
         <translation>Ungültiges Thunderbird-Verzeichnis</translation>
+    </message>
+    <message>
+        <source>Empty Thunderbird command</source>
+        <translation>Kein Thunderbird Befehl</translation>
+    </message>
+    <message>
+        <source>You have enabled New Email menu, but you did not specify a Thunderbird command.</source>
+        <translation>Sie haben das &quot;Neue Email&quot;-Menü aktiviert, aber keinen Befehl zum Starten von Thunderbird festgelegt.</translation>
+    </message>
+    <message>
+        <source>Thunderbird Command</source>
+        <translation>Thunderbird Befehl</translation>
+    </message>
+    <message>
+        <source>Thunderbird command:</source>
+        <translation>Thunderbird Befehl:</translation>
+    </message>
+    <message>
+        <source>Edit the Thunderbird command</source>
+        <translation>Bearbeite den Thunderbird Befehl</translation>
     </message>
 </context>
 <context>
@@ -798,14 +806,6 @@ Wollen Sie fortfahren?</translation>
         <translation>Kann Thunderbird nicht starten</translation>
     </message>
     <message>
-        <source>Error starting Thunderbird as %1:
-
-%2</source>
-        <translation type="vanished">Beim Starten von Thunderbird als %1 ist ein Fehler aufgetreten:
-
-%2</translation>
-    </message>
-    <message>
         <source>Error starting Thunderbird, because we could not attach to the updater:
 
 %1</source>
@@ -821,7 +821,9 @@ Wollen Sie fortfahren?</translation>
         <source>Error starting Thunderbird as &apos;%1 %2&apos;:
 
 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Beim Starten von Thunderbird als &apos;%1 %2&apos; ist ein Fehler aufgetreten:
+
+%3</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -361,10 +361,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Path to Thunderbird executable:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thunderbird window name pattern:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -409,22 +405,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Liberation Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; font-weight:600;&quot;&gt;Birdtray version [VERSION] compiled at [DATE].&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Copyright (C) 2018 by George Yunaev, &lt;/span&gt;&lt;a href=&quot;mailto:gyunaev@ulduzsoft.com&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;gyunaev@ulduzsoft.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Birdtray is FREE SOFTWARE, which is licensed under General Public License v3. To clarify further, you can use it for any purpose, including commercial, without paying anything. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;For those of you who apprericate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>using global search database (wont work with 68+)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -438,14 +418,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>You must specify a Thunderbird directory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty Thunderbird path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>You have enabled New Email menu, but you did not specify Thunderbird path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -535,6 +507,42 @@ Do you want to clear the accounts?</source>
     </message>
     <message>
         <source>Valid Thunderbird directory must contain the file %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Thunderbird command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have enabled New Email menu, but you did not specify a Thunderbird command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thunderbird Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Liberation Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; font-weight:600;&quot;&gt;Birdtray version [VERSION] compiled at [DATE].&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Copyright (C) 2018 by George Yunaev, &lt;/span&gt;&lt;a href=&quot;mailto:gyunaev@ulduzsoft.com&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;gyunaev@ulduzsoft.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Birdtray is FREE SOFTWARE, which is licensed under General Public License v3. To clarify further, you can use it for any purpose, including commercial, without paying anything. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;For those of you who apprericate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thunderbird command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit the Thunderbird command</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -777,12 +777,6 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Error starting Thunderbird as %1:
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Error starting Thunderbird, because we could not attach to the updater:
 
 %1</source>
@@ -790,6 +784,12 @@ Do you want to continue?</source>
     </message>
     <message>
         <source>Ignore unread emails (now %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting Thunderbird as &apos;%1 %2&apos;:
+
+%3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -510,14 +510,6 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Empty Thunderbird command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>You have enabled New Email menu, but you did not specify a Thunderbird command.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thunderbird Command</source>
         <translation type="unfinished"></translation>
     </message>
@@ -543,6 +535,18 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Edit the Thunderbird command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto detect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thunderbird not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to detect Thunderbird on your system.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,6 +10,7 @@
 #  include <windows.h>
 #elif defined (Q_OS_MAC)
 #else
+#  include <QtCore/QFileInfo>
 #  include <wordexp.h>
 #endif
 
@@ -215,4 +216,16 @@ QStringList Utils::getThunderbirdProfilesPaths() {
 #else // Linux
     return {"~/.thunderbird", "~/snap/thunderbird/common/.thunderbird"};
 #endif /* Platform */
+}
+
+QStringList Utils::getDefaultThunderbirdCommand() {
+#ifdef Q_OS_WIN
+    return {R"("%ProgramFiles(x86)%\Mozilla Thunderbird\thunderbird.exe")"};
+#else
+    if (QFileInfo("/usr/bin/thunderbird").isExecutable()) {
+        return {"/usr/bin/thunderbird"};
+    } else {
+        return {"/usr/bin/flatpak-spawn", "--host", "flatpak", "run", "org.mozilla.Thunderbird"};
+    }
+#endif
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -125,17 +125,23 @@ QString Utils::decodeIMAPutf7(const QString &param)
 }
 
 QString Utils::expandPath(const QString &path) {
+    QString rawPath;
+    if (path.startsWith('"') && path.endsWith('"')) {
+        rawPath = path.section('"', 1, 1);
+    } else {
+        rawPath = path;
+    }
 #if defined (Q_OS_WIN)
     TCHAR buffer[MAX_PATH];
 #if defined(UNICODE)
-    std::wstring originalPath = qToStdWString(path);
+    std::wstring originalPath = qToStdWString(rawPath);
 #else
-    std::string originalPath = path.toStdString();
+    std::string originalPath = rawPath.toStdString();
 #endif /* defined(UNICODE) */
     DWORD resultSize = ExpandEnvironmentStrings(
             originalPath.data(), buffer, sizeof(buffer) / sizeof(buffer[0]));
     if (resultSize == 0 || resultSize > sizeof(buffer) / sizeof(buffer[0])) {
-        return path;
+        return rawPath;
     }
 #if defined(UNICODE)
     return QString::fromWCharArray(buffer, static_cast<int>(resultSize - 1));
@@ -144,12 +150,11 @@ QString Utils::expandPath(const QString &path) {
 #endif /* defined(UNICODE) */
 
 #elif defined (Q_OS_MAC)
-    return path;
-    
+    return rawPath;
 #else
     wordexp_t result;
-    if (wordexp(path.toStdString().data(), &result, WRDE_NOCMD) != 0) {
-        return path;
+    if (wordexp(rawPath.toStdString().data(), &result, WRDE_NOCMD) != 0) {
+        return rawPath;
     }
     QString expandedPath(result.we_wordv[0]);
     wordfree(&result);

--- a/src/utils.h
+++ b/src/utils.h
@@ -58,6 +58,11 @@ class Utils
          * @see https://support.mozilla.org/en-US/kb/profiles-where-thunderbird-stores-user-data#w_profile-location-summary
          */
         static QStringList getThunderbirdProfilesPaths();
+
+        /**
+         * @return The default Thunderbird command for the current platform.
+         */
+        static QStringList getDefaultThunderbirdCommand();
 };
 
 #endif // UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,7 +10,8 @@ class Utils
         static QString  decodeIMAPutf7( const QString& param );
     
         /**
-         * Expand the path as a shell would do. This will expand variables and ~/
+         * Expand the path as a shell would do. This will expand variables and ~/.
+         * This function will also remove wrapping quotes.
          *
          * @param path The path.
          * @return The expanded path.


### PR DESCRIPTION
When installed via flatpak, Thunderbird can not be started with the path to the Thunderbird executable. It has to be started via the `flatpak-spawn` command.

Birdtray will prefer the native Thunderbird executable over the flatpak command, if it is present.

This also changes how the user can edit the Thunderbird command in the `Advanced` settings tab: Instead of entering the command in a text editor, the command and arguments can now be entered in a small dialog with a list view, to clearly separate the arguments from another.

<details>
<summary>Pictures</summary>

![The modified "Advanced" settings tab](https://user-images.githubusercontent.com/6966049/68985263-9bd53c80-0815-11ea-8127-b907e5060667.png)

![The Thunderbird command edit dialog](https://user-images.githubusercontent.com/6966049/69300468-92801180-0c13-11ea-8c10-096bf942ac65.png)
</details>