### PR TITLE
Show warnings about problems parsing mail accounts as a tooltip on the tray icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif(NOT Qt5LinguistTools_FOUND)
 if(WIN32)
     set(EXECUTABLE_OPTIONS WIN32)
     ENABLE_LANGUAGE(RC)
-    add_definitions(-DUNICODE)
+    add_definitions(-DUNICODE -DNOMINMAX)
     set(PLATFORM_SOURCES src/windowtools_win.cpp src/birdtrayeventfilter.cpp
             src/processhandle.cpp src/res/birdtray.rc)
     set(PLATFORM_HEADERS src/windowtools_win.h src/birdtrayeventfilter.h src/processhandle.h)

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -45,7 +45,7 @@ QVariant ModelAccountTree::data(const QModelIndex &index, int role) const {
                                                 .value(mAccounts[index.row()]);
             return warning.isNull() ? mAccounts[index.row()] : warning;
         }
-        case Qt::TextColorRole:
+        case Qt::ForegroundRole:
             if (BirdtrayApp::get()->getTrayIcon()->getUnreadMonitor()->getWarnings().contains(
                     mAccounts[index.row()])) {
                 return QColor(255, 150, 0, 255);

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -817,6 +817,10 @@ Wollen Sie fortfahren?</translation>
 
 %3</translation>
     </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation>Warnung: %1</translation>
+    </message>
 </context>
 <context>
     <name>UnreadMonitor</name>
@@ -838,11 +842,11 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <source>Unable to read from %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kann nicht von %1 lesen</translation>
     </message>
     <message>
         <source>Cannot query database: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kann die Datenbank nicht einlesen: %1</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -836,6 +836,14 @@ Wollen Sie fortfahren?</translation>
         <source>Unable to watch %1 for changes.</source>
         <translation>Kann %1 nicht auf Änderungen überwachen.</translation>
     </message>
+    <message>
+        <source>Unable to read from %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot query database: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateDialog</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -792,6 +792,10 @@ Do you want to continue?</source>
 %3</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UnreadMonitor</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -811,6 +811,14 @@ Do you want to continue?</source>
         <source>Unable to watch %1 for changes.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to read from %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot query database: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateDialog</name>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -123,18 +123,12 @@ void TrayIcon::unreadCounterUpdate( unsigned int total, QColor color )
     updateIcon();
 }
 
-void TrayIcon::unreadCounterError(QString message)
-{
-    qWarning("UnreadCounter generated an error: %s", qPrintable(message) );
-
-    mCurrentStatus = message;
-    if (mUnreadMonitor == nullptr) {
-        return;
+void TrayIcon::unreadMonitorWarningChanged(const QString &path) {
+    const QString &message = mUnreadMonitor->getWarnings().value(path);
+    if (!message.isNull()) {
+        qWarning("UnreadMonitor generated a warning for %s: %s",
+                qPrintable(path), qPrintable(message));
     }
-    mUnreadMonitor->deleteLater();
-    mUnreadMonitor = nullptr;
-
-    mUnreadCounter = 0;
     updateIcon();
 }
 
@@ -622,7 +616,8 @@ void TrayIcon::createUnreadCounterThread()
     mUnreadMonitor = new UnreadMonitor( this );
 
     connect( mUnreadMonitor, &UnreadMonitor::unreadUpdated, this, &TrayIcon::unreadCounterUpdate );
-    connect( mUnreadMonitor, &UnreadMonitor::error, this, &TrayIcon::unreadCounterError );
+    connect(mUnreadMonitor, &UnreadMonitor::warningChanged, this,
+            &TrayIcon::unreadMonitorWarningChanged);
 
     mUnreadMonitor->start();
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -45,17 +45,8 @@ TrayIcon::TrayIcon(bool showSettings)
     mThunderbirdStartTime = QDateTime::currentDateTime().addSecs(settings->mLaunchThunderbirdDelay);
 
     mWinTools = WindowTools::create();
-    createUnreadCounterThread();
-
-    // If the settings are not yet configure, pop up the message
-    if ( showSettings || (settings->mFolderNotificationColors.isEmpty() && QMessageBox::question(
-            nullptr, tr( "Would you like to set up Birdtray?" ),
-            tr( "You have not yet configured any email folders to monitor. "
-                "Would you like to do it now?") ) == QMessageBox::Yes )) {
-        QTimer::singleShot(0, this, &TrayIcon::actionSettings);
-    }
-
     createMenu();
+    createUnreadCounterThread();
 
     connect( &mBlinkingTimer, &QTimer::timeout, this, &TrayIcon::blinkTimeout );
     connect( this, &TrayIcon::activated, this, &TrayIcon::actionSystrayIconActivated );
@@ -76,6 +67,14 @@ TrayIcon::TrayIcon(bool showSettings)
     
     if (settings->mFolderNotificationList.isEmpty()) {
         unreadEmailsAtStart = 0;
+    }
+    
+    // If the settings are not yet configure, pop up the message
+    if ( showSettings || (settings->mFolderNotificationColors.isEmpty() && QMessageBox::question(
+            nullptr, tr( "Would you like to set up Birdtray?" ),
+            tr( "You have not yet configured any email folders to monitor. "
+                "Would you like to do it now?") ) == QMessageBox::Yes )) {
+        QTimer::singleShot(0, this, &TrayIcon::actionSettings);
     }
 }
 

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -285,21 +285,7 @@ void TrayIcon::updateIcon()
             toolTip << name + ": " + warning;
         }
         setToolTip(toolTip.join('\n'));
