### PR TITLE
Added a way to pass arguments to running Thunderbird process

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -133,6 +133,7 @@ bool BirdtrayApp::isInstanceRunning()
 
     autoUpdater = new AutoUpdater();
     trayIcon = new TrayIcon( mParser.isSet("settings"), sharedMemory );
+    return false;
 }
 
 BirdtrayApp* BirdtrayApp::get() {

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -1,11 +1,20 @@
 #include <QtCore/QLibraryInfo>
 #include <QtCore/QStandardPaths>
+#include <QtCore/QSharedMemory>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QMessageBox>
+
 #include "birdtrayapp.h"
 #ifdef Q_OS_WIN
 #  include "birdtrayeventfilter.h"
 #endif /* Q_OS_WIN */
 #include "utils.h"
 #include "morkparser.h"
+
+// Maximum memory size for inter-application communication
+static const int SHARED_MEMORY_SIZE = 4096;
+static const char * SHARED_MEMORY_TOKEN = "aeheewah7kahDauteeCeeP0jeipheiJuShailona0heidahyee2chahfiiLoh1ah";
 
 
 BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv) {
@@ -14,6 +23,7 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv) {
     QCoreApplication::setOrganizationDomain("ulduzsoft.com");
     QCoreApplication::setApplicationName("birdtray");
     QCoreApplication::setApplicationVersion(Utils::getBirdtrayVersion());
+
     // This prevents exiting the application when the dialogs are closed on Gnome/XFCE
     QApplication::setQuitOnLastWindowClosed(false);
     
@@ -22,46 +32,107 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv) {
     QCoreApplication::installTranslator(&dynamicTranslator);
     QCoreApplication::installTranslator(&mainTranslator);
 
-#ifdef Q_OS_WIN
-    BirdtrayEventFilter filter;
-    installNativeEventFilter(&filter);
-#endif /* Q_OS_WIN */
+    parseCmdArguments( mParser );
     
-    QCommandLineParser parser;
-    parseCmdArguments(parser);
-    
-    QString morkPath = parser.value("dump-mork");
+    QString morkPath = mParser.value("dump-mork");
     if (!morkPath.isEmpty()) {
         exit(MorkParser::dumpMorkFile(morkPath));
         return;
     }
-    QString imapString = parser.value("decode");
+    QString imapString = mParser.value("decode");
     if (!imapString.isEmpty()) {
         printf("Decoded: %s\n", qPrintable(Utils::decodeIMAPutf7(imapString)));
         exit(EXIT_SUCCESS);
         return;
     }
-    
-    ensureSystemTrayAvailable();
-    
+
     // Load settings
-    settings = new Settings(parser.isSet("debug"));
-    if (parser.isSet("reset-settings")) {
+    settings = new Settings( mParser.isSet("debug"));
+
+    if ( mParser.isSet("reset-settings")) {
         settings->save(); // Saving without loading will reset the values
     } else {
         settings->load();
     }
+
     if (!translationLoadedSuccessfully) {
         Utils::debug("Failed to load translation for %s", qPrintable(QLocale::system().name()));
     }
-    autoUpdater = new AutoUpdater();
-    trayIcon = new TrayIcon(parser.isSet("settings"));
 }
 
 BirdtrayApp::~BirdtrayApp() {
     delete trayIcon;
     delete autoUpdater;
     delete settings;
+}
+
+bool BirdtrayApp::isInstanceRunning()
+{
+    QSharedMemory * sharedMemory = new QSharedMemory( SHARED_MEMORY_TOKEN );
+
+    // If we can attach to it, the segment already exists
+    if ( sharedMemory->attach() )
+    {
+        // Another instance exists; send the command-line there
+        QJsonObject commands;
+
+        // Add more commands here - don't forget to add handling for them in TrayIcon::checkSharedMemoryMessage()
+        if ( mParser.isSet("toggle" ) )
+            commands["toggle"] = 1;
+
+        // Do we have any commands to send there?
+        if ( !commands.isEmpty() )
+        {
+            QByteArray jsondata = QJsonDocument( commands ).toJson();
+
+            if ( jsondata.size() < SHARED_MEMORY_SIZE - 2 )
+            {
+                // Write the size first, then the string
+                if ( sharedMemory->lock() )
+                {
+                    char * data = (char*) sharedMemory->data();
+                    *((short*)data) = jsondata.size();
+                    memcpy( data + 2, jsondata.data(), jsondata.size() );
+
+                    sharedMemory->unlock();
+                }
+                else
+                    qFatal("Failed to lock shared memory segment");
+            }
+            else
+            {
+                qFatal("Argument list too long");
+            }
+        }
+        else
+            qWarning("Another instance of Birdtray is already running");
+
+        // Clean up - this is important since we're finishing this instance
+        delete sharedMemory;
+        return true;
+    }
+
+    // Create a new segment - this is the first running instance
+    if ( !sharedMemory->create( SHARED_MEMORY_SIZE ) )
+    {
+        QMessageBox::critical( 0,
+                               tr("Shared memory segment failed"),
+                               tr("Failed to create a shared memory segment: %1").arg( sharedMemory->errorString()) );
+        return false;
+    }
+
+    // Reset it up so our checker knows there's no data yet
+    *((short*) sharedMemory->data()) = 0;
+
+    ensureSystemTrayAvailable();
+
+#ifdef Q_OS_WIN
+    BirdtrayEventFilter filter;
+    installNativeEventFilter(&filter);
+#endif /* Q_OS_WIN */
+
+    autoUpdater = new AutoUpdater();
+    trayIcon = new TrayIcon( mParser.isSet("settings"), sharedMemory );
 }
 
 BirdtrayApp* BirdtrayApp::get() {
@@ -135,6 +206,7 @@ void BirdtrayApp::parseCmdArguments(QCommandLineParser &parser) {
             {"settings", tr("Show the settings.")},
             {{"r", "reset-settings"}, tr("Reset the settings to the defaults.")},
             {{"d", "debug"}, tr("Enable debugging output.")},
+            { "toggle", tr("Toggle Thunderbird visibility (requires another running instance)")},
     });
     parser.process(*this);
 }

