### PR TITLE
Elaborate confugration file location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,17 @@ You can also enable birdtray to start Thunderbird when you start Birdtray, or en
 
 Once you change settings, often you need to restart birdtray for the new settings to take effect.
 
-All birdtray settings are stored on a per-user basis in `$HOME/.config/ulduzsoft/birdtray.conf`.
+### Configuration File Location
+*Birdtray configuration is stored on a per-user basis, where the location differs depending on environment, as follows:*
+
+#### Linux Package Installation
+`$HOME/.config/ulduzsoft/birdtray.conf`
+
+#### Linux Flatpak Installation
+`$HOME/.var/app/com.ulduzsoft.Birdtray/config/ulduzsoft/birdtray.conf`
+
+#### Windows Installation
+`HKEY_CURRENT_USER\Software\ulduzsoft\birdtray` (Windows registry)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can also enable birdtray to start Thunderbird when you start Birdtray, or en
 
 Once you change settings, often you need to restart birdtray for the new settings to take effect.
 
+All birdtray settings are stored on a per-user basis in `$HOME/.config/ulduzsoft/birdtray.conf`.
+
 ## Troubleshooting
 
 If you have lots of unread messages shown, and you are using global search database to look for unread messages, it may be because the database is corrupt or too old. You may delete the file global-messages-db.sqlite and restart Thunderbird which would rebuild this file. This will also help if "search" function in Thunderbird finds emails which no longer exist.


### PR DESCRIPTION
This PR simply elaborates in the README as to where the Birdtray configuration file is saved, to avoid confusion since the naming is unexpected.