### PR TITLE
Add option to ignore unread mails at startup (by @Mintulix)

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -79,6 +79,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     spinUnreadOpacityLevel->setValue( settings->mUnreadOpacityLevel * 100 );
     spinThunderbirdStartDelay->setValue( settings->mLaunchThunderbirdDelay );
     boxShowUnreadCount->setChecked( settings->mShowUnreadEmailCount );
+    ignoreStartupMailCountBox->setChecked(settings->ignoreStartUnreadCount);
 
     // Form the proper command-line (with escaped arguments if they contain spaces
     QString tbcmdline;
@@ -191,6 +192,7 @@ void DialogSettings::accept()
     settings->mUnreadOpacityLevel = (double) spinUnreadOpacityLevel->value() / 100.0;
     settings->mLaunchThunderbirdDelay = spinThunderbirdStartDelay->value();
     settings->mShowUnreadEmailCount = boxShowUnreadCount->isChecked();
+    settings->ignoreStartUnreadCount = ignoreStartupMailCountBox->isChecked();
 
     settings->setNotificationIcon(btnNotificationIcon->icon().pixmap( settings->mIconSize ));
 

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -425,14 +425,28 @@
            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="boxAllowSuppression">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Allow ignoring the current unread email counter</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <item>
+             <widget class="QCheckBox" name="boxAllowSuppression">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Allow ignoring the current unread email counter</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="ignoreStartupMailCountBox">
+              <property name="toolTip">
+               <string>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</string>
+              </property>
+              <property name="text">
+               <string>Ignore unread emails at startup</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -1006,6 +1020,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnAccountEdit</tabstop>
   <tabstop>btnAccountRemove</tabstop>
   <tabstop>boxAllowSuppression</tabstop>
+  <tabstop>ignoreStartupMailCountBox</tabstop>
   <tabstop>boxLaunchThunderbirdAtStart</tabstop>
   <tabstop>spinThunderbirdStartDelay</tabstop>
   <tabstop>boxHideWindowAtStart</tabstop>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -45,6 +45,7 @@ Settings::Settings(bool verboseOutput)
     mAllowSuppressingUnreads = false;
     mLaunchThunderbirdDelay = 0;
     mShowUnreadEmailCount = true;
+    ignoreStartUnreadCount = false;
     mThunderbirdWindowMatch = "- Mozilla Thunderbird";
     mNotificationMinimumFontSize = 4;
     mNotificationMaximumFontSize = 512;
@@ -82,6 +83,7 @@ void Settings::save()
     mSettings->setValue("common/allowsuppressingunread", mAllowSuppressingUnreads );
     mSettings->setValue("common/launchthunderbirddelay", mLaunchThunderbirdDelay );
     mSettings->setValue("common/showunreademailcount", mShowUnreadEmailCount );
+    mSettings->setValue("common/ignoreStartUnreadCount", ignoreStartUnreadCount);
 
     mSettings->setValue("advanced/tbcmdline", mThunderbirdCmdLine );
     mSettings->setValue("advanced/tbwindowmatch", mThunderbirdWindowMatch );
@@ -167,6 +169,8 @@ void Settings::load()
             "common/launchthunderbirddelay", mLaunchThunderbirdDelay ).toInt();
     mShowUnreadEmailCount = mSettings->value(
             "common/showunreademailcount", mShowUnreadEmailCount ).toBool();
+    ignoreStartUnreadCount = mSettings->value(
+            "common/ignoreStartUnreadCount", ignoreStartUnreadCount).toBool();
 
     QStringList thunderbirdCommand = mSettings->value(
             "advanced/tbcmdline", mThunderbirdCmdLine).toStringList();

--- a/src/settings.h
+++ b/src/settings.h
@@ -103,6 +103,11 @@ class Settings
 
         // Whether to show the unread email count
         bool    mShowUnreadEmailCount;
+        
+        /**
+         * Ignore the total number of unread emails that are present at startup.
+         */
+        bool    ignoreStartUnreadCount;
 
         // Watching file timeout (ms)
         unsigned int mWatchFileTimeout;

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -553,6 +553,14 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Vielen Dank für Ihre Unterstützung!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Ignore unread emails at startup</source>
+        <translation>Ignoriere ungelesene Emails, die beim Starten bereits vorhanden sind</translation>
+    </message>
+    <message>
+        <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
+        <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -518,6 +518,14 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Ignore unread emails at startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -115,6 +115,11 @@ class TrayIcon : public QSystemTrayIcon
         // Current unread messages count and color
         unsigned int    mUnreadCounter;
         QColor          mUnreadColor;
+        
+        /**
+         * The number of unread emails at Birdtray startup.
+         */
+        long            unreadEmailsAtStart = -1;
 
         // Show/hide Thunderbird menu item (we modify its text)
         QAction *       mMenuShowHideThunderbird;


### PR DESCRIPTION
This implements @Mintulix idea from #191 to add an option to ignore unread emails that already exist when Birdtray starts.

This is disabled by default. It can be enabled via a settings in the monitoring tab:
<details>
<summary>Image</summary>

![Monitoring tab in settings with new option](https://user-images.githubusercontent.com/6966049/70581524-b6ea6080-1bb7-11ea-8d89-ae7319693955.PNG)
</details>

@Mintulix Can you please test that this still works as you intended?