### PR TITLE
Prevent crash when reporting multiple errors from UnreadCounter

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -110,6 +110,9 @@ void TrayIcon::unreadCounterError(QString message)
     qWarning("UnreadCounter generated an error: %s", qPrintable(message) );
 
     mCurrentStatus = message;
+    if (mUnreadMonitor == nullptr) {
+        return;
+    }
     mUnreadMonitor->quitAndDelete();
     mUnreadMonitor = nullptr;
 

--- a/src/unreadcounter.cpp
+++ b/src/unreadcounter.cpp
@@ -53,8 +53,10 @@ void UnreadMonitor::run()
 }
 
 void UnreadMonitor::quitAndDelete() {
-    quit();
-    wait();
+    if (isRunning()) {
+        quit();
+        wait();
+    }
     deleteLater();
 }
 


### PR DESCRIPTION
The `TrayIcon::unreadCounterError` callback may be called multiple times (e.g. if multiple `.msf` files are not watchable).