### PR TITLE
Allow the settings to expand with the window

### DIFF
--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -929,6 +929,9 @@ p, li { white-space: pre-wrap; }
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Preferred</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>


### PR DESCRIPTION
This should be helpful for everybody who has configured multiple accounts.

Before:
![Old Settings](https://user-images.githubusercontent.com/6966049/69299345-a413ea00-0c10-11ea-8d27-312a2b34fb35.PNG)

After:
![Expandable Settings](https://user-images.githubusercontent.com/6966049/69299355-ab3af800-0c10-11ea-8b11-cdf32fa98422.PNG)
