### PR TITLE
Add translations for the Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ installer/BirdTray-*.exe
 installer/getArch.exe
 installer/makeUninstallList.exe
 installer/arch.nsh
+installer/installerTranslations.nsi
+installer/makeInstallerTranslations.exe
 
 .idea/*
 !.idea/codeStyles

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ joined with a `_` (e.g. `en` for english or `en_US` for american english).
 ###### Adding a new translation:
 
 To add a new translation to Birdtray, you need to know the [language tag](#language-tag) for the language you want to add.
-Choose one `main_*.ts` and a `dynamic_*.ts` file from [here](src/translations), where `*` is another language tag.
+Choose one `main_*.ts`, a `dynamic_*.ts` and a `installer_*.ts` file from [here](src/translations), where `*` is another language tag.
 Copy the files into the same directory, but replace the previous language tag with the tag for your language.
 Now open both files with a text editor and find the line near the top that looks like this: `<TS version="2.1" language="*">`
 Again, `*` will be another language tag. Replace that tag with your new language tag.
@@ -107,7 +107,7 @@ Now you can continue to edit the new files as described in the next section.
 
 ###### Edit an existing translation:
 
-To change an existing translation, you need to edit the `main_*.ts` and / or `dynamic_*.ts` translation file
+To change an existing translation, you need to edit the `main_*.ts`, `dynamic_*.ts` and / or `installer_*.ts` translation file
 of that language in the [translations directory](src/translations).
 The `*` represents the [language tag](#language-tag) of the language you want to change. To edit these files,
 you can use a text editor or the [Qt Linguist](https://doc.qt.io/qt-5/linguist-translators.html).

--- a/installer/StrUtils.nsh
+++ b/installer/StrUtils.nsh
@@ -1,0 +1,43 @@
+Var STR_HAYSTACK
+Var STR_NEEDLE
+Var STR_CONTAINS_VAR_1
+Var STR_CONTAINS_VAR_2
+Var STR_CONTAINS_VAR_3
+Var STR_CONTAINS_VAR_4
+Var STR_RETURN_VAR
+
+
+# This function does a case sensitive searches for an occurrence of a substring in a string.
+# Written by kenglish_hi, adapted from StrReplace written by dandaman32
+# $0 - STR_NEEDLE: The string to search for.
+# $1 - STR_HAYSTACK: The string to search in.
+# Returns:
+# $0 The substring if found, else "".
+Function StrContains
+    Exch $STR_NEEDLE
+    Exch 1
+    Exch $STR_HAYSTACK
+    StrCpy $STR_RETURN_VAR ""
+    StrCpy $STR_CONTAINS_VAR_1 -1
+    StrLen $STR_CONTAINS_VAR_2 $STR_NEEDLE
+    StrLen $STR_CONTAINS_VAR_4 $STR_HAYSTACK
+    loop:
+        IntOp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_1 + 1
+        StrCpy $STR_CONTAINS_VAR_3 $STR_HAYSTACK $STR_CONTAINS_VAR_2 $STR_CONTAINS_VAR_1
+        StrCmp $STR_CONTAINS_VAR_3 $STR_NEEDLE found
+        StrCmp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_4 done
+        Goto loop
+    found:
+        StrCpy $STR_RETURN_VAR $STR_NEEDLE
+        Goto done
+    done:
+    Pop $STR_NEEDLE
+    Exch $STR_RETURN_VAR
+FunctionEnd
+!macro _StrContainsConstructor OUT NEEDLE HAYSTACK
+    Push `${HAYSTACK}`
+    Push `${NEEDLE}`
+    Call StrContains
+    Pop `${OUT}`
+!macroend
+!define StrContains '!insertmacro "_StrContainsConstructor"'

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -1,6 +1,7 @@
 !include LogicLib.nsh
 !include x64.nsh
 !include nsProcess.nsh
+!include StrUtils.nsh
 
 !define ERROR_ALREADY_EXISTS 0x000000b7
 !define ERROR_ACCESS_DENIED 0x5
@@ -57,9 +58,8 @@
         Delete $0
         ${if} ${errors}
             MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
-                "Error deleting file:$\r$\n$\r$\n$0$\r$\n$\r$\nClick Retry to try again, or$\r$\n\
-                Cancel to stop the uninstall." /SD IDCANCEL IDRETRY try
-            Abort "Error deleting file $0"
+                "$(FileDeleteErrorDialog)" /SD IDCANCEL IDRETRY try
+            Abort "$(FileDeleteError)"
         ${endif}
     FunctionEnd
 !macroend
@@ -112,50 +112,6 @@
         ExecWait '$1 /SS $2 _?=$3' $0
 FunctionEnd
 !endif # UNINSTALL_BUILDER
-
-Var STR_HAYSTACK
-Var STR_NEEDLE
-Var STR_CONTAINS_VAR_1
-Var STR_CONTAINS_VAR_2
-Var STR_CONTAINS_VAR_3
-Var STR_CONTAINS_VAR_4
-Var STR_RETURN_VAR
-
-
-# This function does a case sensitive searches for an occurrence of a substring in a string.
-# Written by kenglish_hi, adapted from StrReplace written by dandaman32
-# $0 - STR_NEEDLE: The string to search for.
-# $1 - STR_HAYSTACK: The string to search in.
-# Returns:
-# $0 The substring if found, else "".
-Function StrContains
-    Exch $STR_NEEDLE
-    Exch 1
-    Exch $STR_HAYSTACK
-    StrCpy $STR_RETURN_VAR ""
-    StrCpy $STR_CONTAINS_VAR_1 -1
-    StrLen $STR_CONTAINS_VAR_2 $STR_NEEDLE
-    StrLen $STR_CONTAINS_VAR_4 $STR_HAYSTACK
-    loop:
-        IntOp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_1 + 1
-        StrCpy $STR_CONTAINS_VAR_3 $STR_HAYSTACK $STR_CONTAINS_VAR_2 $STR_CONTAINS_VAR_1
-        StrCmp $STR_CONTAINS_VAR_3 $STR_NEEDLE found
-        StrCmp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_4 done
-        Goto loop
-    found:
-        StrCpy $STR_RETURN_VAR $STR_NEEDLE
-        Goto done
-    done:
-    Pop $STR_NEEDLE
-    Exch $STR_RETURN_VAR
-FunctionEnd
-!macro _StrContainsConstructor OUT NEEDLE HAYSTACK
-    Push `${HAYSTACK}`
-    Push `${NEEDLE}`
-    Call StrContains
-    Pop `${OUT}`
-!macroend
-!define StrContains '!insertmacro "_StrContainsConstructor"'
 
 Var STR_CAO_CHARACTERS
 Var STR_CAO_STRING
@@ -263,17 +219,14 @@ FunctionEnd
 !macro CheckPlatform PLATFORM
     ${if} ${RunningX64}
         !if ${PLATFORM} == x86
-            MessageBox MB_OKCANCEL|MB_ICONINFORMATION "You are about to install the 32-bit version \
-                of ${PRODUCT_NAME} on your 64-bit Windows. There is a 64-bit version of \
-                ${PRODUCT_NAME} available for download." /SD IDOK IDOK Continue
+            MessageBox MB_OKCANCEL|MB_ICONINFORMATION \
+                "$(Install64On32BitWarning)" /SD IDOK IDOK Continue
             Quit
             Continue:
         !endif
     ${else}
         !if ${PLATFORM} == x64
-            MessageBox MB_ICONSTOP "This installer contains the 64-bit version of ${PRODUCT_NAME}. \
-                Your computer is running a 32-bit version of Windows, which can not execute 64-bit \
-                programs. Please download the 32-bit installer of ${PRODUCT_NAME}." /SD IDOK
+            MessageBox MB_ICONSTOP "$(Install32On64BitError)" /SD IDOK
             Quit
         !endif
     ${endif}
@@ -283,7 +236,7 @@ FunctionEnd
 # MIN_WIN_VER: The minimal windows version.
 !macro CheckMinWinVer MIN_WIN_VER
     ${ifNot} ${AtLeastWin${MIN_WIN_VER}}
-        MessageBox MB_ICONSTOP "This program requires at least Windows ${MIN_WIN_VER}." /SD IDOK
+        MessageBox MB_ICONSTOP "$(UnsupportedWindowsVersionError)" /SD IDOK
         Quit
     ${endif}
 !macroend
@@ -318,13 +271,12 @@ FunctionEnd
         MessageBox MB_OKCANCEL|MB_ICONQUESTION "${DIALOG_FIRST}" \
             /SD IDOK IDOK tryKill IDCANCEL stopFailed
         stopFailed:
-            MessageBox MB_OK|MB_ICONSTOP \
-                "Uninstalling ${PRODUCT_NAME} has been aborted. Please try again later." /SD IDOK
+            MessageBox MB_OK|MB_ICONSTOP "$(UninstallerAborted)" /SD IDOK
             SetErrorLevel ${ERROR_SIGNAL_REFUSED}
             Quit
         tryKill:
         ${doWhile} $R0 == 0
-            DetailPrint "Closing process ${EXE_NAME}"
+            DetailPrint "$(StoppingBirdtray)"
             ${nsProcess::CloseProcess} ${EXE_NAME} $R0
             ${if} $R0 == 0 # Successfully killed the process
                 Sleep 100

--- a/installer/buildInstaller.bat
+++ b/installer/buildInstaller.bat
@@ -200,6 +200,37 @@ if errorLevel 1 (
     echo to the deployment folder at %dependencyFolder%\Plugins\x86-unicode 1>&2
     exit /b %errorLevel%
 )
+set "nsisXMLUrl=https://nsis.sourceforge.io/mediawiki/images/5/55/Xml.zip"
+"%curlExe%" --silent --output "%TEMP%\nsisXML.zip" "%nsisXMLUrl%" 1>nul
+if errorLevel 1 (
+    echo Failed to download nsisXML 1>&2
+    exit /b %errorLevel%
+)
+"%sevenZExe%" e -y -o"%TEMP%\nsisXML" "%TEMP%\nsisXML.zip" 1>nul
+if errorLevel 1 (
+    echo Failed to extract nsisXML 1>&2
+    exit /b %errorLevel%
+)
+del "%TEMP%\nsisXML.zip" /F
+xcopy "%TEMP%\nsisXML\XML.nsh" "%dependencyFolder%\Include" /q /y 1>nul
+if errorLevel 1 (
+    echo Failed to copy the nsisXML library from %TEMP%\nsisXML\XML.nsh 1>&2
+    echo to the deployment folder at %dependencyFolder%\Include 1>&2
+    exit /b %errorLevel%
+)
+xcopy "%TEMP%\nsisXML\xml.dll" "%dependencyFolder%\Plugins\x86-ansi" /q /y 1>nul
+if errorLevel 1 (
+    echo Failed to copy the nsisXML library from %TEMP%\nsisXML\xml.dll 1>&2
+    echo to the deployment folder at %dependencyFolder%\Plugins\x86-ansi 1>&2
+    exit /b %errorLevel%
+)
+xcopy "%TEMP%\nsisXML\xml.dll" "%dependencyFolder%\Plugins\x86-unicode" /q /y 1>nul
+if errorLevel 1 (
+    echo Failed to copy the nsisXML library from %TEMP%\nsisXML\xml.dll 1>&2
+    echo to the deployment folder at %dependencyFolder%\Plugins\x86-unicode 1>&2
+    exit /b %errorLevel%
+)
+rmdir /s /q "%TEMP%\nsisXML" 1>nul
 
 rem  #### Create the actual installer ####
 echo Creating the installer...

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -56,18 +56,6 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define URL_INFO_ABOUT "https://www.ulduzsoft.com/" # "Publisher" link
 !define MIN_WINDOWS_VER "XP"
 
-# Section descriptions
-!define BIRDTRAY_SECTION_DESCRIPTION "A free system tray notification for new mail for Thunderbird."
-!define WIN_INTEGRATION_GROUP_DESCRIPTION "Select how to integrate the program in Windows."
-!define AUTO_RUN_DESCRIPTION "Automatically start ${PRODUCT_NAME} after login."
-!define AUTO_CHECK_UPDATE_DESCRIPTION \
-        "Automatically search for updates of ${PRODUCT_NAME} at startup."
-!define PROGRAM_GROUP_DESCRIPTION \
-        "Create a ${PRODUCT_NAME} program group under Start Menu > Programs."
-!define DESKTOP_ENTRY_DESCRIPTION "Create a ${PRODUCT_NAME} icon on the Desktop."
-!define START_MENU_DESCRIPTION "Create a ${PRODUCT_NAME} icon in the Start Menu."
-!define USER_SETTINGS_DESCRIPTION "Your settings and configuration made within ${PRODUCT_NAME}."
-
 # Paths
 !define EXE_NAME "birdtray.exe"
 !define PROGEXE ${EXE_NAME}  # For the MultiUser plugin
@@ -85,13 +73,14 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define UNINSTALL_BUILDER_FILE "uninstall_builder.exe"
 !define UNINSTALL_LIST_BUILDER_FILE "makeUninstallList.exe"
 !define UNINSTALL_LIST_FILENAME "uninstall_list.nsh"
+!define INSTALLER_TRANSLATIONS_BUILDER_FILE "makeInstallerTranslations.exe"
+!define INSTALLER_TRANSLATIONS_FILENAME "installerTranslations.nsi"
 !define HEADER_IMG_FILE "assets\header.bmp"
 !define SIDEBAR_IMG_FILE "assets\sidebar.bmp"
 !define INSTALL_CONFIG_FILE ".installConfig.ini"
 
 # Other
 !define BAD_PATH_CHARS '?%*:|"<>!;'
-!define LICENSE_START_MENU_LINK_NAME "License Agreement"
 !define SETUP_MUTEX "${COMPANY_NAME} ${PRODUCT_NAME} Setup Mutex" # Don't change this
 
 # === Automatic configuration based on the birdtray executable === #
@@ -123,7 +112,7 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "StartMenuFolder"
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER "${PRODUCT_NAME}"
 !define MUI_FINISHPAGE_RUN
-!define MUI_FINISHPAGE_RUN_TEXT "Start ${PRODUCT_NAME}"
+!define MUI_FINISHPAGE_RUN_TEXT "$(FinishPageRunBirdtray)"
 !define MUI_FINISHPAGE_RUN_FUNCTION StartAppBirdTray
 !define MUI_LANGDLL_ALLLANGUAGES
 !define MUI_LANGDLL_REGISTRY_ROOT SHCTX
@@ -133,7 +122,7 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP ${SIDEBAR_IMG_FILE}
 !define MUI_UNICON ${MUI_ICON} # Same icon for installer and un-installer.
 !define MUI_UNABORTWARNING
-!define MUI_UNCONFIRMPAGE_TEXT_TOP "Click uninstall to begin the process."
+!define MUI_UNCONFIRMPAGE_TEXT_TOP "$(UninstallerConfirmation)"
 !endif # UNINSTALL_BUILDER
 
 # MultiUser config
@@ -232,12 +221,18 @@ VIAddVersionKey LegalCopyright ""
 
 !define MUI_PAGE_CUSTOMFUNCTION_PRE un.FinishPageShow
 !insertmacro MUI_UNPAGE_FINISH
-!endif # UNINSTALL_BUILDER
-
 
 # Installer/Uninstaller languages
-!insertmacro MUI_LANGUAGE "English"
-# Add more languages here
+!makensis '/DINSTALLER_TRANSLATIONS_BUILDER_FILE="${INSTALLER_TRANSLATIONS_BUILDER_FILE}" \
+        /DINSTALLER_TRANSLATIONS_FILENAME="${INSTALLER_TRANSLATIONS_FILENAME}" \
+        makeInstallerTranslations.nsi' = 0
+!system "${INSTALLER_TRANSLATIONS_BUILDER_FILE}" = 0
+!include "${INSTALLER_TRANSLATIONS_FILENAME}"
+!delfile "${INSTALLER_TRANSLATIONS_BUILDER_FILE}"
+!else
+!include "${INSTALLER_TRANSLATIONS_FILENAME}"
+!delfile "${INSTALLER_TRANSLATIONS_FILENAME}"
+!endif # UNINSTALL_BUILDER
 
 !insertmacro MULTIUSER_LANGUAGE_INIT
 !insertmacro MUI_RESERVEFILE_LANGDLL # Make language data faster to decompress at startup
@@ -252,11 +247,8 @@ Section "${PRODUCT_NAME}" SectionBirdTray
     !ifndef UNINSTALL_BUILDER
     !insertmacro UAC_AsUser_Call Function CheckInstallation ${UAC_SYNCREGISTERS}
     ${if} $0 != ""
-        DetailPrint "Uninstalling previous version of ${PRODUCT_NAME}"
-        !insertmacro STOP_PROCESS ${EXE_NAME} "${PRODUCT_NAME} is currently running. \
-                Press OK to stop ${PRODUCT_NAME} to continue with the installation." \
-                "Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually \
-                to continue with the installation."
+        DetailPrint "$(UninstallPreviousVersion)"
+        !insertmacro STOP_PROCESS ${EXE_NAME} "$(StopBirdtray)" "$(StopBirdtrayError)"
         ClearErrors
         ${if} $0 == "AllUsers"
             Call RunUninstaller
@@ -264,12 +256,11 @@ Section "${PRODUCT_NAME}" SectionBirdTray
             !insertmacro UAC_AsUser_Call Function RunUninstaller ${UAC_SYNCREGISTERS}
         ${endif}
         ${if} ${errors} # Stay in installer
-            MessageBox MB_OKCANCEL|MB_ICONSTOP \
-                            "Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing \
-                            will delete EVERYTHING in $3." /SD IDCANCEL IDOK Ignore
+            MessageBox MB_OKCANCEL|MB_ICONSTOP "$(UninstallPreviousVersionError)" \
+                /SD IDCANCEL IDOK Ignore
             SetErrorLevel 2 # Installation aborted by script
             BringToFront
-            Abort "Error executing uninstaller."
+            Abort "$(UninstallExecutionError)"
             Ignore:
             RMDir /r "$3"
         ${else}
@@ -286,7 +277,7 @@ Section "${PRODUCT_NAME}" SectionBirdTray
                 ${default} # All other error codes - Abort installer
                     SetErrorLevel $0
                     BringToFront
-                    Abort "Error executing uninstaller."
+                    Abort "$(UninstallExecutionError)"
             ${EndSwitch}
         ${endif}
 
@@ -321,15 +312,15 @@ SectionEnd
 
 !ifndef UNINSTALL_BUILDER
 
-SectionGroup /e "Windows integration" SectionGroupWinIntegration
-Section "Program Group Entry" SectionProgramGroup
+SectionGroup /e "$(WinIntegrationSectionName)" SectionGroupWinIntegration
+Section "$(ProgramGroupSectionName)" SectionProgramGroup
     !insertmacro MUI_STARTMENU_WRITE_BEGIN ""
 
     CreateDirectory "$SMPROGRAMS\$startMenuFolder"
     CreateShortCut "$SMPROGRAMS\$startMenuFolder\${PRODUCT_NAME}.lnk" "$INSTDIR\${EXE_NAME}"
 
     !ifdef INSTALL_LICENSE
-        CreateShortCut "$SMPROGRAMS\$startMenuFolder\${LICENSE_START_MENU_LINK_NAME}.lnk" \
+        CreateShortCut "$SMPROGRAMS\$startMenuFolder\$(LicenseStartMenuLinkName).lnk" \
             "$INSTDIR\${LICENSE_FILE}"
     !endif
     ${if} $MultiUser.InstallMode == "AllUsers"
@@ -343,22 +334,22 @@ Section "Program Group Entry" SectionProgramGroup
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
-Section "Desktop Entry" SectionDesktopEntry
+Section "$(DesktopEntrySectionName)" SectionDesktopEntry
     CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\${EXE_NAME}"
 SectionEnd
 
-Section /o "Start Menu Entry" SectionStartMenuEntry
+Section /o "$(StartMenuSectionName)" SectionStartMenuEntry
     CreateShortCut "$STARTMENU\${PRODUCT_NAME}.lnk" "$INSTDIR\${EXE_NAME}"
 SectionEnd
 
-Section /o "AutoRun" SectionAutoRun
+Section /o "$(AutoRunSectionName)" SectionAutoRun
     WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Run" \
         "${PRODUCT_NAME}" "$\"$INSTDIR\${EXE_NAME}$\""
     AddSize 1
 SectionEnd
 SectionGroupEnd
 
-Section "Auto Update-Check" SectionAutoCheckUpdate
+Section "$(AutoCheckUpdateSectionName)" SectionAutoCheckUpdate
     ${StrCase} $0 "${COMPANY_NAME}" "L"
     ${StrCase} $1 "${PRODUCT_NAME}" "L"
     DeleteRegValue HKCU "${USER_SETTINGS_REG_PATH}" "hasReadInstallConfig"
@@ -374,14 +365,14 @@ Section "-Write Install Size" # Hidden section, write install size as the final 
 SectionEnd
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionBirdTray} "${BIRDTRAY_SECTION_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoRun} "${AUTO_RUN_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoCheckUpdate} "${AUTO_CHECK_UPDATE_DESCRIPTION}"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionBirdTray} "$(BirdtraySectionDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoRun} "$(AutoRunDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionAutoCheckUpdate} "$(AutoCheckUpdateDescription)"
     !insertmacro MUI_DESCRIPTION_TEXT ${SectionGroupWinIntegration} \
-            "${WIN_INTEGRATION_GROUP_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionProgramGroup} "${PROGRAM_GROUP_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionDesktopEntry} "${DESKTOP_ENTRY_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${SectionStartMenuEntry} "${START_MENU_DESCRIPTION}"
+            "$(WinIntegrationGroupDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionProgramGroup} "$(ProgramGroupDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionDesktopEntry} "$(DesktopEntryDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${SectionStartMenuEntry} "$(StartMenuDescription)"
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 !endif # UNINSTALL_BUILDER
@@ -428,7 +419,7 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
 
 SectionEnd
 
-Section /o "un.${PRODUCT_NAME} User Settings" UNSectionUserSettings
+Section /o "un.$(UserSettingsSectionName)" UNSectionUserSettings
     DeleteRegKey HKCU "${USER_SETTINGS_REG_PATH}"
     DeleteRegKey /ifempty HKCU "${USER_REG_PATH}"
 SectionEnd
@@ -454,8 +445,8 @@ Section -un.Post UNSectionSystem
 SectionEnd
 
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${UNSectionBirdTray} "${BIRDTRAY_SECTION_DESCRIPTION}"
-    !insertmacro MUI_DESCRIPTION_TEXT ${UNSectionUserSettings} "${USER_SETTINGS_DESCRIPTION}"
+    !insertmacro MUI_DESCRIPTION_TEXT ${UNSectionBirdTray} "$(BirdtraySectionDescription)"
+    !insertmacro MUI_DESCRIPTION_TEXT ${UNSectionUserSettings} "$(UserSettingsDescription)"
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_END
 !endif # UNINSTALL_BUILDER
 
@@ -482,9 +473,7 @@ Function .onInit
     !insertmacro CheckMinWinVer ${MIN_WINDOWS_VER}
     ${ifNot} ${UAC_IsInnerInstance}
         !insertmacro CheckPlatform ${Arch}
-        !insertmacro CheckSingleInstance "The setup of ${PRODUCT_NAME} is already running.$\r$\n \
-            Please, close all instances of it and click Retry to continue, or Cancel to exit." \
-            "Global" "${SETUP_MUTEX}"
+        !insertmacro CheckSingleInstance "$(SetupAlreadyRunning)" "Global" "${SETUP_MUTEX}"
     ${endif}
 
     !insertmacro MULTIUSER_INIT
@@ -539,8 +528,7 @@ FunctionEnd
 Function DirectoryPageLeave
     ${ValidPath} $0 $INSTDIR ${BAD_PATH_CHARS}
     ${if} $0 != 0
-        MessageBox MB_OK|MB_ICONEXCLAMATION \
-                'The install path must not contain any of ${BAD_PATH_CHARS}.' /SD IDOK
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(BadInstallPath)" /SD IDOK
         Abort
     ${endif}
     ${IsDirEmpty} $0 $INSTDIR
@@ -548,14 +536,10 @@ Function DirectoryPageLeave
         IfFileExists $INSTDIR\${EXE_NAME} 0 DirNotEmptyNoBirdtray
         IfFileExists $INSTDIR\${UNINSTALL_FILENAME} 0 DirNotEmptyNoBirdtray
         MessageBox MB_OKCANCEL|MB_ICONINFORMATION \
-                        "The install path contains a previously installed ${PRODUCT_NAME} version, \
-                        which will be replaced." /SD IDOK IDOK Ignore
+                        "$(InstallPathContainsPreviousVersion)" /SD IDOK IDOK Ignore
         Abort
         DirNotEmptyNoBirdtray:
-        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-                "The install path is not empty, but it doesn't look like it contains a previous \
-                ${PRODUCT_NAME} installation. The content will get overwritten." \
-                /SD IDOK IDOK Ignore
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "$(InstallPathNotEmpty)" /SD IDOK IDOK Ignore
         Abort
         Ignore:
     ${endif}
@@ -577,10 +561,10 @@ Function ComponentsPagePre
     ${endif}
 
     ${if} $MultiUser.InstallMode == "AllUsers"
-        # Add "(current user only)" text to sections "Start Menu Icon" and "Quick Launch Icon"
+        # Add "(current user only)" text to sections "Start Menu Icon"
         ${if} ${AtLeastWin7}
             SectionGetText ${SectionStartMenuEntry} $0
-            SectionSetText ${SectionStartMenuEntry} "$0 (current user only)"
+            SectionSetText ${SectionStartMenuEntry} "$(CurrentUserOnly)"
         ${endif}
     ${endif}
     !endif # UNINSTALL_BUILDER
@@ -625,8 +609,7 @@ Function InstallerPagePre
 FunctionEnd
 
 Function .onInstFailed
-    MessageBox MB_ICONSTOP "${PRODUCT_NAME} ${VERSION} could not be fully installed.$\r$\n\
-        Please, restart Windows and run the setup program again." /SD IDOK
+    MessageBox MB_ICONSTOP "$(InstallFailed)" /SD IDOK
 FunctionEnd
 
 # === Uninstaller functions === #
@@ -652,9 +635,7 @@ Function un.onInit
 
     ${ifNot} ${UAC_IsInnerInstance}
     ${andIf} $RunningFromInstaller == 0
-        !insertmacro CheckSingleInstance "The uninstall of ${PRODUCT_NAME} is already running.$\r\
-            $\n Please, close all instances of it and click Retry to continue, or Cancel to exit." \
-            "Global" "${SETUP_MUTEX}"
+        !insertmacro CheckSingleInstance "$(UninstallAlreadyRunning)" "Global" "${SETUP_MUTEX}"
     ${endif}
 
     !insertmacro MULTIUSER_UNINIT
@@ -662,10 +643,7 @@ Function un.onInit
     # We always get the language, since the outer and inner instance might have different language
     !insertmacro MUI_UNGETLANGUAGE
 
-    !insertmacro STOP_PROCESS ${EXE_NAME} "${PRODUCT_NAME} is currently running. \
-        Press OK to stop ${PRODUCT_NAME} to continue with the uninstall." \
-        "Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually \
-        to continue with the uninstall."
+    !insertmacro STOP_PROCESS ${EXE_NAME} "$(StopBirdtrayUninstall)" "$(StopBirdtrayUninstallError)"
 FunctionEnd
 
 Function un.InstallModePageChangeMode
@@ -704,11 +682,9 @@ FunctionEnd
 
 Function un.onUninstFailed
     ${if} $SemiSilentMode == 0
-        MessageBox MB_ICONSTOP "${PRODUCT_NAME} ${VERSION} could not be fully uninstalled.$\r$\n\
-            Please, restart Windows and run the uninstaller again." /SD IDOK
+        MessageBox MB_ICONSTOP "$(UninstallFailed)" /SD IDOK
     ${else}
-        MessageBox MB_ICONSTOP "${PRODUCT_NAME} could not be fully installed.$\r$\n\
-            Please, restart Windows and run the setup program again." /SD IDOK
+        MessageBox MB_ICONSTOP "$(InstallFailedCauseUninstallerFailed)" /SD IDOK
     ${endif}
 FunctionEnd
 

--- a/installer/makeInstallerTranslations.nsi
+++ b/installer/makeInstallerTranslations.nsi
@@ -75,16 +75,16 @@ FunctionEnd
 # $R0 - OUTPUT_FILE: The file to write the translations to.
 # $R1 - TRANSLATION_FOLDER: The directory that contains the translations.
 Function CreateTranslations
-	Pop $R1  # translations folder
-	Pop $R0	 # output file
+    Pop $R1  # translations folder
+    Pop $R0	 # output file
 
     FileOpen $R4 $R0 w
-	ClearErrors
+    ClearErrors
 
-	FindFirst $R2 $R3 "$R1\installer_*.ts"
+    FindFirst $R2 $R3 "$R1\installer_*.ts"
 
 CreateTranslations_Loop:
-	IfErrors CreateTranslations_Done
+    IfErrors CreateTranslations_Done
 
     ${xml::LoadFile} "$R1\$R3" $0
     ${if} $0 = -1
@@ -134,13 +134,13 @@ CreateTranslations_Loop:
         ${endif}
         ${xml::NextSiblingElement} "message" $1 $0
     ${loop}
-	ClearErrors
-	FindNext $R2 $R3
-	Goto CreateTranslations_Loop
+    ClearErrors
+    FindNext $R2 $R3
+    Goto CreateTranslations_Loop
 
 CreateTranslations_Done:
-	FindClose $R2
-	FileClose $R4
+    FindClose $R2
+    FileClose $R4
 FunctionEnd
 
 

--- a/installer/makeInstallerTranslations.nsi
+++ b/installer/makeInstallerTranslations.nsi
@@ -1,0 +1,158 @@
+!addplugindir /x86-ansi nsisDependencies\Plugins\x86-ansi
+!addplugindir /x86-unicode nsisDependencies\Plugins\x86-unicode
+!addincludedir nsisDependencies\Include
+!addincludedir .
+
+!include XML.nsh
+!include LogicLib.nsh
+!include StrFunc.nsh
+!Include StrUtils.nsh
+${StrCase}
+
+SetCompress off
+Name "makeTranslationsList"
+OutFile "${INSTALLER_TRANSLATIONS_BUILDER_FILE}"
+SilentInstall silent
+RequestExecutionLevel user
+
+
+# Gets the text contents of a child node of the current xml node .
+# $0 - NAME: The name of the child node.
+# Returns:
+# $0 - TEXT: The text of the child node.
+# $1 - RESULT: 0 on success, -1 on failure.
+Function GetNodeText
+    Exch $1
+    Push $0
+    ${xml::FirstChildElement} "$1" $0 $0
+    ${if} $0 != -1
+        ${xml::GetText} $1 $0
+        ${if} $0 != -1
+            ${xml::Parent} $0 $0
+        ${else}
+            ${xml::Parent} $1 $1 # Preserve the error in $0
+        ${endif}
+    ${endif}
+    Exch $0
+    Exch 1
+    Exch $1
+FunctionEnd
+
+!macro GetNodeText NODE RESULT TEXT
+    Push ${NODE}
+    Call GetNodeText
+    Pop ${TEXT}
+    Pop ${RESULT}
+!macroend
+!define GetNodeText '!insertmacro GetNodeText'
+
+# Parse the current xml node as a message node.
+# Returns:
+# $0 - RESULT: 0 on success, -1 on failure.
+# $1 - SOURCE: The text in the source element.
+# $2 - TRANSLATION: The text in the translation element.
+Function ParseMessageNode
+    ${GetNodeText} "source" $0 $1
+    ${if} $0 != -1
+        ${GetNodeText} "translation" $0 $2
+    ${endif}
+    Push $2
+    Push $1
+    Push $0
+FunctionEnd
+
+!macro ParseMessageNode RESULT SOURCE TRANSLATION
+    Call ParseMessageNode
+    Pop ${RESULT}
+    Pop ${SOURCE}
+    Pop ${TRANSLATION}
+!macroend
+!define ParseMessageNode '!insertmacro ParseMessageNode'
+
+
+
+# Create a file containing NSIS translations for the installer.
+# $R0 - OUTPUT_FILE: The file to write the translations to.
+# $R1 - TRANSLATION_FOLDER: The directory that contains the translations.
+Function CreateTranslations
+	Pop $R1  # translations folder
+	Pop $R0	 # output file
+
+    FileOpen $R4 $R0 w
+	ClearErrors
+
+	FindFirst $R2 $R3 "$R1\installer_*.ts"
+
+CreateTranslations_Loop:
+	IfErrors CreateTranslations_Done
+
+    ${xml::LoadFile} "$R1\$R3" $0
+    ${if} $0 = -1
+        Abort "Failed to open translation at $R1\$R3"
+    ${endif}
+    ${xml::RootElement} $1 $0
+    ${if} $0 = -1
+        Abort "Failed to find the root element in $R1\$R3"
+    ${endif}
+    ${xml::FirstChildElement} "context" $1 $0
+    ${if} $0 = -1
+        Abort "Failed to find the 'context' child in $R1\$R3"
+    ${endif}
+
+    ${xml::FirstChildElement} "message" $1 $0
+    ${doWhile} $0 != -1
+        ${ParseMessageNode} $0 $1 $2
+        ${if} $0 = -1
+            Abort "Failed to parse message node"
+        ${endif}
+        ${if} $1 == "__LANGUAGE_NAME__"
+            FileWrite $R4 '!insertmacro MUI_LANGUAGE "$2"$\r$\n'
+            ${StrCase} $3 $2 "U"
+            ${xml::RemoveNode} $0
+            ${break}
+        ${endif}
+        ${xml::NextSiblingElement} "message" $1 $0
+    ${loop}
+    ${if} $0 = -1
+        Abort "Failed to find the '__LANGUAGE_NAME__' child in $R1\$R3"
+    ${endif}
+
+    ${xml::FirstChildElement} "message" $1 $0
+    ${doWhile} $0 != -1
+        ${ParseMessageNode} $0 $1 $2
+        ${if} $0 = -1
+            Abort "Failed to parse message node"
+        ${endif}
+        ${StrContains} $0 "$${BAD_PATH_CHARS}" $2
+        ${if} $0 == ""
+            ${StrContains} $0 '"' $2
+        ${endif}
+        ${if} $0 != ""
+            FileWrite $R4 "LangString $1 $${LANG_$3} '$2'$\r$\n"
+        ${else}
+            FileWrite $R4 'LangString $1 $${LANG_$3} "$2"$\r$\n'
+        ${endif}
+        ${xml::NextSiblingElement} "message" $1 $0
+    ${loop}
+	ClearErrors
+	FindNext $R2 $R3
+	Goto CreateTranslations_Loop
+
+CreateTranslations_Done:
+	FindClose $R2
+	FileClose $R4
+FunctionEnd
+
+
+!macro CreateTranslations TRANSLATIONS_FOLDER OUTPUT_FILE_PATH
+    Push ${OUTPUT_FILE_PATH} # output file
+    Push ${TRANSLATIONS_FOLDER} # translations folder
+    Call CreateTranslations
+!macroend
+!define CreateTranslations '!insertmacro CreateTranslations'
+
+Section
+    System::Call "kernel32::GetCurrentDirectory(i ${NSIS_MAX_STRLEN}, t .r0)"
+    GetFullPathName $0 "$0\..\src\translations"
+    ${CreateTranslations} $0 "${INSTALLER_TRANSLATIONS_FILENAME}"
+SectionEnd

--- a/installer/makeUninstallList.nsi
+++ b/installer/makeUninstallList.nsi
@@ -63,73 +63,73 @@ FunctionEnd
 # $R2 - LOCAL_FOLDER: The current folder relative to the global folder to examine.
 # $R3 - GLOBAL_FOLDER: The global root folder from where the search starts.
 Function MakeRecurrentFileList
-	Pop $R3  # global folder
-	Pop $R2	 # local folder
-	Pop $R1	 # filter
-	Pop $R0	 # output file
+    Pop $R3  # global folder
+    Pop $R2	 # local folder
+    Pop $R1	 # filter
+    Pop $R0	 # output file
 
-	ClearErrors
-	FindFirst $R4 $R5 "$R3\$R2\*.*"
+    ClearErrors
+    FindFirst $R4 $R5 "$R3\$R2\*.*"
 
 MakeRecurrentFileList_Loop:
-	IfErrors MakeRecurrentFileList_Done
-	# check if it is folder
-	IfFileExists "$R3\$R2\$R5\*.*"  0 MakeRecurrentFileList_file
-	# directory
-	StrCmp $R5 "." MakeRecurrentFileList_next			# skip current folder
-	StrCmp $R5 ".." MakeRecurrentFileList_next			# skip parent folder
-	# go Recurrent
-	# save current variables
-	Push $R5
-	Push $R4
-	Push $R3
-	Push $R2
-	Push $R1
-	Push $R0
+    IfErrors MakeRecurrentFileList_Done
+    # check if it is folder
+    IfFileExists "$R3\$R2\$R5\*.*"  0 MakeRecurrentFileList_file
+    # directory
+    StrCmp $R5 "." MakeRecurrentFileList_next			# skip current folder
+    StrCmp $R5 ".." MakeRecurrentFileList_next			# skip parent folder
+    # go Recurrent
+    # save current variables
+    Push $R5
+    Push $R4
+    Push $R3
+    Push $R2
+    Push $R1
+    Push $R0
 
-	# set parameters
-	Push $R0		# output file
-	Push $R1		# filter
-	Push "$R2\$R5"	# local folder
-	Push $R3		# global folder
-	Call MakeRecurrentFileList
-	# restore current variables
-	Pop $R0
-	Pop $R1
-	Pop $R2
-	Pop $R3
-	Pop $R4
-	Pop $R5
+    # set parameters
+    Push $R0		# output file
+    Push $R1		# filter
+    Push "$R2\$R5"	# local folder
+    Push $R3		# global folder
+    Call MakeRecurrentFileList
+    # restore current variables
+    Pop $R0
+    Pop $R1
+    Pop $R2
+    Pop $R3
+    Pop $R4
+    Pop $R5
 
     Push $R1
-	FileOpen $R6 $R0 a
+    FileOpen $R6 $R0 a
     FileSeek $R6 0 END
     ${StrStrip} ".\" "$R2\$R5" $R1
     FileWrite $R6 "RMDir $\"$$INSTDIR\$R1$\"$\r$\n"
     FileClose $R6
     Pop $R1
-	Goto MakeRecurrentFileList_next
+    Goto MakeRecurrentFileList_next
 
 MakeRecurrentFileList_file:
-	# use filter
-	StrCmp $R1 $R5 MakeRecurrentFileList_skip
-	# filter found, add file to list
-	Push $R1
-	FileOpen $R6 $R0 a
-	FileSeek $R6 0 END
-	${StrStrip} ".\" "$R2\$R5" $R1
-	FileWrite $R6 "!insertmacro DeleteRetryAbort $\"$$INSTDIR\$R1$\"$\r$\n"
-	FileClose $R6
-	Pop $R1
+    # use filter
+    StrCmp $R1 $R5 MakeRecurrentFileList_skip
+    # filter found, add file to list
+    Push $R1
+    FileOpen $R6 $R0 a
+    FileSeek $R6 0 END
+    ${StrStrip} ".\" "$R2\$R5" $R1
+    FileWrite $R6 "!insertmacro DeleteRetryAbort $\"$$INSTDIR\$R1$\"$\r$\n"
+    FileClose $R6
+    Pop $R1
 
 MakeRecurrentFileList_skip:
 MakeRecurrentFileList_next:
-	ClearErrors
-	FindNext $R4 $R5
-	Goto MakeRecurrentFileList_Loop
+    ClearErrors
+    FindNext $R4 $R5
+    Goto MakeRecurrentFileList_Loop
 
 MakeRecurrentFileList_Done:
-	FindClose $R4
+    FindClose $R4
 FunctionEnd
 
 

--- a/src/translations/installer_de.ts
+++ b/src/translations/installer_de.ts
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>WindowsInstaller</name>
+    <message>
+        <source>__LANGUAGE_NAME__</source>
+        <translatorcomment>This must be the name of one of the NSIS translation files at https://sourceforge.net/p/nsis/code/HEAD/tree/NSIS/trunk/Contrib/Language%20files/ without the file extension.</translatorcomment>
+        <translation>German</translation>
+    </message>
+    <message>
+        <source>BirdtraySectionDescription</source>
+        <translation>Ein freies Taskleisten Benachrichtigungsprogramm für neue Mails von Thunderbird.</translation>
+    </message>
+    <message>
+        <source>WinIntegrationSectionName</source>
+        <translation>Windows Integration</translation>
+    </message>
+    <message>
+        <source>WinIntegrationGroupDescription</source>
+        <translation>Wähle aus, wie ${PRODUCT_NAME} in Windows integriert werden soll.</translation>
+    </message>
+    <message>
+        <source>AutoRunSectionName</source>
+        <translation>Autostart</translation>
+    </message>
+    <message>
+        <source>AutoRunDescription</source>
+        <translation>Starte ${PRODUCT_NAME} automatisch nach dem Einloggen.</translation>
+    </message>
+    <message>
+        <source>AutoCheckUpdateSectionName</source>
+        <translation>Aktualisierungsüberprüfung</translation>
+    </message>
+    <message>
+        <source>AutoCheckUpdateDescription</source>
+        <translation>Suche beim Starten von ${PRODUCT_NAME} automatisch nach Aktualisierungen.</translation>
+    </message>
+    <message>
+        <source>ProgramGroupSectionName</source>
+        <translation>Programmgruppeneintrag</translation>
+    </message>
+    <message>
+        <source>ProgramGroupDescription</source>
+        <translation>Erstellt eine ${PRODUCT_NAME} Programmgruppe in der Programmliste des Startmenüs.</translation>
+    </message>
+    <message>
+        <source>DesktopEntrySectionName</source>
+        <translation>Desktop Verknüpfung</translation>
+    </message>
+    <message>
+        <source>DesktopEntryDescription</source>
+        <translation>Erstellt eine ${PRODUCT_NAME} Verknüpfung auf dem Desktop.</translation>
+    </message>
+    <message>
+        <source>StartMenuSectionName</source>
+        <translation>Startmenü Verknüpfung</translation>
+    </message>
+    <message>
+        <source>StartMenuDescription</source>
+        <translation>Erstellt eine ${PRODUCT_NAME} Verknüpfung im Startmenü.</translation>
+    </message>
+    <message>
+        <source>UserSettingsSectionName</source>
+        <translation>${PRODUCT_NAME} Benutzerkonfiguration</translation>
+    </message>
+    <message>
+        <source>UserSettingsDescription</source>
+        <translation>Ihre Einstellungen und Konfigurationen in ${PRODUCT_NAME}.</translation>
+    </message>
+    <message>
+        <source>LicenseStartMenuLinkName</source>
+        <translation>Lizenzvereinbarung</translation>
+    </message>
+    <message>
+        <source>FinishPageRunBirdtray</source>
+        <translation>Starte ${PRODUCT_NAME}</translation>
+    </message>
+    <message>
+        <source>UninstallerConfirmation</source>
+        <translation>Klicke &quot;Deinstallieren&quot;, um den Vorgang zu starten.</translation>
+    </message>
+    <message>
+        <source>UninstallPreviousVersion</source>
+        <translation>Deinstalliere vorherige ${PRODUCT_NAME} Version</translation>
+    </message>
+    <message>
+        <source>UninstallPreviousVersionError</source>
+        <translation>Das Deinstallieren der alten ${PRODUCT_NAME} Version ist fehlgeschlagen! Wollen Sie fortfahren und ALLES in $3 löschen.</translation>
+    </message>
+    <message>
+        <source>UninstallExecutionError</source>
+        <translation>Fehler beim Ausführen des Deinstallationsprogramms.</translation>
+    </message>
+    <message>
+        <source>StopBirdtray</source>
+        <translation>${PRODUCT_NAME} wird momentan ausgeführt. Drücken Sie OK, um ${PRODUCT_NAME} zu stoppen und mit der Installation fortzufahren.</translation>
+    </message>
+    <message>
+        <source>StoppingBirdtray</source>
+        <translation>Stoppe Prozess ${EXE_NAME}</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayError</source>
+        <translation>Das Stoppen von ${PRODUCT_NAME} ist fehlgeschlagen. Bitte versuchen Sie es erneut oder schließen Sie ${PRODUCT_NAME} manuell, um mit der Installation fortzufahren.</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayUninstall</source>
+        <translation>${PRODUCT_NAME} wird momentan ausgeführt. Drücken Sie OK, um ${PRODUCT_NAME} zu stoppen und mit der Deinstallation fortzufahren.</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayUninstallError</source>
+        <translation>Das Stoppen von ${PRODUCT_NAME} ist fehlgeschlagen. Bitte versuchen Sie es erneut oder schließen Sie ${PRODUCT_NAME} manuell, um mit der Deinstallation fortzufahren.</translation>
+    </message>
+    <message>
+        <source>SetupAlreadyRunning</source>
+        <translation>Das Installationsprogramm von ${PRODUCT_NAME} wird bereits ausgeführt.$\r$\nBitte schließen Sie alle anderen Instanzen und klicken sie &quot;Wiederholen&quot; um fortzufahren, oder &quot;Abbruch&quot; um die Installation abzubrechen.</translation>
+    </message>
+    <message>
+        <source>UninstallAlreadyRunning</source>
+        <translation>Das Denstallationsprogramm von ${PRODUCT_NAME} wird bereits ausgeführt.$\r$\nBitte schließen Sie alle anderen Instanzen und klicken sie &quot;Wiederholen&quot; um fortzufahren, oder &quot;Abbruch&quot; um die Deinstallation abzubrechen.</translation>
+    </message>
+    <message>
+        <source>BadInstallPath</source>
+        <translation>Der Installationspfad darf keine der folgenden Buchstaben enthalten:$\r$\n${BAD_PATH_CHARS}</translation>
+    </message>
+    <message>
+        <source>InstallPathContainsPreviousVersion</source>
+        <translation>Im Installationspfad wurde eine vorherig installierte ${PRODUCT_NAME} Version gefunden, die ersetzt wird.</translation>
+    </message>
+    <message>
+        <source>InstallPathNotEmpty</source>
+        <translation>Der Installationspfad ist nicht leer, aber scheint keine vorherig installierte ${PRODUCT_NAME} Version zu beinhalten. Der Inhalt des Ordners wird Überschrieben.</translation>
+    </message>
+    <message>
+        <source>CurrentUserOnly</source>
+        <translation>$0 (nur für den momentaner Benutzer)</translation>
+    </message>
+    <message>
+        <source>InstallFailed</source>
+        <translation>${PRODUCT_NAME} ${VERSION} konnte nicht komplett installiert werden.$\r$\n\Bitte starten Sie Windows neu und führen Sie das Installationsprogramm erneut aus.</translation>
+    </message>
+    <message>
+        <source>InstallFailedCauseUninstallerFailed</source>
+        <translation>${PRODUCT_NAME} konnte nicht komplett installiert werden.$\r$\n\Bitte starten Sie Windows neu und führen Sie das Installationsprogramm erneut aus.</translation>
+    </message>
+    <message>
+        <source>UninstallFailed</source>
+        <translation>${PRODUCT_NAME} ${VERSION} konnte nicht komplett deinstalliert werden.$\r$\n\Bitte starten Sie Windows neu und führen Sie das Deinstallationsprogramm erneut aus.</translation>
+    </message>
+    <message>
+        <source>FileDeleteErrorDialog</source>
+        <translation>Fehler beim Löschen der Datei:$\r$\n$\r$\n$0$\r$\n$\r$\nKlicke &quot;Wiederholen&quot;, um es erneut zu versuchen, oder$\r$\n&quot;Abbruch&quot;, um die Deinstallation abzubrechen.</translation>
+    </message>
+    <message>
+        <source>FileDeleteError</source>
+        <translation>Fehler beim Löschen der Datei $0</translation>
+    </message>
+    <message>
+        <source>Install64On32BitWarning</source>
+        <translation>Sie sind dabei, die 32-bit Version von ${PRODUCT_NAME} auf ihrem 64-bit Windows zu installieren. Es gibt eine 64-bit ${PRODUCT_NAME} Version, die heruntergeladen werden kann.</translation>
+    </message>
+    <message>
+        <source>Install32On64BitError</source>
+        <translation>Dieses Installationsprogramm beinhaltet die 64-bit Version von ${PRODUCT_NAME}. Auf Ihrem Computer läuft eine 32-bit Version von Windows, welche keine 64-bit Programme ausführen kann. Bitte laden sie das 32-bit Installationsprogramm von ${PRODUCT_NAME} herunter.</translation>
+    </message>
+    <message>
+        <source>UnsupportedWindowsVersionError</source>
+        <translation>Dieses Programm benötigt mindestens Windows ${MIN_WINDOWS_VER}.</translation>
+    </message>
+    <message>
+        <source>UninstallerAborted</source>
+        <translation>Die ${PRODUCT_NAME} Deinstallation wurde abgebrochen. Bitte versuchen Sie es später erneut.</translation>
+    </message>
+</context>
+</TS>

--- a/src/translations/installer_en.ts
+++ b/src/translations/installer_en.ts
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>WindowsInstaller</name>
+    <message>
+        <source>__LANGUAGE_NAME__</source>
+        <translatorcomment>This must be the name of one of the NSIS translation files at https://sourceforge.net/p/nsis/code/HEAD/tree/NSIS/trunk/Contrib/Language%20files/ without the file extension.</translatorcomment>
+        <translation>English</translation>
+    </message>
+    <message>
+        <source>BirdtraySectionDescription</source>
+        <translation>A free system tray notification for new mail for Thunderbird.</translation>
+    </message>
+    <message>
+        <source>WinIntegrationSectionName</source>
+        <translation>Windows integration</translation>
+    </message>
+    <message>
+        <source>WinIntegrationGroupDescription</source>
+        <translation>Select how to integrate the program in Windows.</translation>
+    </message>
+    <message>
+        <source>AutoRunSectionName</source>
+        <translation>AutoRun</translation>
+    </message>
+    <message>
+        <source>AutoRunDescription</source>
+        <translation>Automatically start ${PRODUCT_NAME} after login.</translation>
+    </message>
+    <message>
+        <source>AutoCheckUpdateSectionName</source>
+        <translation>Auto Update-Check</translation>
+    </message>
+    <message>
+        <source>AutoCheckUpdateDescription</source>
+        <translation>Automatically search for updates of ${PRODUCT_NAME} at startup.</translation>
+    </message>
+    <message>
+        <source>ProgramGroupSectionName</source>
+        <translation>Program Group Entry</translation>
+    </message>
+    <message>
+        <source>ProgramGroupDescription</source>
+        <translation>Create a ${PRODUCT_NAME} program group under Start Menu > Programs.</translation>
+    </message>
+    <message>
+        <source>DesktopEntrySectionName</source>
+        <translation>Desktop Entry</translation>
+    </message>
+    <message>
+        <source>DesktopEntryDescription</source>
+        <translation>Create a ${PRODUCT_NAME} icon on the Desktop.</translation>
+    </message>
+    <message>
+        <source>StartMenuSectionName</source>
+        <translation>Start Menu Entry</translation>
+    </message>
+    <message>
+        <source>StartMenuDescription</source>
+        <translation>Create a ${PRODUCT_NAME} icon in the Start Menu.</translation>
+    </message>
+    <message>
+        <source>UserSettingsSectionName</source>
+        <translation>${PRODUCT_NAME} User Settings</translation>
+    </message>
+    <message>
+        <source>UserSettingsDescription</source>
+        <translation>Your settings and configuration made within ${PRODUCT_NAME}.</translation>
+    </message>
+    <message>
+        <source>LicenseStartMenuLinkName</source>
+        <translation>License Agreement</translation>
+    </message>
+    <message>
+        <source>FinishPageRunBirdtray</source>
+        <translation>Start ${PRODUCT_NAME}</translation>
+    </message>
+    <message>
+        <source>UninstallerConfirmation</source>
+        <translation>Click uninstall to begin the process.</translation>
+    </message>
+    <message>
+        <source>UninstallPreviousVersion</source>
+        <translation>Uninstalling previous version of ${PRODUCT_NAME}</translation>
+    </message>
+    <message>
+        <source>UninstallPreviousVersionError</source>
+        <translation>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</translation>
+    </message>
+    <message>
+        <source>UninstallExecutionError</source>
+        <translation>Error executing uninstaller.</translation>
+    </message>
+    <message>
+        <source>StopBirdtray</source>
+        <translation>${PRODUCT_NAME} is currently running. Press OK to stop ${PRODUCT_NAME} to continue with the installation.</translation>
+    </message>
+    <message>
+        <source>StoppingBirdtray</source>
+        <translation>Closing process ${EXE_NAME}</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayError</source>
+        <translation>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayUninstall</source>
+        <translation>${PRODUCT_NAME} is currently running. Press OK to stop ${PRODUCT_NAME} to continue with the uninstall.</translation>
+    </message>
+    <message>
+        <source>StopBirdtrayUninstallError</source>
+        <translation>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the uninstall.</translation>
+    </message>
+    <message>
+        <source>SetupAlreadyRunning</source>
+        <translation>The setup of ${PRODUCT_NAME} is already running.$\r$\nPlease, close all instances of it and click Retry to continue, or Cancel to exit.</translation>
+    </message>
+    <message>
+        <source>UninstallAlreadyRunning</source>
+        <translation>The uninstall of ${PRODUCT_NAME} is already running.$\r$\n Please, close all instances of it and click Retry to continue, or Cancel to exit.</translation>
+    </message>
+    <message>
+        <source>BadInstallPath</source>
+        <translation>The install path must not contain any of$\r$\n${BAD_PATH_CHARS}.</translation>
+    </message>
+    <message>
+        <source>InstallPathContainsPreviousVersion</source>
+        <translation>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</translation>
+    </message>
+    <message>
+        <source>InstallPathNotEmpty</source>
+        <translation>The install path is not empty, but it doesn't look like it contains a previous ${PRODUCT_NAME} installation. The content will get overwritten.</translation>
+    </message>
+    <message>
+        <source>CurrentUserOnly</source>
+        <translation>$0 (current user only)</translation>
+    </message>
+    <message>
+        <source>InstallFailed</source>
+        <translation>${PRODUCT_NAME} ${VERSION} could not be fully installed.$\r$\n\Please, restart Windows and run the setup program again.</translation>
+    </message>
+    <message>
+        <source>InstallFailedCauseUninstallerFailed</source>
+        <translation>${PRODUCT_NAME} could not be fully installed.$\r$\n\Please, restart Windows and run the setup program again.</translation>
+    </message>
+    <message>
+        <source>UninstallFailed</source>
+        <translation>${PRODUCT_NAME} ${VERSION} could not be fully uninstalled.$\r$\nPlease, restart Windows and run the uninstaller again.</translation>
+    </message>
+    <message>
+        <source>FileDeleteErrorDialog</source>
+        <translation>Error deleting file:$\r$\n$\r$\n$0$\r$\n$\r$\nClick Retry to try again, or$\r$\nCancel to stop the uninstall.</translation>
+    </message>
+    <message>
+        <source>FileDeleteError</source>
+        <translation>Error deleting file $0</translation>
+    </message>
+    <message>
+        <source>Install64On32BitWarning</source>
+        <translation>You are about to install the 32-bit version of ${PRODUCT_NAME} on your 64-bit Windows. There is a 64-bit version of ${PRODUCT_NAME} available for download.</translation>
+    </message>
+    <message>
+        <source>Install32On64BitError</source>
+        <translation>This installer contains the 64-bit version of ${PRODUCT_NAME}. Your computer is running a 32-bit version of Windows, which can not execute 64-bit programs. Please download the 32-bit installer of ${PRODUCT_NAME}.</translation>
+    </message>
+    <message>
+        <source>UnsupportedWindowsVersionError</source>
+        <translation>This program requires at least Windows ${MIN_WINDOWS_VER}.</translation>
+    </message>
+    <message>
+        <source>UninstallerAborted</source>
+        <translation>Uninstalling ${PRODUCT_NAME} has been aborted. Please try again later.</translation>
+    </message>
+</context>
+</TS>

--- a/tools/qt-installer-windows.qs
+++ b/tools/qt-installer-windows.qs
@@ -91,8 +91,6 @@ Controller.prototype.ReadyForInstallationPageCallback = function() {
 
 Controller.prototype.FinishedPageCallback = function() {
     console.log("Step: " + gui.currentPageWidget());
-    // TODO somehow the installer crashes after this step.
-    // https://stackoverflow.com/questions/25105269/silent-install-qt-run-installer-on-ubuntu-server
     var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm;
     if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
         checkBoxForm.launchQtCreatorCheckBox.checked = false;


### PR DESCRIPTION
This adds the ability to translate the Windows installer. The user will be asked to choose a language when the installer/uninstaller starts.

The translations are generated from the `src/translations/installer_*.ts` files.
To add a new translation, one has to copy an existing `installer_*.ts` file and and change the 
`message` entry with the `__LANGUAGE_NAME__` `source`. The `translation` value for this indicates the target language and must be the name of one of the [NSIS translation files](https://sourceforge.net/p/nsis/code/HEAD/tree/NSIS/trunk/Contrib/Language%20files/) without the file extension. E.g. `German.nlf` becomes:
```xml
<message>
    <source>__LANGUAGE_NAME__</source>
    <translation>German</translation>
</message>
```