### PR TITLE
Add setting to hide the Birdtray icon if no new mail is present

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -80,6 +80,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     spinThunderbirdStartDelay->setValue( settings->mLaunchThunderbirdDelay );
     boxShowUnreadCount->setChecked( settings->mShowUnreadEmailCount );
     ignoreStartupMailCountBox->setChecked(settings->ignoreStartUnreadCount);
+    onlyShowIconOnNewMail->setChecked(settings->onlyShowIconOnUnreadMessages);
 
     // Form the proper command-line (with escaped arguments if they contain spaces
     QString tbcmdline;
@@ -193,6 +194,7 @@ void DialogSettings::accept()
     settings->mLaunchThunderbirdDelay = spinThunderbirdStartDelay->value();
     settings->mShowUnreadEmailCount = boxShowUnreadCount->isChecked();
     settings->ignoreStartUnreadCount = ignoreStartupMailCountBox->isChecked();
+    settings->onlyShowIconOnUnreadMessages = onlyShowIconOnNewMail->isChecked();
 
     settings->setNotificationIcon(btnNotificationIcon->icon().pixmap( settings->mIconSize ));
 

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -868,7 +868,7 @@
             <item>
              <widget class="QCheckBox" name="onlyShowIconOnNewMail">
               <property name="text">
-               <string>hide it if no new mail is present</string>
+               <string>hide it if no new mail is present.</string>
               </property>
              </widget>
             </item>

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -861,7 +861,14 @@
             <item>
              <widget class="QLabel" name="label_14">
               <property name="text">
-               <string>opaque when new mail is present</string>
+               <string>opaque when new mail is present,</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="onlyShowIconOnNewMail">
+              <property name="text">
+               <string>hide it if no new mail is present</string>
               </property>
              </widget>
             </item>
@@ -1055,6 +1062,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>spinMinimumFontSize</tabstop>
   <tabstop>boxBlinkingUsesAlpha</tabstop>
   <tabstop>spinUnreadOpacityLevel</tabstop>
+  <tabstop>onlyShowIconOnNewMail</tabstop>
   <tabstop>checkUpdateOnStartup</tabstop>
   <tabstop>checkUpdateButton</tabstop>
   <tabstop>browserAbout</tabstop>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -9,6 +9,7 @@
 #define BORDER_COLOR_KEY "common/bordercolor"
 #define BORDER_WIDTH_KEY "common/borderwidth"
 #define UPDATE_ON_STARTUP_KEY "advanced/updateOnStartup"
+#define ONLY_SHOW_ICON_ON_UNREAD_MESSAGES_KEY "advanced/onlyShowIconOnUnreadMessages"
 #define READ_INSTALL_CONFIG_KEY "hasReadInstallConfig"
 
 Settings::Settings(bool verboseOutput)
@@ -54,6 +55,7 @@ Settings::Settings(bool verboseOutput)
     mWatchFileTimeout = 150;
     mBlinkingUseAlphaTransition = false;
     mUpdateOnStartup = false;
+    onlyShowIconOnUnreadMessages = false;
     mUnreadOpacityLevel = 0.75;
     mNewEmailMenuEnabled = false;
     mThunderbirdCmdLine = Utils::getDefaultThunderbirdCommand();
@@ -98,6 +100,7 @@ void Settings::save()
     mSettings->setValue("advanced/unreadopacitylevel", mUnreadOpacityLevel );
     mSettings->setValue(UPDATE_ON_STARTUP_KEY, mUpdateOnStartup );
     mSettings->setValue("advanced/ignoreUpdateVersion", mIgnoreUpdateVersion );
+    mSettings->setValue(ONLY_SHOW_ICON_ON_UNREAD_MESSAGES_KEY, onlyShowIconOnUnreadMessages );
 
     // Convert the map into settings
     mSettings->setValue("accounts/count", mFolderNotificationColors.size() );
@@ -195,6 +198,8 @@ void Settings::load()
     mUnreadOpacityLevel = mSettings->value(
             "advanced/unreadopacitylevel", mUnreadOpacityLevel ).toDouble();
     mUpdateOnStartup = mSettings->value(UPDATE_ON_STARTUP_KEY, mUpdateOnStartup ).toBool();
