### PR TITLE
Guard the clean_translations target behind if(Qt5LinguistTools_FOUND)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,19 +191,21 @@ else()
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ulduzsoft/birdtray)
 endif()
 
-add_custom_target(clean_translations COMMENT "Remove obsolete translation entries")
-foreach(TRANSLATION_FILE ${MAIN_TRANSLATION_FILES})
-    get_filename_component(TRANSLATION_NAME ${TRANSLATION_FILE} NAME)
-    set(TRANSLATION_LST_FILE
-            "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${TRANSLATION_NAME}_lst_file")
-    if(NOT EXISTS ${TRANSLATION_LST_FILE})
-        get_filename_component(TRANSLATION_NAME ${TRANSLATION_FILE} NAME_WE)
+if(Qt5LinguistTools_FOUND)
+    add_custom_target(clean_translations COMMENT "Remove obsolete translation entries")
+    foreach(TRANSLATION_FILE ${MAIN_TRANSLATION_FILES})
+        get_filename_component(TRANSLATION_NAME ${TRANSLATION_FILE} NAME)
         set(TRANSLATION_LST_FILE
                 "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${TRANSLATION_NAME}_lst_file")
-    endif()
-    add_custom_command(TARGET clean_translations
-            COMMAND ${Qt5_LUPDATE_EXECUTABLE}
-            ARGS -locations none -no-obsolete "@${TRANSLATION_LST_FILE}"
-            -ts ${CMAKE_CURRENT_SOURCE_DIR}/${TRANSLATION_FILE}
-            DEPENDS ${TRANSLATION_LST_FILE})
-endforeach()
+        if(NOT EXISTS ${TRANSLATION_LST_FILE})
+            get_filename_component(TRANSLATION_NAME ${TRANSLATION_FILE} NAME_WE)
+            set(TRANSLATION_LST_FILE
+                    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${TRANSLATION_NAME}_lst_file")
+        endif()
+        add_custom_command(TARGET clean_translations
+                COMMAND ${Qt5_LUPDATE_EXECUTABLE}
+                ARGS -locations none -no-obsolete "@${TRANSLATION_LST_FILE}"
+                -ts ${CMAKE_CURRENT_SOURCE_DIR}/${TRANSLATION_FILE}
+                DEPENDS ${TRANSLATION_LST_FILE})
+    endforeach()
+endif()


### PR DESCRIPTION
The Cmake target requires the Qt linguistic tools to be present. Since commit 57e805660eba41d2771c71447129017367f9fe82, the QtLinguisticTools are optional, so we only define the target if we find them.