### PR TITLE
Better fix for delete while still running error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SOURCES
         src/settings.cpp
         src/sqlite_statement.cpp
         src/trayicon.cpp
-        src/unreadcounter.cpp
+        src/unreadmonitor.cpp
         src/utils.cpp
         src/windowtools.cpp
         src/autoupdater.cpp
@@ -84,7 +84,7 @@ set(HEADERS
         src/settings.h
         src/sqlite_statement.h
         src/trayicon.h
-        src/unreadcounter.h
+        src/unreadmonitor.h
         src/utils.h
         src/version.h
         src/windowtools.h

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -8,7 +8,7 @@
 #include <QtNetwork/QNetworkSession>
 
 #include "trayicon.h"
-#include "unreadcounter.h"
+#include "unreadmonitor.h"
 #include "windowtools.h"
 #include "utils.h"
 #include "autoupdater.h"
@@ -87,7 +87,7 @@ TrayIcon::~TrayIcon() {
         networkConnectivityManager = nullptr;
     }
     if (mUnreadMonitor != nullptr) {
-        mUnreadMonitor->quitAndDelete();
+        mUnreadMonitor->deleteLater();
         mUnreadMonitor = nullptr;
     }
 }
@@ -113,7 +113,7 @@ void TrayIcon::unreadCounterError(QString message)
     if (mUnreadMonitor == nullptr) {
         return;
     }
-    mUnreadMonitor->quitAndDelete();
+    mUnreadMonitor->deleteLater();
     mUnreadMonitor = nullptr;
 
     mUnreadCounter = 0;

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -12,9 +12,9 @@
 #include "birdtrayapp.h"
 
 UnreadMonitor::UnreadMonitor( TrayIcon * parent )
-    : QThread(nullptr ), mChangedMSFtimer(this)
+    : QThread( 0 ), mChangedMSFtimer(this)
 {
-    mSqlitedb = nullptr;
+    mSqlitedb = 0;
     mLastReportedUnread = 0;
 
     // We get notification once either sqlite file or Mork files have been modified.
@@ -25,8 +25,7 @@ UnreadMonitor::UnreadMonitor( TrayIcon * parent )
     connect( parent, &TrayIcon::settingsChanged, this, &UnreadMonitor::slotSettingsChanged );
 
     // Set up the watched file timer
-    mChangedMSFtimer.setInterval(
-            static_cast<int>(BirdtrayApp::get()->getSettings()->mWatchFileTimeout));
+    mChangedMSFtimer.setInterval(BirdtrayApp::get()->getSettings()->mWatchFileTimeout);
     mChangedMSFtimer.setSingleShot( true );
 
     connect( &mChangedMSFtimer, &QTimer::timeout, this, &UnreadMonitor::updateUnread );
@@ -60,7 +59,7 @@ void UnreadMonitor::slotSettingsChanged()
     if ( mSqlitedb )
     {
         sqlite3_close_v2( mSqlitedb );
-        mSqlitedb = nullptr;
+        mSqlitedb = 0;
     }
 
     mMorkUnreadCounts.clear();
@@ -86,7 +85,7 @@ bool UnreadMonitor::openDatabase()
     // Open the database
     if ( sqlite3_open_v2( mSqliteDbFile.toUtf8().data(),
                            &mSqlitedb,
-                           SQLITE_OPEN_READONLY, nullptr ) != SQLITE_OK )
+                           SQLITE_OPEN_READONLY, 0 ) != SQLITE_OK )
     {
         emit error(tr("Error opening sqlite database: %1").arg(sqlite3_errmsg(mSqlitedb)));
         return false;

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -17,11 +17,11 @@ class UnreadMonitor : public QThread
     Q_OBJECT
 
     public:
-        explicit UnreadMonitor( TrayIcon * parent );
-        ~UnreadMonitor() override;
+        UnreadMonitor( TrayIcon * parent );
+        virtual ~UnreadMonitor();
 
         // Thread run function
-        void run() override;
+        virtual void run() override;
 
     signals:
         // Unread counter changed

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -1,5 +1,5 @@
-#ifndef FOLDERWATCHER_H
-#define FOLDERWATCHER_H
+#ifndef UNREAD_MONITOR_H
+#define UNREAD_MONITOR_H
 
 #include <QThread>
 #include <QString>
@@ -17,16 +17,11 @@ class UnreadMonitor : public QThread
     Q_OBJECT
 
     public:
-        UnreadMonitor( TrayIcon * parent );
-        virtual ~UnreadMonitor();
+        explicit UnreadMonitor( TrayIcon * parent );
+        ~UnreadMonitor() override;
 
         // Thread run function
-        virtual void run() override;
-        
-        /**
-         * Safely enqueues the this unread monitor for deletion.
-         */
-        void quitAndDelete();
+        void run() override;
 
     signals:
         // Unread counter changed
@@ -78,4 +73,4 @@ class UnreadMonitor : public QThread
         QColor mLastColor;
 };
 
-#endif // FOLDERWATCHER_H
+#endif /* UNREAD_MONITOR_H */


### PR DESCRIPTION
This is a better fix than #174. It could still sometimes crash when Birdtray was exiting.

We no no longer move the `QThread` object to the thread. This causes the destructor tobe executed on the main thread, allowing us to wait for the thread to exit before continuing destruction the object.

I also renamed the source file so it matches the class name. 