### PR TITLE
Add a "No new update" indicator to the advanced settings page

### DIFF
--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -31,9 +31,10 @@ Q_SIGNALS:
     /**
      * Indicates that an update check finished.
      *
+     * @param hasUpdate true if a new update was found.
      * @param errorString An error String of the request failed, else a null string.
      */
-    void onCheckUpdateFinished(const QString &errorString);
+    void onCheckUpdateFinished(bool hasUpdate, const QString &errorString);
 
 public slots:
     

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -245,7 +245,7 @@ void DialogSettings::profilePathChanged()
 
 }
 
-void DialogSettings::onCheckUpdateFinished(const QString &errorString) {
+void DialogSettings::onCheckUpdateFinished(bool foundUpdate, const QString &errorString) {
     if (checkUpdateButton->isEnabled()) {
         return; // We received an error that was not initiated by us. Ignore it.
     }
@@ -256,6 +256,8 @@ void DialogSettings::onCheckUpdateFinished(const QString &errorString) {
                 nullptr, tr("Version check failed"),
                 tr("Failed to check for a new Birdtray version:\n") + errorString,
                 QMessageBox::StandardButton::Ok);
+    } else {
+        noUpdateIndicator->setVisible(!foundUpdate);
     }
 }
 
@@ -505,6 +507,8 @@ void DialogSettings::activateTab(int tabIndex) {
     // #1 is the Accounts tab
     if (tabIndex == 1) {
         updateAccountList();
+    } else if (tabIndex == 4) {
+        noUpdateIndicator->hide();
     }
 }
 

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -33,8 +33,11 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         
         /**
          * Called once the update check finished.
+         *
+         * @param hasUpdate true if a new update was found.
+         * @param errorMessage A message indicating an error during the check, or a null string.
          */
-        void    onCheckUpdateFinished(const QString &errorString);
+        void    onCheckUpdateFinished(bool foundUpdate, const QString &errorString);
 
         // Calls the database fixer running in a DatabaseFixer thread
         // Receives databaseUnreadsFixed() once fixed

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -903,6 +903,19 @@
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="noUpdateIndicator">
+              <property name="text">
+               <string>No new updates found</string>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::NoTextInteraction</set>
+              </property>
+              <property name="visible">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_6">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -577,6 +577,10 @@ p, li { white-space: pre-wrap; }
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignoriere alle ungelesenen Emails, die beim Starten von Birdtray bereits vorhanden sind. Nur neue Emails werden bei der Berechnung der Anzahl ungelesener Emails beachtet.</translation>
     </message>
+    <message>
+        <source>No new updates found</source>
+        <translation>Keine neue Version gefunden</translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -555,6 +555,10 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Noto Sans&apos;; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>No new updates found</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -748,7 +748,8 @@ void TrayIcon::onQuit() {
     }
 }
 
-void TrayIcon::onAutoUpdateCheckFinished(const QString &errorMessage) {
+void TrayIcon::onAutoUpdateCheckFinished(bool foundUpdate, const QString &errorMessage) {
+    Q_UNUSED(foundUpdate)
     AutoUpdater* autoUpdater = BirdtrayApp::get()->getAutoUpdater();
     if (errorMessage.isNull()) {
         disconnect(autoUpdater, &AutoUpdater::onCheckUpdateFinished,

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -110,9 +110,10 @@ class TrayIcon : public QSystemTrayIcon
         /**
          * Called when the auto update finished.
          *
+         * @param hasUpdate true if a new update was found.
          * @param errorMessage A message indicating an error during the check, or a null string.
          */
-        void    onAutoUpdateCheckFinished(const QString& errorMessage);
+        void    onAutoUpdateCheckFinished(bool foundUpdate, const QString& errorMessage);
 
     private:
         void    createMenu();


### PR DESCRIPTION
This adds a visual feedback to the advanced settings tab if no update was found.

![Advanced settings tab](https://user-images.githubusercontent.com/6966049/72773787-90810180-3c08-11ea-9113-5f67711e1f70.png)