-        p.setOpacity(1.0);
-        int width = temp.width() / 4;
-        QPen pen(QColor(255, 150, 0, 255));
-//        QPen pen(Qt::white);
-        pen.setWidth(width);
-        p.setPen(pen);
-        int x = temp.width() - static_cast<int>(temp.width() * 0.125) - pen.width() / 2;
-        p.drawLine(x, static_cast<int>(temp.height() * 0.33), x, temp.height() - width / 2);
-        pen.setColor(Qt::red);
-//        pen.setColor(QColor(255, 100, 0, 255));
-        pen.setWidthF(std::max(pen.width() - 16, 1));
-//        pen.setWidthF(std::max(pen.width() - 12, 1));
-        p.setPen(pen);
-        p.drawLine(x, static_cast<int>(temp.height() * 0.33), x, temp.height() - 20 - width);
-        p.drawPoint(x, temp.height() - width / 2);
+        drawWarningIndicator(p, temp.size());
     }
 
     p.end();
@@ -803,4 +789,21 @@ void TrayIcon::doAutoUpdateCheck() {
     connect(autoUpdater, &AutoUpdater::onCheckUpdateFinished,
             this, &TrayIcon::onAutoUpdateCheckFinished);
     autoUpdater->checkForUpdates();
+}
+
+void TrayIcon::drawWarningIndicator(QPainter &painter, const QSize &iconSize) {
+    painter.setOpacity(1.0);
+    int width = iconSize.width() / 4;
+    QPen pen(QColor(255, 200, 0, 255));
+    pen.setWidth(width);
+    painter.setPen(pen);
+    int x = iconSize.width() - static_cast<int>(iconSize.width() * 0.125) - pen.width() / 2;
+    painter.drawLine(x, static_cast<int>(iconSize.height() * 0.33),
+            x, iconSize.height() - width / 2);
+    pen.setColor(QColor(255, 120, 0, 255));
+    pen.setWidthF(std::max(pen.width() - 16, 1));
+    painter.setPen(pen);
+    painter.drawLine(x, static_cast<int>(iconSize.height() * 0.33),
+            x, iconSize.height() - 20 - width);
+    painter.drawPoint(x, iconSize.height() - width / 2);
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -282,13 +282,20 @@ void TrayIcon::updateIcon()
         }
         setToolTip(toolTip.join('\n'));
         p.setOpacity(1.0);
-        QPen pen(QColor(255, 146, 0, 255));
-        int width = temp.width() / 5;
+        int width = temp.width() / 4;
+        QPen pen(QColor(255, 150, 0, 255));
+//        QPen pen(Qt::white);
         pen.setWidth(width);
         p.setPen(pen);
-        int x = temp.width() - 10 - width/ 2;
+        int x = temp.width() - static_cast<int>(temp.width() * 0.125) - pen.width() / 2;
+        p.drawLine(x, static_cast<int>(temp.height() * 0.33), x, temp.height() - width / 2);
+        pen.setColor(Qt::red);
+//        pen.setColor(QColor(255, 100, 0, 255));
+        pen.setWidthF(std::max(pen.width() - 16, 1));
+//        pen.setWidthF(std::max(pen.width() - 12, 1));
+        p.setPen(pen);
         p.drawLine(x, static_cast<int>(temp.height() * 0.33), x, temp.height() - 20 - width);
