### PR TITLE
Add recursive selection of mail folders to monitor

### DIFF
--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -279,7 +279,7 @@ QList<QTreeWidgetItem*> MailAccountDialog::getCheckedAccountItems() const {
 
 void MailAccountDialog::propagateChangesToAccountChildren(
         QTreeWidgetItem* parent, Qt::CheckState checkState) {
-    for (int i = 0; i < parent->childCount(); ++i) {
+    for (int i = 0; i < parent->childCount(); i++) {
         QTreeWidgetItem* child = parent->child(i);
         child->setCheckState(0, checkState);
         propagateChangesToAccountChildren(child, checkState);

--- a/src/mailaccountdialog.h
+++ b/src/mailaccountdialog.h
@@ -103,15 +103,6 @@ private:
     bool validateAccountsPage();
     
     /**
-     * Propagates the changes to the parent account item to it's children.
-     *
-     * @param parent The parent of the account item.
-     * @param checkState The new check state of the children.
-     */
-    static void propagateChangesToAccountChildren(
-            QTreeWidgetItem* parent, Qt::CheckState checkState);
-    
-    /**
      * @return All checked account items from the accountList.
      */
     QList<QTreeWidgetItem*> getCheckedAccountItems() const;

--- a/src/mailaccountdialog.h
+++ b/src/mailaccountdialog.h
@@ -105,8 +105,8 @@ private:
     /**
      * Propagates the changes to the parent account item to it's children.
      *
-     * @param parent
-     * @param checkState
+     * @param parent The parent of the account item.
+     * @param checkState The new check state of the children.
      */
     static void propagateChangesToAccountChildren(
             QTreeWidgetItem* parent, Qt::CheckState checkState);

--- a/src/mailaccountdialog.h
+++ b/src/mailaccountdialog.h
@@ -63,6 +63,13 @@ private Q_SLOTS:
      * @param newProfileIndex The index of the new selected profile.
      */
     void onProfileSelectionChanged(int newProfileIndex);
+    
+    /**
+     * Called when an account item in the accounts list changed.
+     * @param item The account item.
+     * @param column The changed column.
+     */
+    static void onAccountItemChanged(QTreeWidgetItem* item, int column);
 
 private:
     /**
@@ -94,6 +101,15 @@ private:
      * @return Whether or not the account selection is valid.
      */
     bool validateAccountsPage();
+    
+    /**
+     * Propagates the changes to the parent account item to it's children.
+     *
+     * @param parent
+     * @param checkState
+     */
+    static void propagateChangesToAccountChildren(
+            QTreeWidgetItem* parent, Qt::CheckState checkState);
     
     /**
      * @return All checked account items from the accountList.


### PR DESCRIPTION
This allows to automatically select all detected `.msf` files in an account by selecting a checkbox at the account item.
![Recursive Select](https://user-images.githubusercontent.com/6966049/70274518-90d65200-17ac-11ea-8b0a-d80a06b53f56.PNG)
