### PR TITLE
Fix tab traversal order and small aligment issue in settings dialog

### DIFF
--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -1004,19 +1004,19 @@ p, li { white-space: pre-wrap; }
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>notificationFont</tabstop>
+  <tabstop>notificationFontWeight</tabstop>
+  <tabstop>btnNotificationColor</tabstop>
+  <tabstop>borderColorButton</tabstop>
+  <tabstop>borderWidthSlider</tabstop>
   <tabstop>sliderBlinkingSpeed</tabstop>
   <tabstop>btnNotificationIcon</tabstop>
   <tabstop>boxShowUnreadCount</tabstop>
   <tabstop>boxNotificationIconUnread</tabstop>
   <tabstop>btnNotificationIconUnread</tabstop>
-  <tabstop>btnNotificationColor</tabstop>
-  <tabstop>notificationFontWeight</tabstop>
-  <tabstop>borderColorButton</tabstop>
-  <tabstop>borderWidthSlider</tabstop>
   <tabstop>btnFixUnreadCount</tabstop>
   <tabstop>boxParserSelection</tabstop>
-  <tabstop>leProfilePath</tabstop>
   <tabstop>btnBrowse</tabstop>
+  <tabstop>leProfilePath</tabstop>
   <tabstop>treeAccounts</tabstop>
   <tabstop>btnAccountAdd</tabstop>
   <tabstop>btnAccountEdit</tabstop>
@@ -1037,6 +1037,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnNewEmailAdd</tabstop>
   <tabstop>btnNewEmailEdit</tabstop>
   <tabstop>btnNewEmailDelete</tabstop>
+  <tabstop>leThunderbirdCmdLine</tabstop>
   <tabstop>leThunderbirdWindowMatch</tabstop>
   <tabstop>spinMinimumFontSize</tabstop>
   <tabstop>boxBlinkingUsesAlpha</tabstop>

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -820,7 +820,7 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item row="0" column="1" colspan="2">
              <widget class="QLineEdit" name="leThunderbirdCmdLine">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
Fix misaligned thunderbird command line input not being aligned to the other input:
![Misaligned input](https://user-images.githubusercontent.com/6966049/72775083-56fec500-3c0d-11ea-8449-772d1c2f2088.png)

Also fixes the order in which the `<Tab>` key traverses the widgets in the settings dialog.