-        p.drawPoint(x, temp.height() - 10 - width / 2);
+        p.drawPoint(x, temp.height() - width / 2);
     }
 
     p.end();

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -52,7 +52,7 @@ TrayIcon::TrayIcon(bool showSettings)
             nullptr, tr( "Would you like to set up Birdtray?" ),
             tr( "You have not yet configured any email folders to monitor. "
                 "Would you like to do it now?") ) == QMessageBox::Yes )) {
-        actionSettings();
+        QTimer::singleShot(0, this, &TrayIcon::actionSettings);
     }
 
     createMenu();

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -267,8 +267,10 @@ void TrayIcon::updateIcon()
         if (!globalWarning.isNull()) {
             toolTip << tr("Warning: %1").arg(globalWarning);
         }
-        for (auto it = warnings.constKeyValueBegin(); it != warnings.constKeyValueEnd(); it++) {
-            const QString &path = (*it).first;
+        QMapIterator<QString, QString> warningsIterator(warnings);
+        while (warningsIterator.hasNext()) {
+            warningsIterator.next();
+            const QString &path = warningsIterator.key();
             if (path.isNull()) {
                 continue;
             }
@@ -280,7 +282,7 @@ void TrayIcon::updateIcon()
             } else {
                 name = Utils::decodeIMAPutf7(path);
             }
-            const QString &warning = (*it).second;
+            const QString &warning = warningsIterator.value();
             toolTip << name + ": " + warning;
         }
         setToolTip(toolTip.join('\n'));

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -100,6 +100,10 @@ WindowTools* TrayIcon::getWindowTools() const {
     return mWinTools;
 }
 
+UnreadMonitor* TrayIcon::getUnreadMonitor() const {
+    return mUnreadMonitor;
+}
+
 void TrayIcon::unreadCounterUpdate( unsigned int total, QColor color )
 {
     Utils::debug("unreadCounterUpdate %d", total );

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -35,8 +35,12 @@ class TrayIcon : public QSystemTrayIcon
     public slots:
         void    unreadCounterUpdate(unsigned int total, QColor color );
 
-        // An error happened
-        void    unreadCounterError( QString message );
+        /**
+         * The warning status of a watched path in the unread monitor changed.
+         *
+         * @param path The path whose warning has changed or a null-string for a global warning.
+         */
+        void unreadMonitorWarningChanged(const QString &path);
 
 
     private slots:
@@ -136,9 +140,6 @@ class TrayIcon : public QSystemTrayIcon
 
         // State checking timer (once a second)
         QTimer          mStateTimer;
-
-        // Current status
-        QString         mCurrentStatus;
 
         // Time when Thunderbird could be started
         QDateTime       mThunderbirdStartTime;

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -28,6 +28,11 @@ class TrayIcon : public QSystemTrayIcon
          * @return The window tools used by the tray icon.
          */
         WindowTools* getWindowTools() const;
+    
+        /**
+         * @return The unread monitor holding information about the watched mail accounts.
+         */
+        UnreadMonitor* getUnreadMonitor() const;
 
     signals:
         void    settingsChanged();

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -111,6 +111,13 @@ class TrayIcon : public QSystemTrayIcon
          * Do an automatic check for a new version of Birdtray.
          */
         void    doAutoUpdateCheck();
+        
+        /**
+         * Draw the warning indicator.
+         * @param painter The painter to use when drawing.
+         * @param iconSize The size of the icon image to draw on in pixel.
+         */
+        static void drawWarningIndicator(QPainter &painter, const QSize &iconSize);
 
         // State variables for blinking; mBlinkingTimeout=0 means we are not blinking
         double          mBlinkingIconOpacity;

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -53,7 +53,7 @@ void UnreadMonitor::run()
     exec();
 }
 
