### PR TITLE
Clarify the show, hide and toggle command line options

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -9,9 +9,9 @@
 #include "windowtools.h"
 
 #define SINGLE_INSTANCE_SERVER_NAME "birdtray.ulduzsoft.single.instance.server.socket"
-#define TOGGLE_THUNDERBIRD_COMMAND "toggle-thunderbird"
-#define SHOW_THUNDERBIRD_COMMAND "show-thunderbird"
-#define HIDE_THUNDERBIRD_COMMAND "hide-thunderbird"
+#define TOGGLE_THUNDERBIRD_COMMAND "toggle-tb"
+#define SHOW_THUNDERBIRD_COMMAND "show-tb"
+#define HIDE_THUNDERBIRD_COMMAND "hide-tb"
 #define SETTINGS_COMMAND "settings"
 
 

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -9,9 +9,9 @@
 #include "windowtools.h"
 
 #define SINGLE_INSTANCE_SERVER_NAME "birdtray.ulduzsoft.single.instance.server.socket"
-#define TOGGLE_THUNDERBIRD_COMMAND "toggle"
-#define SHOW_THUNDERBIRD_COMMAND "show"
-#define HIDE_THUNDERBIRD_COMMAND "hide"
+#define TOGGLE_THUNDERBIRD_COMMAND "toggle-thunderbird"
+#define SHOW_THUNDERBIRD_COMMAND "show-thunderbird"
+#define HIDE_THUNDERBIRD_COMMAND "hide-thunderbird"
 #define SETTINGS_COMMAND "settings"
 
 

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -157,9 +157,9 @@ void BirdtrayApp::parseCmdArguments() {
              tr("databaseFile")},
             {"decode", tr("Decode an IMAP Utf7 string."), tr("string")},
             {SETTINGS_COMMAND, tr("Show the settings.")},
-            {TOGGLE_THUNDERBIRD_COMMAND, tr("Toggle the Thunderbird window.")},
-            {SHOW_THUNDERBIRD_COMMAND, tr("Show the Thunderbird window.")},
-            {HIDE_THUNDERBIRD_COMMAND, tr("Hide the Thunderbird window.")},
+            {{"t", TOGGLE_THUNDERBIRD_COMMAND}, tr("Toggle the Thunderbird window.")},
+            {{"s", SHOW_THUNDERBIRD_COMMAND}, tr("Show the Thunderbird window.")},
+            {{"H", HIDE_THUNDERBIRD_COMMAND}, tr("Hide the Thunderbird window.")},
             {{"r", "reset-settings"}, tr("Reset the settings to the defaults.")},
             {{"d", "debug"}, tr("Enable debugging output.")},
     });


### PR DESCRIPTION
I propose to add a `-thunderbird` suffix to the name of the three command line options, to prevent confusion about their meaning. This shouldn't really affect anybody, since these commands were added only two days ago.

`--toggle` → `--toggle-thunderbird`
`--show` → `--show-thunderbird`
`--hide` → `--hide-thunderbird`