### PR TITLE
Add a "Don't ask again" button to the "No accounts configured" dialog

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -46,6 +46,7 @@ Settings::Settings(bool verboseOutput)
     mLaunchThunderbirdDelay = 0;
     mShowUnreadEmailCount = true;
     ignoreStartUnreadCount = false;
+    showDialogIfNoAccountsConfigured = true;
     mThunderbirdWindowMatch = "- Mozilla Thunderbird";
     mNotificationMinimumFontSize = 4;
     mNotificationMaximumFontSize = 512;
@@ -84,6 +85,8 @@ void Settings::save()
     mSettings->setValue("common/launchthunderbirddelay", mLaunchThunderbirdDelay );
     mSettings->setValue("common/showunreademailcount", mShowUnreadEmailCount );
     mSettings->setValue("common/ignoreStartUnreadCount", ignoreStartUnreadCount);
+    mSettings->setValue("common/showDialogIfNoAccountsConfigured",
+            showDialogIfNoAccountsConfigured);
 
     mSettings->setValue("advanced/tbcmdline", mThunderbirdCmdLine );
     mSettings->setValue("advanced/tbwindowmatch", mThunderbirdWindowMatch );
@@ -171,6 +174,8 @@ void Settings::load()
             "common/showunreademailcount", mShowUnreadEmailCount ).toBool();
     ignoreStartUnreadCount = mSettings->value(
             "common/ignoreStartUnreadCount", ignoreStartUnreadCount).toBool();
+    showDialogIfNoAccountsConfigured = mSettings->value(
+            "common/showDialogIfNoAccountsConfigured", showDialogIfNoAccountsConfigured).toBool();
 
     QStringList thunderbirdCommand = mSettings->value(
             "advanced/tbcmdline", mThunderbirdCmdLine).toStringList();

--- a/src/settings.h
+++ b/src/settings.h
@@ -108,6 +108,11 @@ class Settings
          * Ignore the total number of unread emails that are present at startup.
          */
         bool    ignoreStartUnreadCount;
+        
+        /**
+         * Enables or disabled the dialog on startup that shows if no accounts were configured.
+         */
+        bool    showDialogIfNoAccountsConfigured;
 
         // Watching file timeout (ms)
         unsigned int mWatchFileTimeout;

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -821,6 +821,10 @@ Wollen Sie fortfahren?</translation>
         <source>Warning: %1</source>
         <translation>Warnung: %1</translation>
     </message>
+    <message>
+        <source>Don&apos;t ask again</source>
+        <translation>Nicht nochmal fragen</translation>
+    </message>
 </context>
 <context>
     <name>UnreadMonitor</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -796,6 +796,10 @@ Do you want to continue?</source>
         <source>Warning: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Don&apos;t ask again</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UnreadMonitor</name>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -77,7 +77,7 @@ TrayIcon::TrayIcon(bool showSettings)
                    "Would you like to do it now?"), QMessageBox::Yes | QMessageBox::No);
         QPushButton* dontAskAgainButton = questionDialog.addButton(
                 tr("Don't ask again"), QMessageBox::RejectRole);
-        showSettings = questionDialog.exec() == QDialog::Accepted;
+        showSettings = questionDialog.exec() == QMessageBox::Yes;
         if (questionDialog.clickedButton() == dontAskAgainButton) {
             settings->showDialogIfNoAccountsConfigured = false;
             settings->save();

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -70,10 +70,20 @@ TrayIcon::TrayIcon(bool showSettings)
     }
     
     // If the settings are not yet configure, pop up the message
-    if ( showSettings || (settings->mFolderNotificationColors.isEmpty() && QMessageBox::question(
-            nullptr, tr( "Would you like to set up Birdtray?" ),
-            tr( "You have not yet configured any email folders to monitor. "
-                "Would you like to do it now?") ) == QMessageBox::Yes )) {
+    if (!showSettings && settings->showDialogIfNoAccountsConfigured
+        && settings->mFolderNotificationColors.isEmpty()) {
+        QMessageBox questionDialog(QMessageBox::Question, tr("Would you like to set up Birdtray?"),
+                tr("You have not yet configured any email folders to monitor. "
+                   "Would you like to do it now?"), QMessageBox::Yes | QMessageBox::No);
+        QPushButton* dontAskAgainButton = questionDialog.addButton(
+                tr("Don't ask again"), QMessageBox::RejectRole);
+        showSettings = questionDialog.exec() == QDialog::Accepted;
+        if (questionDialog.clickedButton() == dontAskAgainButton) {
+            settings->showDialogIfNoAccountsConfigured = false;
+            settings->save();
+        }
+    }
+    if (showSettings) {
         QTimer::singleShot(0, this, &TrayIcon::actionSettings);
     }
 }


### PR DESCRIPTION
This closes #216. The new `Don't ask again` button allows to disable the dialog.