-const QMap<QString, QString> UnreadMonitor::getWarnings() const {
+const QMap<QString, QString> &UnreadMonitor::getWarnings() const {
     return warnings;
 }
 

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -242,7 +242,8 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
         for (const QString &path : settings->mFolderNotificationColors.keys()) {
             mMorkUnreadCounts[path] = getMorkUnreadCount(path);
             if (!mDBWatcher.files().contains(path) && !mDBWatcher.addPath(path)) {
-                setWarning(tr("Unable to watch %1 for changes.").arg(path), path);
+                setWarning(tr("Unable to watch %1 for changes.")
+                        .arg(QFileInfo(path).fileName()), path);
             } else {
                 clearWarning(path);
             }
@@ -279,7 +280,7 @@ int UnreadMonitor::getMorkUnreadCount(const QString &path)
 {
     MorkParser parser;
     if (!parser.open(path)) {
-        setWarning(tr("Unable to read from %1.").arg(path), path);
+        setWarning(tr("Unable to read from %1.").arg(QFileInfo(path).fileName()), path);
         return 0;
     } else {
         clearWarning(path);

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -67,7 +67,12 @@ void UnreadMonitor::slotSettingsChanged()
     }
 
     mMorkUnreadCounts.clear();
-
+    QStringList accountsList = BirdtrayApp::get()->getSettings()->mFolderNotificationList;
+    for (const QString &path : warnings.keys()) {
+        if (!accountsList.contains(path)) {
+            clearWarning(path);
+        }
+    }
     updateUnread();
 }
 

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -53,6 +53,10 @@ void UnreadMonitor::run()
     exec();
 }
 
+const QMap<QString, QString> UnreadMonitor::getWarnings() const {
+    return warnings;
+}
+
 void UnreadMonitor::slotSettingsChanged()
 {
     // We reinitialize everything because the settings changed
@@ -87,7 +91,7 @@ bool UnreadMonitor::openDatabase()
                            &mSqlitedb,
                            SQLITE_OPEN_READONLY, 0 ) != SQLITE_OK )
     {
-        emit error(tr("Error opening sqlite database: %1").arg(sqlite3_errmsg(mSqlitedb)));
+        setWarning(tr("Error opening sqlite database: %1").arg(sqlite3_errmsg(mSqlitedb)));
         return false;
     }
 
@@ -96,9 +100,12 @@ bool UnreadMonitor::openDatabase()
     mAllFolderIDs.clear();
 
     SQLiteStatement stmt;
-
-    if ( !stmt.prepare( mSqlitedb, "SELECT id,folderURI FROM folderlocations") )
+    
+    if (!stmt.prepare(mSqlitedb, "SELECT id,folderURI FROM folderlocations")) {
+        setWarning(tr("Cannot query database: %1").arg(sqlite3_errmsg(mSqlitedb)));
         return false;
+    }
+    clearWarning();
 
     // Make a copy as we'd delete them when found
     auto folders = BirdtrayApp::get()->getSettings()->mFolderNotificationColors;
@@ -117,13 +124,15 @@ bool UnreadMonitor::openDatabase()
 
             mAllFolderIDs += QString::number( id );
             folders.remove( uri );
+            clearWarning(uri);
         }
     }
 
     // If anything left, we didn't find those
