### PR TITLE
Enable Travis autodeploy on tag, but only as a draft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,13 +144,14 @@ before_deploy:
       cd ..;
     fi
 
-#deploy:
-#  - provider: releases
-#    api_key:
-#      secure: SECURE_KEY_GOES_HERE
-#    file_glob: true
-#    file: installer/Birdtray-*.exe
-#    skip_cleanup: true
-#    on:
-#      tags: true
-#      branch: master
+deploy:
+  - provider: releases
+    api_key:
+      secure: SECURE_KEY_GOES_HERE
+    file_glob: true
+    file: installer/Birdtray-*.exe
+    skip_cleanup: true
+    draft: true
+    on:
+      tags: true
+      branch: master


### PR DESCRIPTION
This is a proposal to enable the automatic creation of a draft release on Github, if a tag is pushed to the master branch.
Building to Birdtray installers for Windows on my machine is not ideal. They should ideally be created in a clean environment.
I know you didn't like the idea in the past. I wanted to restart the discussion and see, if some of the concerns you had might have been resolved now.
A major concern was to be able to manually test Birdtray before creating a release ([comment](https://github.com/gyunaev/birdtray/pull/80#issuecomment-481356568)). You will still be able to do that, as this automation only creates a draft of a release. Once the draft is created, you can download the installer or compile the code and test it. If you find anything, just discard the draft, fix the error and push another commit with a tag.
