### PR TITLE
Prevent UnreadCounter from being deleted while still running

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -22,7 +22,6 @@ TrayIcon::TrayIcon(bool showSettings)
 
     mIgnoredUnreadEmails = 0;
     mUnreadCounter = 0;
-    mUnreadMonitor = 0;
 
     // Context menu
     mSystrayMenu = new QMenu();
@@ -87,6 +86,10 @@ TrayIcon::~TrayIcon() {
         networkConnectivityManager->deleteLater();
         networkConnectivityManager = nullptr;
     }
+    if (mUnreadMonitor != nullptr) {
+        mUnreadMonitor->quitAndDelete();
+        mUnreadMonitor = nullptr;
+    }
 }
 
 WindowTools* TrayIcon::getWindowTools() const {
@@ -107,8 +110,8 @@ void TrayIcon::unreadCounterError(QString message)
     qWarning("UnreadCounter generated an error: %s", qPrintable(message) );
 
     mCurrentStatus = message;
-    mUnreadMonitor->deleteLater();
-    mUnreadMonitor = 0;
+    mUnreadMonitor->quitAndDelete();
+    mUnreadMonitor = nullptr;
 
     mUnreadCounter = 0;
     updateIcon();
@@ -196,7 +199,8 @@ void TrayIcon::updateIcon()
     p.setFont(settings->mNotificationFont);
 
     // Do we need to draw error sign?
-    if (mUnreadMonitor == 0 || (settings->mMonitorThunderbirdWindow && !mThunderbirdWindowExists)) {
+    if (mUnreadMonitor == nullptr ||
+        (settings->mMonitorThunderbirdWindow && !mThunderbirdWindowExists)) {
         p.setOpacity( 1.0 );
         QPen pen( Qt::red );
         pen.setWidth( (temp.width() * 10) / 100 );

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -127,7 +127,7 @@ class TrayIcon : public QSystemTrayIcon
         QDateTime       mSnoozedUntil;
 
         // Unread counter thread
-        UnreadMonitor * mUnreadMonitor;
+        UnreadMonitor * mUnreadMonitor = nullptr;
 
         // State checking timer (once a second)
         QTimer          mStateTimer;

--- a/src/unreadcounter.cpp
+++ b/src/unreadcounter.cpp
@@ -52,6 +52,12 @@ void UnreadMonitor::run()
     exec();
 }
 
+void UnreadMonitor::quitAndDelete() {
+    quit();
+    wait();
+    deleteLater();
+}
+
 void UnreadMonitor::slotSettingsChanged()
 {
     // We reinitialize everything because the settings changed

--- a/src/unreadcounter.h
+++ b/src/unreadcounter.h
@@ -22,6 +22,11 @@ class UnreadMonitor : public QThread
 
         // Thread run function
         virtual void run() override;
+        
+        /**
+         * Safely enqueues the this unread monitor for deletion.
+         */
+        void quitAndDelete();
 
     signals:
         // Unread counter changed


### PR DESCRIPTION
This fixes the error that caused #171:
`QThread: Destroyed while thread is still running`