### PR TITLE
Fix commands between Birdtray instances sometimes not send

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -70,14 +70,14 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv) {
 }
 
 BirdtrayApp::~BirdtrayApp() {
-    delete trayIcon;
-    delete autoUpdater;
-    delete settings;
     if (singleInstanceServer != nullptr) {
         singleInstanceServer->close();
         singleInstanceServer->deleteLater();
         singleInstanceServer = nullptr;
     }
+    delete trayIcon;
+    delete autoUpdater;
+    delete settings;
 }
 
 BirdtrayApp* BirdtrayApp::get() {

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -205,8 +205,8 @@ bool BirdtrayApp::connectToRunningInstance() const {
     if (serverSocket.waitForConnected()) {
         sendCommandsToRunningInstance(serverSocket);
         connectionSuccessful = true;
+        serverSocket.disconnectFromServer();
     }
-    serverSocket.disconnect();
     return connectionSuccessful;
 }
 

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -223,6 +223,7 @@ void BirdtrayApp::sendCommandsToRunningInstance(QLocalSocket &serverSocket) cons
     if (commandLineParser.isSet(SETTINGS_COMMAND)) {
         serverSocket.write(SETTINGS_COMMAND "\n");
     }
+    serverSocket.flush();
 }
 
 void BirdtrayApp::onSecondInstanceCommand(QLocalSocket* clientSocket) {

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -223,7 +223,7 @@ void BirdtrayApp::sendCommandsToRunningInstance(QLocalSocket &serverSocket) cons
     if (commandLineParser.isSet(SETTINGS_COMMAND)) {
         serverSocket.write(SETTINGS_COMMAND "\n");
     }
-    serverSocket.flush();
+    serverSocket.waitForBytesWritten();
 }
 
 void BirdtrayApp::onSecondInstanceCommand(QLocalSocket* clientSocket) {


### PR DESCRIPTION
This mainly fixes an issue on Linux, where the commands sometimes wouldn't be send to the main Birdtray instance, because the second instance quit too fast. This fixes this by waiting for the data to be send before quitting.

This also uses the correct function to close the socket and closes the server before destructing the rest of the attributes. The latter wasn't really a problem, because the event loop always exits before the Destructor is called.