### PR TITLE
Only allow one one Birdtray instance

### DIFF
--- a/src/birdtrayapp.h
+++ b/src/birdtrayapp.h
@@ -3,6 +3,8 @@
 
 #include <QApplication>
 #include <QTranslator>
+#include <QtNetwork/QLocalServer>
+#include <QtNetwork/QLocalSocket>
 #include <QtCore/QCommandLineParser>
 #include "settings.h"
 #include "autoupdater.h"
@@ -49,6 +51,13 @@ public:
 protected:
     bool event(QEvent* event) override;
 
+protected Q_SLOTS:
+    
+    /**
+     * Called when a secondary Birdtray instance attaches to this primary instance.
+     */
+    void onSecondInstanceAttached();
+
 private:
     /**
      * A translator holding the current Qt system translation
@@ -81,6 +90,16 @@ private:
     TrayIcon* trayIcon = nullptr;
     
     /**
+     * A server to handle commands from secondary Birdtray instances.
+     */
+    QLocalServer* singleInstanceServer = nullptr;
+    
+    /**
+     * Command line parser containing the parsed Birdtray command line.
+     */
+    QCommandLineParser commandLineParser;
+    
+    /**
      * Load the translations for the current system locale.
      *
      * @return True, if a translation for the current locale has been loaded successfully.
@@ -100,11 +119,40 @@ private:
                                 const QString &translationName, const QStringList &paths);
     
     /**
-     * Parse the command line arguments.
-     *
-     * @param parser A command line parser that will contain the parsed arguments.
+     * Parse the command line arguments given to Birdtray.
      */
-    void parseCmdArguments(QCommandLineParser &parser);
+    void parseCmdArguments();
+    
+    /**
+     * Start a local server to handle requests from secondary instances of Birdtray.
+     * If this succeeds, this instance of Birdtray will become the primary singleton instance.
+     *
+     * @return true if the server was started successfully,
+     *         false if another instance of Birdtray is already running.
+     */
+    bool startSingleInstanceServer();
+    
+    /**
+     * Connect to a running instance of Birdtray.
+     *
+     * @return true, if a connection was established successfully.
+     */
+    bool connectToRunningInstance() const;
+    
+    /**
+     * Send commands indicated by the command line to the primary singleton Birdtray instance.
+     *
+     * @param serverSocket The socket tu use to communicate with the singleton Birdtray instance.
+     */
+    void sendCommandsToRunningInstance(QLocalSocket &serverSocket) const;
+    
+    /**
+     * Called when the primary Birdtray instance receives
+     * a command from a secondary Birdtray instance.
+     *
+     * @param clientSocket The socket to the secondary Birdtray instance.
+     */
+    void onSecondInstanceCommand(QLocalSocket* clientSocket);
     
     /**
      * Wait for the system tray to become available and exit if it doesn't within 60 seconds.

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -563,11 +563,17 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Birdtray ist eine FREIE SOFTWARE, welche unter der General Public License v3 lizenziert ist. Sie können Birtray also für jeden Zweck, auch für kommerzielle Zwecke, verwenden, ohne etwas zu bezahlen.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Für Hilfe, um Verbesserungen vorzuschlagen oder um Fehler zu melden nutzen Sie bitte die &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;Github Projektseite&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Diejenigen, die meine Arbeit an Birdtray wertschätzen, die ich in meiner freien Zeit mache, können mich hier unterstützen: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Vielen Dank für Ihre Unterstützung!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Ignore unread emails at startup</source>
+        <translation>Ignoriere ungelesene Emails, die beim Starten bereits vorhanden sind</translation>
+    </message>
+    <message>
+        <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
+        <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -74,15 +74,15 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
     </message>
     <message>
         <source>Toggle the Thunderbird window.</source>
-        <translation type="unfinished"></translation>
+        <translation>Toggelt das Thunderbird Fenster.</translation>
     </message>
     <message>
         <source>Show the Thunderbird window.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeight das Thunderbird Fenster.</translation>
     </message>
     <message>
         <source>Hide the Thunderbird window.</source>
-        <translation type="unfinished"></translation>
+        <translation>Versteckt das Thunderbird Fenster.</translation>
     </message>
 </context>
 <context>
@@ -563,17 +563,11 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Birdtray ist eine FREIE SOFTWARE, welche unter der General Public License v3 lizenziert ist. Sie können Birtray also für jeden Zweck, auch für kommerzielle Zwecke, verwenden, ohne etwas zu bezahlen.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Für Hilfe, um Verbesserungen vorzuschlagen oder um Fehler zu melden nutzen Sie bitte die &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;Github Projektseite&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Diejenigen, die meine Arbeit an Birdtray wertschätzen, die ich in meiner freien Zeit mache, können mich hier unterstützen: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Noto Sans&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Vielen Dank für Ihre Unterstützung!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignoriere ungelesene Emails, die beim Starten bereits vorhanden sind</translation>
-    </message>
-    <message>
-        <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
-        <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -72,6 +72,18 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <source>Enable debugging output.</source>
         <translation>Aktiviert Debugging-Ausgaben.</translation>
     </message>
+    <message>
+        <source>Toggle the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseAccounts</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -69,6 +69,18 @@ OpenSSL might not be installed.</source>
         <source>Enable debugging output.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide the Thunderbird window.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseAccounts</name>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -84,7 +84,7 @@ TrayIcon::TrayIcon(bool showSettings)
         }
     }
     if (showSettings) {
-        QTimer::singleShot(0, this, &TrayIcon::actionSettings);
+        QTimer::singleShot(0, this, &TrayIcon::showSettings);
     }
 }
 

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -440,7 +440,7 @@ void TrayIcon::actionQuit()
     QApplication::quit();
 }
 
-void TrayIcon::actionSettings()
+void TrayIcon::showSettings()
 {
     if (settingsDialog != nullptr) {
         settingsDialog->show();
@@ -642,7 +642,7 @@ void TrayIcon::createMenu()
     mSystrayMenu->addSeparator();
 
     // Some generic actions
-    mSystrayMenu->addAction( tr("Settings..."), this, SLOT(actionSettings()) );
+    mSystrayMenu->addAction( tr("Settings..."), this, SLOT(showSettings()) );
 
     mSystrayMenu->addSeparator();
 

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -33,6 +33,16 @@ class TrayIcon : public QSystemTrayIcon
          * @return The unread monitor holding information about the watched mail accounts.
          */
         UnreadMonitor* getUnreadMonitor() const;
