### PR TITLE
Fix memory leaks in windowtools_x11.cpp

### DIFF
--- a/src/windowtools_x11.cpp
+++ b/src/windowtools_x11.cpp
@@ -244,6 +244,9 @@ static Window activeWindow(Display * display) {
         int revert;
         XGetInputFocus(display, &w, &revert);
     }
+    if (r == Success) {
+        XFree(data);
+    }
     return w;
 }
 

--- a/src/windowtools_x11.cpp
+++ b/src/windowtools_x11.cpp
@@ -185,33 +185,27 @@ static bool analyzeWindow(Display *display, Window w, const QString &ename )
  */
 static Window findWindow(Display *display, Window window, bool checkNormality, const QString &ename, QList<Window> dockedWindows = QList<Window>() )
 {
-    Window w = None;
+    Window targetWindow = None;
     Window root;
     Window parent;
-    Window *child;
+    Window *children;
     unsigned int num_child;
 
-    if (XQueryTree(display, window, &root, &parent, &child, &num_child) != 0) {
+    if (XQueryTree(display, window, &root, &parent, &children, &num_child) != 0) {
         for (unsigned int i = 0; i < num_child; i++) {
-            if (analyzeWindow(display, child[i], ename)) {
-                if (!dockedWindows.contains(child[i])) {
-                    if (checkNormality) {
-                        if (isNormalWindow(display, child[i])) {
-                            return child[i];
-                        }
-                    } else {
-                        return child[i];
-                    }
-                }
+            if (analyzeWindow(display, children[i], ename) && !dockedWindows.contains(children[i])
+                && (!checkNormality || isNormalWindow(display, children[i]))) {
+                targetWindow = children[i];
+                break;
             }
-
-            w = findWindow(display, child[i], checkNormality, ename);
-            if (w != None) {
+            targetWindow = findWindow(display, children[i], checkNormality, ename);
+            if (targetWindow != None) {
                 break;
             }
         }
+        XFree(children);
     }
-    return w;
+    return targetWindow;
 }
 
 /*


### PR DESCRIPTION
According to the [```XQueryTree``` documentation](https://tronche.com/gui/x/xlib/window-information/XQueryTree.html) it is the responsibility of the caller to free the list of children windows.
The same goes for the data parameter of [```XGetWindowProperty```](https://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html).

This should fix #219.