--- a/src/birdtrayapp.h
+++ b/src/birdtrayapp.h
@@ -27,6 +27,14 @@ public:
     ~BirdtrayApp() override;
     
     /**
+     * Returns true if another Birdtray instance is running
+     * and we have passed the arguments to it. This means the current
+     * instance should close, as the action would be performed by
+     * another instance.
+     */
+    bool    isInstanceRunning();
+
+    /**
      * @return The main Birdtray app instance.
      */
     static BirdtrayApp* get();
@@ -110,6 +118,9 @@ private:
      * Wait for the system tray to become available and exit if it doesn't within 60 seconds.
      */
     static void ensureSystemTrayAvailable();
+
+
+    QCommandLineParser mParser;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,5 +4,9 @@
 
 int main(int argc, char *argv[]) {
     BirdtrayApp app(argc, argv);
+
+    if ( app.isInstanceRunning() )
+        return 0;
+
     return QApplication::exec();
 }

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -72,6 +72,18 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <source>Enable debugging output.</source>
         <translation>Aktiviert Debugging-Ausgaben.</translation>
     </message>
+    <message>
+        <source>Shared memory segment failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to create a shared memory segment: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Thunderbird visibility (requires another running instance)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseAccounts</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -69,6 +69,18 @@ OpenSSL might not be installed.</source>
         <source>Enable debugging output.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shared memory segment failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to create a shared memory segment: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Thunderbird visibility (requires another running instance)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseAccounts</name>

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -15,13 +15,14 @@
 
 class UnreadMonitor;
 class WindowTools;
+class QSharedMemory;
 
 class TrayIcon : public QSystemTrayIcon
 {
     Q_OBJECT
 
     public:
-        explicit TrayIcon(bool showSettings);
+        explicit TrayIcon(bool showSettings, QSharedMemory * ipcSharedMemory );
         ~TrayIcon() override;
         
         /**
@@ -97,6 +98,7 @@ class TrayIcon : public QSystemTrayIcon
         void    hideThunderbird();
         void    showThunderbird();
         void    updateIgnoredUnreads();
+        void    checkSharedMemoryMessage();
         
         /**
          * Do an automatic check for a new version of Birdtray.
@@ -164,6 +166,10 @@ class TrayIcon : public QSystemTrayIcon
 
         // System tray context menu. Once set, it remains there, so we have to modify existing one
         QMenu       *   mSystrayMenu;
+
+        // This is the shared memory buffer which is used to pass command-line options from
+        // new Birdtray instances.
+        QSharedMemory * mSharedMemory;
     
         /**
          * The currently opened settings dialog.


### PR DESCRIPTION
This is used to implement toggle command support ( for #48 ). One unfortunate side effect of it is that if main instance of Birdtray is killed with -9, it will not restart until the shared segment is deleted (would require running it twice).