### PR TITLE
Allow to select the translations to be installed with Birdtray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ installer/nsisDependencies
 installer/BirdTray-*.exe
 installer/getArch.exe
 installer/makeUninstallList.exe
+installer/makeTranslationsList.exe
+installer/translations_list.nsh
 installer/arch.nsh
 installer/installerTranslations.nsi
 installer/makeInstallerTranslations.exe

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -292,3 +292,41 @@ FunctionEnd
         ${loop}
     ${endif}
 !macroend
+
+!define TVGN_ROOT        0
+!define TVGN_NEXT        1
+!define TVGN_NEXTVISIBLE 6
+!define TVIF_TEXT        1
+!define TVM_GETNEXTITEM  4362
+!define TVM_GETITEMA     4364
+!define TVM_GETITEMW     4414
+!define TVM_SORTCHILDREN 4371
+!define TVITEM '(i, i, i, i, i, i, i, i, i, i)'
+!ifdef NSIS_UNICODE
+    !define TVM_GETITEM ${TVM_GETITEMW}
+!else
+    !define TVM_GETITEM ${TVM_GETITEMA}
+!endif
+
+# Sorts all items inside of a section group alphabetically.
+# SORT_SECTION_GROUP: The name of the section group.
+!macro SORT_SECTION_GROUP GROUP_NAME
+    FindWindow $0 "#32770" "" $HWNDPARENT
+    GetDlgItem $0 $0 1032
+    SendMessage $0 ${TVM_GETNEXTITEM} ${TVGN_ROOT} 0 $1
+
+    System::Alloc ${NSIS_MAX_STRLEN}
+    Pop $2
+    loop:
+    	System::Call '*${TVITEM}(${TVIF_TEXT}, r1,,, r2, ${NSIS_MAX_STRLEN},,,,) i .r3'
+    	SendMessage $0 ${TVM_GETITEM} 0 $3
+    	System::Call '*$2(&t${NSIS_MAX_STRLEN} .r4)'
+    	StrCmp $4 "${GROUP_NAME}" found
+    	SendMessage $0 ${TVM_GETNEXTITEM} ${TVGN_NEXTVISIBLE} $1 $1
+    	StrCmp 0 $1 done loop
+    found:
+    	SendMessage $0 ${TVM_SORTCHILDREN} 0 $1
+    done:
+    System::Free $2
+    System::Free $3
+!macroend

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -318,14 +318,14 @@ FunctionEnd
     System::Alloc ${NSIS_MAX_STRLEN}
     Pop $2
     loop:
-    	System::Call '*${TVITEM}(${TVIF_TEXT}, r1,,, r2, ${NSIS_MAX_STRLEN},,,,) i .r3'
-    	SendMessage $0 ${TVM_GETITEM} 0 $3
-    	System::Call '*$2(&t${NSIS_MAX_STRLEN} .r4)'
-    	StrCmp $4 "${GROUP_NAME}" found
-    	SendMessage $0 ${TVM_GETNEXTITEM} ${TVGN_NEXTVISIBLE} $1 $1
-    	StrCmp 0 $1 done loop
+        System::Call '*${TVITEM}(${TVIF_TEXT}, r1,,, r2, ${NSIS_MAX_STRLEN},,,,) i .r3'
+        SendMessage $0 ${TVM_GETITEM} 0 $3
+        System::Call '*$2(&t${NSIS_MAX_STRLEN} .r4)'
+        StrCmp $4 "${GROUP_NAME}" found
+        SendMessage $0 ${TVM_GETNEXTITEM} ${TVGN_NEXTVISIBLE} $1 $1
+        StrCmp 0 $1 done loop
     found:
-    	SendMessage $0 ${TVM_SORTCHILDREN} 0 $1
+        SendMessage $0 ${TVM_SORTCHILDREN} 0 $1
     done:
     System::Free $2
     System::Free $3

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -57,9 +57,6 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define MIN_WINDOWS_VER "XP"
 
 # Paths
-!define TRANSLATIONS_GROUP_DESCRIPTION "Select translations for Birdtray. \
-        Birdtray will choose a translation based on the system language."
-
 !define EXE_NAME "birdtray.exe"
 !define PROGEXE ${EXE_NAME}  # For the MultiUser plugin
 !define ICON_NAME "birdtray.ico"
