### PR TITLE
Add a debug/advanced dialog to add any mork file for watching

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -334,6 +334,16 @@ void DialogSettings::accountAdd()
             return;
         }
         mAccountModel->addAccount(dlg.account(), dlg.color());
+    } else if (QGuiApplication::keyboardModifiers() & Qt::ShiftModifier &&
+               QGuiApplication::keyboardModifiers() & Qt::ControlModifier) {
+        QStringList files = QFileDialog::getOpenFileNames(
+                nullptr, tr("Choose one or more MSF files"), "", tr("Mail Index (*.msf)"));
+        if (files.isEmpty()) {
+            return;
+        }
+        for (const QString &file : files) {
+            mAccountModel->addAccount(file, btnNotificationColor->color());
+        }
     } else {
         MailAccountDialog accountDialog(this, btnNotificationColor->color());
         if (accountDialog.exec() != QDialog::Accepted) {

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -582,6 +582,14 @@ p, li { white-space: pre-wrap; }
         <translation>verstecke es, wenn es keine neuen Mails gibt.</translation>
     </message>
     <message>
+        <source>Choose one or more MSF files</source>
+        <translation>Wähle eine oder mehrere MSF Dateien</translation>
+    </message>
+    <message>
+        <source>Mail Index (*.msf)</source>
+        <translation>Mail Index (*.msf)</translation>
+    </message>
+    <message>
         <source>No new updates found</source>
         <translation>Keine neue Version gefunden</translation>
     </message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -542,6 +542,14 @@ Do you want to clear the accounts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Choose one or more MSF files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mail Index (*.msf)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -546,6 +546,14 @@ Wilt u de accounts verwijderen?</translation>
         <translation>Negeer alle ongelezen e-mails die beschikbaar zijn als Birdtray opstart. Alleen nieuwe e-mails worden geteld door de ongelezen e-mail-aanduiding.</translation>
     </message>
     <message>
+        <source>Choose one or more MSF files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mail Index (*.msf)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }


### PR DESCRIPTION
This adds a debug / advanced dialog in the monitoring tab of the settings, that lets the user add any mork file anywhere as a watched account.

The advanced "Add mail accounts" dialog added by #145 was a nice improvement in terms of usability and user interface, but it took away the ability to freely select any mork file. And we know there will always be someone with mork files in a directory that we have not accounted for (like #195 and #167). The new dialog will readd that flexibillity.

To prevent an unexperienced user from accidentally stumbling into the dialog, you will need to press `<Shift>` and `<Control>` while clicking on the `Add` button to open the dialog.

@gyunaev Should I add a tooltip to the `Add` button that describes how to access the dialog?