### PR TITLE
Simplify checking for new and changed mork files

### DIFF
--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -213,10 +213,7 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
 {
     Settings* settings = BirdtrayApp::get()->getSettings();
     for (const QString &path : settings->mFolderNotificationColors.keys()) {
-        if (!QFile::exists(path)) {
-            continue;
-        }
-        if (!mDBWatcher.files().contains(path)) {
+        if (!mDBWatcher.files().contains(path) && QFile::exists(path)) {
             if (!mDBWatcher.addPath(path)) {
                 emit error(tr("Unable to watch %1 for changes.").arg(path));
                 continue;


### PR DESCRIPTION
This is an optimization for the Mork parser and simplification of the logic in `UnreadMonitor::getUnreadCount_Mork`. We no longer read the unread count from all msf files if we add a new msf file. Instead, only the newly added and the changed msf files are read.