-    if ( !folders.isEmpty() )
-    {
-        emit error(tr("Folder %1 was not found in database.").arg(folders.firstKey()));
+    for (const QString &uri: folders.keys()) {
+        setWarning(tr("Folder %1 was not found in database.").arg(uri), uri);
+    }
+    if (!folders.isEmpty()) {
         return false;
     }
 
@@ -175,10 +184,13 @@ void UnreadMonitor::getUnreadCount_SQLite(int &count, QColor &color)
     SQLiteStatement stmt;
 
     // This returns the number of unread messages (JSON attribute "59": false)
-    if ( !stmt.prepare( mSqlitedb, QString("SELECT folderID FROM messages WHERE folderID IN (%1) AND json_extract( jsonAttributes, '$.59' ) = 0") .arg( mAllFolderIDs) ) )
-    {
-        emit error(tr("Cannot query database."));
-        this->exit( 0 );
+    if (!stmt.prepare(mSqlitedb,QString(
+            "SELECT folderID FROM messages WHERE folderID IN (%1) "
+            "AND json_extract( jsonAttributes, '$.59' ) = 0").arg(mAllFolderIDs))) {
+        setWarning(tr("Cannot query database."));
+        this->exit(0);
+    } else {
+        clearWarning();
     }
 
     int res;
@@ -228,12 +240,11 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
     {
         mMorkUnreadCounts.clear();
         for (const QString &path : settings->mFolderNotificationColors.keys()) {
-            if (!QFile::exists(path)) {
-                continue;
-            }
             mMorkUnreadCounts[path] = getMorkUnreadCount(path);
             if (!mDBWatcher.files().contains(path) && !mDBWatcher.addPath(path)) {
-                emit error(tr("Unable to watch %1 for changes.").arg(path));
+                setWarning(tr("Unable to watch %1 for changes.").arg(path), path);
+            } else {
+                clearWarning(path);
             }
         }
     }
@@ -267,10 +278,12 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
 int UnreadMonitor::getMorkUnreadCount(const QString &path)
 {
     MorkParser parser;
-
-    if ( !parser.open( path ) )
+    if (!parser.open(path)) {
+        setWarning(tr("Unable to read from %1.").arg(path), path);
         return 0;
-
+    } else {
+        clearWarning(path);
+    }
     unsigned int unread = 0;
 
     // First we parse the unreadChildren column (generic view)
@@ -330,4 +343,17 @@ int UnreadMonitor::getMorkUnreadCount(const QString &path)
 
     Utils::debug("Unread counter for %s: %d", qPrintable( path ), unread );
     return unread;
+}
+
+void UnreadMonitor::setWarning(const QString &message, const QString &path) {
+    if (warnings.value(path) != message) {
+        warnings.insert(path, message);
+        emit warningChanged(path);
+    }
+}
+
+void UnreadMonitor::clearWarning(const QString &path) {
+    if (warnings.remove(path) > 0) {
+        emit warningChanged(path);
+    }
 }

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -36,7 +36,7 @@ class UnreadMonitor : public QThread
         void    unreadUpdated( unsigned int total, QColor color );
 
         /**
-         * A warning was added or removed for the given watched path
+         * A warning was added or removed for the given watched path.
          *
          * @param path The watched path or null-string for a global warning.
          */

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -22,13 +22,25 @@ class UnreadMonitor : public QThread
 
         // Thread run function
         virtual void run() override;
+    
+        /**
+         * Get the current warnings for the watched paths.
+         * The null-string key can contain a warning for all paths.
+         *
+         * @return A path to warnings mapping.
+         */
+        const QMap<QString, QString> getWarnings() const;
 
     signals:
         // Unread counter changed
         void    unreadUpdated( unsigned int total, QColor color );
 
-        // An error happened
-        void    error( QString message );
+        /**
+         * A warning was added or removed for the given watched path
+         *
+         * @param path The watched path or null-string for a global warning.
+         */
+        void warningChanged(const QString &path);
 
     public slots:
         void    slotSettingsChanged();
@@ -41,6 +53,23 @@ class UnreadMonitor : public QThread
         void    getUnreadCount_SQLite( int & count, QColor& color );
         void    getUnreadCount_Mork( int & count, QColor& color );
         int     getMorkUnreadCount( const QString& path );
+    
+        /**
+         * Set a warning for a given path or for all paths, if no path is given.
+         * Overwrites any previous warning.
+         *
+         * @param message The warning message.
+         * @param path The watched path.
+         */
+        void setWarning(const QString &message, const QString &path = QString());
+        
+        /**
+         * Reset the warning if there was one for the given watched path.
+         * Or reset the global warning for all paths, if no path is given.
+         *
+         * @param path
+         */
+        void clearWarning(const QString &path = QString());
 
     private:
         QString         mSqliteDbFile;
@@ -71,6 +100,12 @@ class UnreadMonitor : public QThread
         // Last reported unread
         int    mLastReportedUnread;
         QColor mLastColor;
+    
+        /**
+         * This contains mappings from watched paths to warning messages for that path.
+         * If there is a warning in the null-string key, it applies to all paths.
+         */
+        QMap<QString, QString> warnings;
 };
 
 #endif /* UNREAD_MONITOR_H */

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -29,7 +29,7 @@ class UnreadMonitor : public QThread
          *
          * @return A path to warnings mapping.
          */
-        const QMap<QString, QString> getWarnings() const;
+        const QMap<QString, QString> &getWarnings() const;
 
     signals:
         // Unread counter changed


### PR DESCRIPTION
Previously, we showed a red `X` in the icon, if the parsing of one account failed, even if we could parse the unread count from other accounts.

We now don't abort the parsing process, if only one account couldn't be parsed. If a problem occurs, we show an exclamation mark in the icon:
![Icon with warning](https://user-images.githubusercontent.com/6966049/70569765-da52e280-1b9a-11ea-96a6-4ce5d6342966.PNG)
![Icon with unread count and warning](https://user-images.githubusercontent.com/6966049/70569776-dd4dd300-1b9a-11ea-93a0-dad9d16b26ac.PNG)
Additionally, a tooltip is added with the problem description:
![Warning tooltip](https://user-images.githubusercontent.com/6966049/70569855-04a4a000-1b9b-11ea-9f60-4d0b0abdcb0d.PNG)
<details>
<summary>Problematic accounts are also marked in the settings.</summary>

![Accounts list with warning](https://user-images.githubusercontent.com/6966049/70570076-8399d880-1b9b-11ea-8f75-85de1665d2ca.PNG)
</details>

If anybody has a better color combination for the exclamation mark, let me know. I'm not an artist and this is the best I could come up with that was still readable on the small icon.