@@ -365,7 +362,7 @@ Section "$(AutoCheckUpdateSectionName)" SectionAutoCheckUpdate
     FileWrite $2 "updateOnStartup = true$\r$\n"
 SectionEnd
 
-SectionGroup /e "Translations" SectionGroupTranslations
+SectionGroup /e "$(TranslationsSectionName)" SectionGroupTranslations
     !makensis '/DDIST_DIR="${DIST_DIR}" \
                 /DTRANSLATIONS_LIST_FILENAME="${TRANSLATIONS_LIST_FILENAME}" \
                 makeTranslationsList.nsi' = 0
@@ -385,8 +382,7 @@ SectionEnd
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoCheckUpdate} "$(AutoCheckUpdateDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupWinIntegration} \
             "$(WinIntegrationGroupDescription)"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupTranslations} \
-            "${TRANSLATIONS_GROUP_DESCRIPTION}"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupTranslations} "$(TranslationsDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionProgramGroup} "$(ProgramGroupDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionDesktopEntry} "$(DesktopEntryDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionStartMenuEntry} "$(StartMenuDescription)"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -195,6 +195,7 @@ VIAddVersionKey LegalCopyright ""
 !insertmacro MUI_PAGE_DIRECTORY
 
 !define MUI_PAGE_CUSTOMFUNCTION_PRE ComponentsPagePre
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW ComponentsPageShow
 !insertmacro MUI_PAGE_COMPONENTS
 
 !define MUI_PAGE_CUSTOMFUNCTION_PRE StartMenuPagePre
@@ -581,6 +582,10 @@ Function ComponentsPagePre
         ${endif}
     ${endif}
     !endif # UNINSTALL_BUILDER
+FunctionEnd
+
+Function ComponentsPageShow
+    !insertmacro SORT_SECTION_GROUP "$(TranslationsSectionName)"
 FunctionEnd
 
 # Called when changing selections on the component page

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -57,6 +57,9 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define MIN_WINDOWS_VER "XP"
 
 # Paths
+!define TRANSLATIONS_GROUP_DESCRIPTION "Select translations for Birdtray. \
+        Birdtray will choose a translation based on the system language."
+
 !define EXE_NAME "birdtray.exe"
 !define PROGEXE ${EXE_NAME}  # For the MultiUser plugin
 !define ICON_NAME "birdtray.ico"
@@ -75,6 +78,8 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define UNINSTALL_LIST_FILENAME "uninstall_list.nsh"
 !define INSTALLER_TRANSLATIONS_BUILDER_FILE "makeInstallerTranslations.exe"
 !define INSTALLER_TRANSLATIONS_FILENAME "installerTranslations.nsi"
+!define TRANSLATIONS_LIST_BUILDER_FILE "makeTranslationsList.exe"
+!define TRANSLATIONS_LIST_FILENAME "translations_list.nsh"
 !define HEADER_IMG_FILE "assets\header.bmp"
 !define SIDEBAR_IMG_FILE "assets\sidebar.bmp"
 !define INSTALL_CONFIG_FILE ".installConfig.ini"
@@ -301,7 +306,7 @@ Section "${PRODUCT_NAME}" SectionBirdTray
             "${MUI_LANGDLL_REGISTRY_VALUENAME}" $LANGUAGE
     ${endif}
 
-    File /r "${DIST_DIR}\*"
+    File /r /x translations "${DIST_DIR}\*"
 
     !ifdef INSTALL_LICENSE
         File "${LICENSE_PATH}"
@@ -360,6 +365,16 @@ Section "$(AutoCheckUpdateSectionName)" SectionAutoCheckUpdate
     FileWrite $2 "updateOnStartup = true$\r$\n"
 SectionEnd
 