+    onlyShowIconOnUnreadMessages = mSettings->value(
+            ONLY_SHOW_ICON_ON_UNREAD_MESSAGES_KEY, onlyShowIconOnUnreadMessages ).toBool();
     mIgnoreUpdateVersion = mSettings->value(
             "advanced/ignoreUpdateVersion", mIgnoreUpdateVersion ).toString();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -113,6 +113,11 @@ class Settings
          * Enables or disabled the dialog on startup that shows if no accounts were configured.
          */
         bool    showDialogIfNoAccountsConfigured;
+        
+        /**
+         * Whether to show the Birdtray system tray icon only if there are unread Mail messages.
+         */
+        bool    onlyShowIconOnUnreadMessages;
 
         // Watching file timeout (ms)
         unsigned int mWatchFileTimeout;

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -396,10 +396,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Setze die Transparenz des Taskleistensymbols auf</translation>
     </message>
     <message>
-        <source>opaque when new mail is present</source>
-        <translation>beim Eingang neuer Mails</translation>
-    </message>
-    <message>
         <source>Check for new updates when Birdtray starts</source>
         <translation>Suche nach Aktualisierungen, wenn Birdtray startet</translation>
     </message>
@@ -576,6 +572,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
+    </message>
+    <message>
+        <source>Choose one or more MSF files</source>
+        <translation>Wähle eine oder mehrere MSF Dateien</translation>
+    </message>
+    <message>
+        <source>Mail Index (*.msf)</source>
+        <translation>Mail Index (*.msf)</translation>
+    </message>
+    <message>
+        <source>opaque when new mail is present,</source>
+        <translation>beim Eingang neuer Mails,</translation>
+    </message>
+    <message>
+        <source>hide it if no new mail is present</source>
+        <translation>verstecke es, wenn es keine neuen Mails gibt.</translation>
     </message>
     <message>
         <source>No new updates found</source>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -586,7 +586,7 @@ p, li { white-space: pre-wrap; }
         <translation>beim Eingang neuer Mails,</translation>
     </message>
     <message>
-        <source>hide it if no new mail is present</source>
+        <source>hide it if no new mail is present.</source>
         <translation>verstecke es, wenn es keine neuen Mails gibt.</translation>
     </message>
     <message>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -574,10 +574,6 @@ p, li { white-space: pre-wrap; }
         <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
     </message>
     <message>
-        <source>Choose one or more MSF files</source>
-        <translation>Wähle eine oder mehrere MSF Dateien</translation>
-    </message>
-    <message>
         <source>Mail Index (*.msf)</source>
         <translation>Mail Index (*.msf)</translation>
     </message>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -574,10 +574,6 @@ p, li { white-space: pre-wrap; }
         <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
     </message>
     <message>
-        <source>Mail Index (*.msf)</source>
-        <translation>Mail Index (*.msf)</translation>
-    </message>
-    <message>
         <source>opaque when new mail is present,</source>
         <translation>beim Eingang neuer Mails,</translation>
     </message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -393,10 +393,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>opaque when new mail is present</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Check for new updates when Birdtray starts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -535,6 +531,22 @@ Do you want to clear the accounts?</source>
     </message>
     <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose one or more MSF files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mail Index (*.msf)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>opaque when new mail is present,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hide it if no new mail is present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -534,10 +534,6 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mail Index (*.msf)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>opaque when new mail is present,</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -546,7 +546,7 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>hide it if no new mail is present</source>
+        <source>hide it if no new mail is present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -534,10 +534,6 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Choose one or more MSF files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mail Index (*.msf)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -201,6 +201,12 @@ void TrayIcon::updateIcon()
         if ( unread == 0 && mBlinkingTimeout != 0 )
             enableBlinking( false );
     }
+    if (settings->onlyShowIconOnUnreadMessages && unread == 0) {
+        this->hide();
+        return;
+    } else {
+        this->show();
+    }
 
     QPixmap temp(settings->getNotificationIcon().size());
     QPainter p;


### PR DESCRIPTION
Resolves #96. This adds a new option in the advanced tab, which is disabled by default.
If enabled, the Birdtray system icon is hidden, if no new mails are detected. It will also be hidden if the user uses the snooze feature, is that ok with you @gyunaev?

If the Birdtray icon is hidden, one can access the setting to turn off the option by starting a second instance of Birdtray with the `--settings` parameter. Note that just starting Birdtray without a parameter does nothing.

<details>
<summary>New setting in the advanced tab</summary>

![Advanced settings tab](https://user-images.githubusercontent.com/6966049/72768910-2e6cd000-3bf9-11ea-9de8-9e4345faec5e.png)
</details>