### PR TITLE
Fix potentially not watching mork files

### DIFF
--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -221,7 +221,7 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
     {
         for ( QString path : mChangedMSFfiles )
             if ( !mMorkUnreadCounts.contains( path ) )
-                rescanall = false;
+                rescanall = true;
     }
 
     if ( rescanall )


### PR DESCRIPTION
I'm not sure what his code do does. As of right now, without this change, the `else` block seems to do nothing, because `rescanall` is initialized to `false` a few lines above.

I think the intention here is to add the path to the filesystem watcher if it is not already watched, is that right? If so, this could be simplified.

@gyunaev Could you please clarify what this code is intended to do?
