### PR TITLE
Update German translations

### DIFF
--- a/src/mailaccountdialog.ui
+++ b/src/mailaccountdialog.ui
@@ -122,7 +122,7 @@
       </attribute>
       <column>
        <property name="text">
-        <string notr="true">Email Folder</string>
+        <string>Email Folder</string>
        </property>
       </column>
       <column>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -638,6 +638,10 @@ Do you want to continue?</source>
         <translation>Es wurde kein Email-Ordner zur Überwachung ausgewählt.
 Wollen Sie fortfahren?</translation>
     </message>
+    <message>
+        <source>Email Folder</source>
+        <translation>Email Ordner</translation>
+    </message>
 </context>
 <context>
     <name>ModelNewEmails</name>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -519,11 +519,11 @@ Sollen die Informationen über bestehende Konten gelöscht werden?</translation>
     </message>
     <message>
         <source>Thunderbird command line:</source>
-        <translation type="unfinished"></translation>
+        <translation>Thunderbird Kommandozeile:</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dies ist die komplette Kommandozeile (mit Argumenten), welche zum Starten von Thunderbird genutzt wird. Argumente müssen mit Leerzeichen getrennt werden, allerdings sind Leerzeichen in Anführungszeichen erlaubt. Z.B.: &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -617,6 +617,10 @@ p, li { white-space: pre-wrap; }
 Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Email Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ModelNewEmails</name>


### PR DESCRIPTION
Add the missing German translations.

I also found a string in the `MailAccountDialog` that was not translated.