### PR TITLE
Allow to select msf files in mail subfolders

### DIFF
--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -36,14 +36,8 @@ QVariant ModelAccountTree::data(const QModelIndex &index, int role) const
                 return Utils::decodeIMAPutf7(account);
             }
             QFileInfo fileInfo(account);
-            QString folderName = fileInfo.baseName();
-            if (folderName == "INBOX") {
-                folderName = QObject::tr("Inbox");
-            } else {
-                folderName = QCoreApplication::translate(
-                        "EmailFolders", folderName.toUtf8().constData());
-            }
-            QString accountName = fileInfo.dir().dirName();
+            QString folderName = Utils::getMailFolderName(fileInfo);
+            QString accountName = Utils::getMailAccountName(fileInfo);
             return accountName + " [" + folderName + "]";
         } else if ( role == Qt::ToolTipRole && index.column() == 0 ) {
             return mAccounts[index.row()];

--- a/src/translations/dynamic_de.ts
+++ b/src/translations/dynamic_de.ts
@@ -4,6 +4,10 @@
 <context>
     <name>EmailFolders</name>
     <message>
+        <source>INBOX</source>
+        <translation>Posteingang</translation>
+    </message>
+    <message>
         <source>Archives</source>
         <translation>Archiv</translation>
     </message>

--- a/src/translations/dynamic_en.ts
+++ b/src/translations/dynamic_en.ts
@@ -4,6 +4,10 @@
 <context>
     <name>EmailFolders</name>
     <message>
+        <source>INBOX</source>
+        <translation>Inbox</translation>
+    </message>
+    <message>
         <source>Archives</source>
         <translation>Archives</translation>
     </message>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -518,30 +518,6 @@ Sollen die Informationen über bestehende Konten gelöscht werden?</translation>
         <translation>Ungültiges Thunderbird-Verzeichnis</translation>
     </message>
     <message>
-        <source>Thunderbird Command</source>
-        <translation type="vanished">Thunderbird Befehl</translation>
-    </message>
-    <message>
-        <source>Thunderbird command:</source>
-        <translation type="vanished">Thunderbird Befehl:</translation>
-    </message>
-    <message>
-        <source>Edit the Thunderbird command</source>
-        <translation type="vanished">Bearbeite den Thunderbird Befehl</translation>
-    </message>
-    <message>
-        <source>Auto detect</source>
-        <translation type="vanished">Automatisch erkennen</translation>
-    </message>
-    <message>
-        <source>Thunderbird not found</source>
-        <translation type="vanished">Thunderbird konnte nicht gefunden werden</translation>
-    </message>
-    <message>
-        <source>Unable to detect Thunderbird on your system.</source>
-        <translation type="vanished">Thunderbird konnte auf ihrem System nicht gefunden werden.</translation>
-    </message>
-    <message>
         <source>Thunderbird command line:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -653,10 +629,6 @@ p, li { white-space: pre-wrap; }
         <translation>Das gewählte Thunderbird Profil existiert nicht mehr.</translation>
     </message>
     <message>
-        <source>Inbox</source>
-        <translation>Posteingang</translation>
-    </message>
-    <message>
         <source>No folder selected</source>
         <translation>Kein Ordner ausgewählt</translation>
     </message>
@@ -730,10 +702,6 @@ Wollen Sie fortfahren?</translation>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Inbox</source>
-        <translation>Posteingang</translation>
-    </message>
     <message>
         <source>Account</source>
         <translation>Konto</translation>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -510,22 +510,6 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Liberation Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; font-weight:600;&quot;&gt;Birdtray version [VERSION] compiled at [DATE].&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Copyright (C) 2018 by George Yunaev, &lt;/span&gt;&lt;a href=&quot;mailto:gyunaev@ulduzsoft.com&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;gyunaev@ulduzsoft.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Birdtray is FREE SOFTWARE, which is licensed under General Public License v3. To clarify further, you can use it for any purpose, including commercial, without paying anything. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;For those of you who apprericate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thunderbird command line:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -625,10 +609,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbox</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -701,10 +681,6 @@ Do you want to continue?</source>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Inbox</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Account</source>
         <translation type="unfinished"></translation>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,12 +5,12 @@
 #include <QApplication>
 #include <QTextCodec>
 #include <QtWidgets/QMessageBox>
+#include <QtCore/QDir>
 
 #if defined (Q_OS_WIN)
 #  include <windows.h>
 #elif defined (Q_OS_MAC)
 #else
-#  include <QtCore/QFileInfo>
 #  include <wordexp.h>
 #endif
 
@@ -274,5 +274,28 @@ QStringList Utils::splitCommandLine(const QString &src)
         out.push_back( current );
 
     return out;
+}
+
+QString Utils::getMailFolderName(const QFileInfo &morkFile) {
+    QString dirName;
+    QDir parentDir = morkFile.dir();
+    QString name = QCoreApplication::translate(
+            "EmailFolders", morkFile.completeBaseName().toUtf8().constData());
+    while ((dirName = parentDir.dirName()).endsWith(".sbd")) {
+        dirName.chop(4);
+        name = QCoreApplication::translate(
+                "EmailFolders", dirName.toUtf8().constData()) + '/' + name;
+        parentDir.cdUp();
+    }
+    return name;
+}
+
+QString Utils::getMailAccountName(const QFileInfo &morkFile) {
+    QDir parentDir = morkFile.dir();
+    QString name;
+    while ((name = parentDir.dirName()).endsWith(".sbd")) {
+        parentDir.cdUp();
+    }
+    return name;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,7 @@
 #define UTILS_H
 
 #include <QString>
+#include <QtCore/QFileInfo>
 
 class Utils
 {
@@ -67,6 +68,22 @@ class Utils
 
         // Splits the string into stringlist using space as separator, but ignoring spaces inside quoted content
         static QStringList splitCommandLine( const QString& src );
+        
+        /**
+         * Get the mail folder name from the mork path.
+         *
+         * @param morkPath The file info for a msf file.
+         * @return The mail folder name.
+         */
+        static QString getMailFolderName(const QFileInfo &morkFile);
+        
+        /**
+         * Get the mil account name from a mork path
+         *
+         * @param morkPath The file info for a msf file.
+         * @return The mail account name.
+         */
+        static QString getMailAccountName(const QFileInfo &morkFile);
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
This fixes #194.
We allow to select `.msf` files in mail subfolders (folders ending with `.sbd`).
We should merge this before we make a new release.