+SectionGroup /e "Translations" SectionGroupTranslations
+    !makensis '/DDIST_DIR="${DIST_DIR}" \
+                /DTRANSLATIONS_LIST_FILENAME="${TRANSLATIONS_LIST_FILENAME}" \
+                makeTranslationsList.nsi' = 0
+    !system "${TRANSLATIONS_LIST_BUILDER_FILE}" = 0
+    !include "${TRANSLATIONS_LIST_FILENAME}"
+    !delfile "${TRANSLATIONS_LIST_BUILDER_FILE}"
+    !delfile "${TRANSLATIONS_LIST_FILENAME}"
+SectionGroupEnd
+
 Section "-Write Install Size" # Hidden section, write install size as the final step
     !insertmacro MULTIUSER_RegistryAddInstallSizeInfo
 SectionEnd
@@ -370,6 +385,8 @@ SectionEnd
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoCheckUpdate} "$(AutoCheckUpdateDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupWinIntegration} \
             "$(WinIntegrationGroupDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupTranslations} \
+            "${TRANSLATIONS_GROUP_DESCRIPTION}"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionProgramGroup} "$(ProgramGroupDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionDesktopEntry} "$(DesktopEntryDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionStartMenuEntry} "$(StartMenuDescription)"

--- a/installer/makeTranslationsList.nsi
+++ b/installer/makeTranslationsList.nsi
@@ -1,0 +1,53 @@
+SetCompress off
+Name "makeTranslationsList"
+OutFile "makeTranslationsList.exe"
+SilentInstall silent
+RequestExecutionLevel user
+
+
+# Create a file containing NSIS sections for translations in a directory.
+# $R0 - OUTPUT_FILE: The file to write the sections to.
+# $R1 - TRANSLATION_FOLDER: The directory that contains the translations.
+Function CreateTranslationsList
+	Pop $R1  # translations folder
+	Pop $R0	 # output file
+
+    FileOpen $R4 $R0 w
+    FileWrite $R4 '!macro insert_translation_section name$\r$\n'
+    FileWrite $R4 '  Section "$${name}"$\r$\n'
+    FileWrite $R4 '    SetOutPath "$$INSTDIR\translations"$\r$\n'
+    FileWrite $R4 '    File /nonfatal "$R1\*_$${name}.qm"$\r$\n'
+    FileWrite $R4 '  SectionEnd$\r$\n'
+    FileWrite $R4 '!macroend$\r$\n'
+
+	ClearErrors
+	FindFirst $R2 $R3 "$R1\main_*.qm"
+
+CreateTranslationsList_Loop:
+	IfErrors CreateTranslationsList_Done
+
+	# Add section for translation
+	FileSeek $R4 0 END
+	StrCpy $R5 $R3 -3 5
+	FileWrite $R4 '!insertmacro insert_translation_section "$R5"$\r$\n'
+
+	ClearErrors
+	FindNext $R2 $R3
+	Goto CreateTranslationsList_Loop
+
+CreateTranslationsList_Done:
+	FindClose $R2
+	FileClose $R4
+FunctionEnd
+
+
+!macro CreateTranslationsList DIR OUTPUT_FILE_PATH
+    Push ${OUTPUT_FILE_PATH} # output file
+    Push ${DIR}              # dir
+    Call CreateTranslationsList
+!macroend
+!define CreateTranslationsList '!insertmacro CreateTranslationsList'
+
+Section
+    ${CreateTranslationsList} "${DIST_DIR}\translations" "${TRANSLATIONS_LIST_FILENAME}"
+SectionEnd

--- a/installer/makeTranslationsList.nsi
+++ b/installer/makeTranslationsList.nsi
@@ -14,7 +14,7 @@ Function CreateTranslationsList
 
     FileOpen $R4 $R0 w
     FileWrite $R4 '!macro insert_translation_section name$\r$\n'
-    FileWrite $R4 '  Section "$${name}"$\r$\n'
+    FileWrite $R4 '  Section "$$(Lang_$${name})"$\r$\n'
     FileWrite $R4 '    SetOutPath "$$INSTDIR\translations"$\r$\n'
     FileWrite $R4 '    File /nonfatal "$R1\*_$${name}.qm"$\r$\n'
     FileWrite $R4 '  SectionEnd$\r$\n'

--- a/installer/makeTranslationsList.nsi
+++ b/installer/makeTranslationsList.nsi
@@ -9,8 +9,8 @@ RequestExecutionLevel user
 # $R0 - OUTPUT_FILE: The file to write the sections to.
 # $R1 - TRANSLATION_FOLDER: The directory that contains the translations.
 Function CreateTranslationsList