+    
+        /**
+         * Hide the Thunderbird window.
+         */
+        void hideThunderbird();
+        
+        /**
+         * Show the Thunderbird window.
+         */
+        void showThunderbird();
 
     signals:
         void    settingsChanged();
@@ -46,6 +56,11 @@ class TrayIcon : public QSystemTrayIcon
          * @param path The path whose warning has changed or a null-string for a global warning.
          */
         void unreadMonitorWarningChanged(const QString &path);
+        
+        /**
+         * Show the settings dialog.
+         */
+        void showSettings();
 
 
     private slots:
@@ -64,7 +79,6 @@ class TrayIcon : public QSystemTrayIcon
 
         // Context menu actions
         static void actionQuit();
-        void    actionSettings();
         void    actionActivate();
         void    actionSnoozeFor();
         void    actionUnsnooze();
@@ -103,8 +117,6 @@ class TrayIcon : public QSystemTrayIcon
     private:
         void    createMenu();
         void    createUnreadCounterThread();
-        void    hideThunderbird();
-        void    showThunderbird();
         void    updateIgnoredUnreads();
         
         /**


### PR DESCRIPTION
This allows only one instance of Birdtray to be running at any given time (preventing situations like #157).
The details of the implementation were discussed in #209. It was tested with Windows 10 and Ubuntu 18.04.
The second instance will exit, once it passes its arguments to the first instance.
This makes it possible to control the first instance of Birdtray by starting the second instance with a command, e.g. to toggle the Thunderbird window (closes #48).

The following new commands were added (they currently only work if another Birdtray instance is already running):
* `--show`: Shows the Thunderbird window.
* `--hide`: Hides the Thunderbird window.
* `--toggle`: Shows the Thunderbird window if it was hidden, hides it otherwise.

The `--settings` command can now also be used to display the settings dialog of an existing Birdtray instance.