-	Pop $R1  # translations folder
-	Pop $R0	 # output file
+    Pop $R1  # translations folder
+    Pop $R0	 # output file
 
     FileOpen $R4 $R0 w
     FileWrite $R4 '!macro insert_translation_section name$\r$\n'
@@ -20,24 +20,24 @@ Function CreateTranslationsList
     FileWrite $R4 '  SectionEnd$\r$\n'
     FileWrite $R4 '!macroend$\r$\n'
 
-	ClearErrors
-	FindFirst $R2 $R3 "$R1\main_*.qm"
+    ClearErrors
+    FindFirst $R2 $R3 "$R1\main_*.qm"
 
 CreateTranslationsList_Loop:
-	IfErrors CreateTranslationsList_Done
+    IfErrors CreateTranslationsList_Done
 
-	# Add section for translation
-	FileSeek $R4 0 END
-	StrCpy $R5 $R3 -3 5
-	FileWrite $R4 '!insertmacro insert_translation_section "$R5"$\r$\n'
+    # Add section for translation
+    FileSeek $R4 0 END
+    StrCpy $R5 $R3 -3 5
+    FileWrite $R4 '!insertmacro insert_translation_section "$R5"$\r$\n'
 
-	ClearErrors
-	FindNext $R2 $R3
-	Goto CreateTranslationsList_Loop
+    ClearErrors
+    FindNext $R2 $R3
+    Goto CreateTranslationsList_Loop
 
 CreateTranslationsList_Done:
-	FindClose $R2
-	FileClose $R4
+    FindClose $R2
+    FileClose $R4
 FunctionEnd
 
 

--- a/src/translations/installer_de.ts
+++ b/src/translations/installer_de.ts
@@ -61,6 +61,14 @@
         <translation>Erstellt eine ${PRODUCT_NAME} Verknüpfung im Startmenü.</translation>
     </message>
     <message>
+        <source>TranslationsSectionName</source>
+        <translation>Anzeigesprachen</translation>
+    </message>
+    <message>
+        <source>TranslationsDescription</source>
+        <translation>Wählen Sie Anzeigesprachen für ${PRODUCT_NAME} aus. ${PRODUCT_NAME} wird eine Sprache basierend auf die Systemsprache auswählen.</translation>
+    </message>
+    <message>
         <source>UserSettingsSectionName</source>
         <translation>${PRODUCT_NAME} Benutzerkonfiguration</translation>
     </message>
@@ -171,6 +179,14 @@
     <message>
         <source>UninstallerAborted</source>
         <translation>Die ${PRODUCT_NAME} Deinstallation wurde abgebrochen. Bitte versuchen Sie es später erneut.</translation>
+    </message>
+    <message>
+        <source>Lang_en</source>
+        <translation>Englisch</translation>
+    </message>
+    <message>
+        <source>Lang_de</source>
+        <translation>Deutsch</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/installer_en.ts
+++ b/src/translations/installer_en.ts
@@ -61,6 +61,14 @@
         <translation>Create a ${PRODUCT_NAME} icon in the Start Menu.</translation>
     </message>
     <message>
+        <source>TranslationsSectionName</source>
+        <translation>Translations</translation>
+    </message>
+    <message>
+        <source>TranslationsDescription</source>
+        <translation>Select translations for ${PRODUCT_NAME}. ${PRODUCT_NAME} will choose a translation based on the system language.</translation>
+    </message>
+    <message>
         <source>UserSettingsSectionName</source>
         <translation>${PRODUCT_NAME} User Settings</translation>
     </message>
@@ -171,6 +179,14 @@
     <message>
         <source>UninstallerAborted</source>
         <translation>Uninstalling ${PRODUCT_NAME} has been aborted. Please try again later.</translation>
+    </message>
+    <message>
+        <source>Lang_en</source>
+        <translation>English</translation>
+    </message>
+    <message>
+        <source>Lang_de</source>
+        <translation>German</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Adds the ability to select which translations should get installed from the Windows installer.

![Updated component selection page of the installer](https://user-images.githubusercontent.com/6966049/68994909-44bc7f80-0888-11ea-8860-cceb31511b8f.png)
