### PR TITLE
Improve the AddAccountDialog

### DIFF
--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -2,60 +2,40 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <QtCore/QDirIterator>
+#include <QtGui/QPainter>
+#include <QtGui/QKeyEvent>
 #include "mailaccountdialog.h"
 #include "ui_mailaccountdialog.h"
 #include "utils.h"
 #include "colorbutton.h"
 
 MailAccountDialog::MailAccountDialog(QWidget* parent, QColor defaultColor) :
-        QWizard(parent),
+        QDialog(parent),
         ui(new Ui::MailAccountDialog),
         defaultColor(std::move(defaultColor)) {
     ui->setupUi(this);
-    connect(this, &QWizard::currentIdChanged, this, &MailAccountDialog::onCurrentIdChanged);
     connect(ui->tbProfilesBrowseButton, &QAbstractButton::clicked,
             this, &MailAccountDialog::onProfilesDirBrowseButtonClicked);
     connect(ui->tbProfilesPathEdit, &QLineEdit::editingFinished,
-            this, &MailAccountDialog::onProfilesDirEditCommit);
-    connect(ui->profileSelector,
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-            this, &MailAccountDialog::onProfileSelectionChanged);
+            this, &MailAccountDialog::loadProfiles);
     connect(ui->accountsList, &QTreeWidget::itemChanged, &MailAccountDialog::onAccountItemChanged);
+    for (const QString &path : Utils::getThunderbirdProfilesPaths()) {
+        if (QDir(Utils::expandPath(path)).exists()) {
+            ui->tbProfilesPathEdit->setText(path);
+            loadProfiles();
+            break;
+        }
+    }
 }
 
 MailAccountDialog::~MailAccountDialog() {
     delete ui;
-    delete profilesDir;
-}
-
-void MailAccountDialog::initializePage(int id) {
-    QWizard::initializePage(id);
-    switch (static_cast<PageId>(id)) {
-    case profilesDirPage:
-        initializeProfilesDirPage();
-        break;
-    case profilePage:
-        initializeTbProfilesPage();
-        break;
-    case accountsPage:
-        initializeAccountsPage();
-        break;
-    case noPage: break;
-    }
-}
-
-bool MailAccountDialog::validateCurrentPage() {
-    switch (static_cast<PageId>(currentId())) {
-    case profilesDirPage: return validateProfilesDirPage();
-    case profilePage: return validateTbProfilesPage();
-    case accountsPage: return validateAccountsPage();
-    case noPage:break;
-    }
-    return QWizard::validateCurrentPage();
 }
 
 void MailAccountDialog::getSelectedAccounts(QList<std::tuple<QString, QColor>> &outList) const {
-    for (QTreeWidgetItem* selectedItem : getCheckedAccountItems()) {
+    QTreeWidgetItemIterator iterator = iterateCheckedAccountItems();
+    for (; *iterator != nullptr; ++iterator) {
+        QTreeWidgetItem* selectedItem = *iterator;
         QVariant color = selectedItem->data(1, Qt::UserRole);
         outList.append(std::make_tuple(
                 selectedItem->data(0, Qt::UserRole).toString(),
@@ -63,23 +43,23 @@ void MailAccountDialog::getSelectedAccounts(QList<std::tuple<QString, QColor>> &
     }
 }
 
-void MailAccountDialog::onCurrentIdChanged(int id) {
-    bool skipPage = false;
-    switch (static_cast<PageId>(id)) {
-    case profilesDirPage:
-        skipPage = furthestPage < PageId::profilesDirPage && profilesDir != nullptr;
-        break;
-    case profilePage:
-        skipPage = furthestPage < PageId::profilePage && !thunderbirdProfileMailDirs.isEmpty();
-        break;
-    case accountsPage:
-    case noPage: break;
+void MailAccountDialog::accept() {
+    if (*iterateCheckedAccountItems() != nullptr || QMessageBox::warning(
+            this, tr("No folder selected"),
+            tr("No mail folder was selected to monitor.\nDo you want to continue?"),
+            QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel
+    ) == QMessageBox::StandardButton::Ok) {
+        QDialog::accept();
     }
-    if (furthestPage < id) {
-        furthestPage = static_cast<PageId>(id);
-    }
-    if (skipPage) {
-        next();
+}
+
+void MailAccountDialog::keyPressEvent(QKeyEvent* event) {
+    switch (event->key()) {
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+        break; // Prevent enter from closing the dialog
+    default:
+        QDialog::keyPressEvent(event);
     }
 }
 
@@ -90,30 +70,8 @@ void MailAccountDialog::onProfilesDirBrowseButtonClicked() {
     if (directory.isEmpty()) {
         return;
     }
-    QDir* newProfilesDir = new QDir(directory);
-    if (!newProfilesDir->exists()) {
-        delete newProfilesDir;
-        return;
-    } else {
-        delete profilesDir;
-        profilesDir = newProfilesDir;
-    }
     ui->tbProfilesPathEdit->setText(QDir::toNativeSeparators(directory));
-}
-
-void MailAccountDialog::onProfilesDirEditCommit() {
-    QDir* newProfilesDir = new QDir(Utils::expandPath(ui->tbProfilesPathEdit->text()));
-    if (!newProfilesDir->exists()) {
-        delete newProfilesDir;
-    } else {
-        delete profilesDir;
-        profilesDir = newProfilesDir;
-    }
-}
-
-void MailAccountDialog::onProfileSelectionChanged(int newProfileIndex) {
-    Q_UNUSED(newProfileIndex)
-    thunderbirdProfileMailDirs.clear();
+    loadProfiles();
 }
 
 void MailAccountDialog::onAccountItemChanged(QTreeWidgetItem* item, int column) {
@@ -142,101 +100,41 @@ void MailAccountDialog::onAccountItemChanged(QTreeWidgetItem* item, int column) 
     parent->setCheckState(column, isPartiallySelected ? Qt::PartiallyChecked : checkState);
 }
 
-void MailAccountDialog::initializeProfilesDirPage() {
-    if (profilesDir != nullptr) {
+void MailAccountDialog::loadProfiles() {
+    if (profilesDirPath == ui->tbProfilesPathEdit->text()) {
         return;
     }
-    QString profilesPath;
-    for (const QString &path : Utils::getThunderbirdProfilesPaths()) {
-        profilesDir = new QDir(Utils::expandPath(path));
-        if (profilesDir->exists()) {
-            profilesPath = path;
-            break;
-        } else {
-            delete profilesDir;
-            profilesDir = nullptr;
-        }
-    }
-    if (profilesDir != nullptr) {
-        ui->tbProfilesPathEdit->setText(profilesPath);
-    }
-}
-
-bool MailAccountDialog::validateProfilesDirPage() {
-    if (profilesDir == nullptr) {
-        QMessageBox::warning(this, tr("Invalid Thunderbird profile directory"),
-                             tr("Please enter the path to a valid directory."),
-                             QMessageBox::StandardButton::Ok);
-        return false;
-    }
-    if (profilesDir->entryList(QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot).isEmpty()) {
-        QMessageBox::warning(this, tr("Invalid Thunderbird profile directory"),
-                             tr("The Thunderbird profile directory contains no profiles."),
-                             QMessageBox::StandardButton::Ok);
-        return false;
-    }
-    return true;
-}
-
-void MailAccountDialog::initializeTbProfilesPage() {
-    if (profilesDir == nullptr) {
-        return;
-    }
-    thunderbirdProfileMailDirs.clear();
-    QStringList profileDirs = profilesDir->entryList(
-            QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot);
-    // If we don't block the signals, Qt crashes on clear or addItem.
-    bool oldState = ui->profileSelector->blockSignals(true);
-    ui->profileSelector->clear();
-    for (const QString &profileDirName : profileDirs) {
-        QDir profileDir(profilesDir->absoluteFilePath(profileDirName));
-        QStringList mailFolders = profileDir.entryList({"*Mail"}, QDir::Dirs);
-        if (!mailFolders.isEmpty()) {
-            std::transform(mailFolders.begin(), mailFolders.end(), mailFolders.begin(),
-                    [=](const QString& folder) { return profileDir.absoluteFilePath(folder); });
-            ui->profileSelector->addItem(
-                    profileDirName.mid(profileDirName.indexOf('.') + 1), mailFolders);
-        }
-    }
-    ui->profileSelector->blockSignals(oldState);
-    if (ui->profileSelector->count() == 1) {
-        for (const QString &selectedDir : ui->profileSelector->itemData(0).toStringList()) {
-            thunderbirdProfileMailDirs.append(selectedDir);
-        }
-    }
-}
-
-bool MailAccountDialog::validateTbProfilesPage() {
-    if (thunderbirdProfileMailDirs.isEmpty()) {
-        QVariant selected = ui->profileSelector->itemData(ui->profileSelector->currentIndex());
-        if (selected.isNull()) {
-            QMessageBox::warning(this, tr("Invalid Thunderbird profile"),
-                                 tr("Please select a valid Thunderbird profile."),
-                                 QMessageBox::StandardButton::Ok);
-            return false;
-        }
-        for (const QString &selectedDir : selected.toStringList()) {
-            thunderbirdProfileMailDirs.append(selectedDir);
-        }
-    }
-    QMutableListIterator<QDir> iterator(thunderbirdProfileMailDirs);
-    while (iterator.hasNext()) {
-        if (!iterator.next().exists()) {
-            iterator.remove();
-        }
-    }
-    if (thunderbirdProfileMailDirs.isEmpty()) {
-        QMessageBox::warning(this, tr("Invalid Thunderbird profile"),
-                             tr("The selected Thunderbird profile does not exist."),
-                             QMessageBox::StandardButton::Ok);
-        return false;
-    }
-    return true;
-}
-
-void MailAccountDialog::initializeAccountsPage() {
+    profilesDirPath = ui->tbProfilesPathEdit->text();
     ui->accountsList->clear();
-    for (const QDir &mailDir : thunderbirdProfileMailDirs) {
+    QDir profilesDir(Utils::expandPath(profilesDirPath));
+    bool foundAValidProfileDir = false;
+    for (const QString &profileDirName: profilesDir.entryList(
+            QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot)) {
+        const QString profileDir = profilesDir.absoluteFilePath(profileDirName);
+        const QStringList mailFolders = getMailFoldersFor(profileDir);
+        if (mailFolders.isEmpty()) {
+            continue;
+        }
+        foundAValidProfileDir = true;
+        auto* profileItem = new QTreeWidgetItem(
+                ui->accountsList, {tr("%1 (Profile)").arg(getProfileName(profileDirName))});
+        profileItem->setExpanded(true);
+        ui->accountsList->addTopLevelItem(profileItem);
+        loadAccounts(profileItem, mailFolders);
+    }
+    if (!foundAValidProfileDir) {
+        if (!getMailFoldersFor(profilesDirPath).isEmpty()) {
+            profilesDir.cdUp();
+            ui->tbProfilesPathEdit->setText(QDir::toNativeSeparators(profilesDir.path()));
+            loadProfiles();
+        }
+    }
+}
+
+void MailAccountDialog::loadAccounts(QTreeWidgetItem* profileTreeItem,
+                                     const QStringList &mailFolders) {
+    for (const QString &mailDirPath : mailFolders) {
+        QDir mailDir(mailDirPath);
         for (const QString &mailAccount : mailDir.entryList(
                 QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot)) {
             QString accountDirectoryPath = mailDir.absoluteFilePath(mailAccount);
@@ -245,10 +143,13 @@ void MailAccountDialog::initializeAccountsPage() {
             if (!msfFileIterator.hasNext()) {
                 continue;
             }
-            auto* accountItem = new QTreeWidgetItem(ui->accountsList, {mailAccount});
+            auto* accountItem = new QTreeWidgetItem(profileTreeItem, {mailAccount});
             accountItem->setExpanded(true);
-            accountItem->setCheckState(0, Qt::Unchecked);
-            ui->accountsList->addTopLevelItem(accountItem);
+            if (msfFileIterator.hasNext()) {
+                accountItem->setCheckState(0, Qt::Unchecked);
+                profileTreeItem->setCheckState(0, Qt::Unchecked);
+            }
+            profileTreeItem->addChild(accountItem);
             while (msfFileIterator.hasNext()) {
                 (void) msfFileIterator.next();
                 QFileInfo msfFile = msfFileIterator.fileInfo();
@@ -274,24 +175,36 @@ void MailAccountDialog::initializeAccountsPage() {
     }
 }
 
-bool MailAccountDialog::validateAccountsPage() {
-    return !(getCheckedAccountItems().isEmpty() && QMessageBox::warning(
-            this, tr("No folder selected"),
-            tr("No mail folder was selected to monitor.\nDo you want to continue?"),
-            QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel
-    ) == QMessageBox::StandardButton::Cancel);
+QTreeWidgetItemIterator MailAccountDialog::iterateCheckedAccountItems() const {
+    return QTreeWidgetItemIterator(
+            ui->accountsList,
+            QTreeWidgetItemIterator::Checked | QTreeWidgetItemIterator::NoChildren);
 }
 
-QList<QTreeWidgetItem*> MailAccountDialog::getCheckedAccountItems() const {
-    QList<QTreeWidgetItem*> checkedItems;
-    for (int i = 0; i < ui->accountsList->topLevelItemCount(); i++) {
-        QTreeWidgetItem* accountItem = ui->accountsList->topLevelItem(i);
-        for (int j = 0; j < accountItem->childCount(); j++) {
-            QTreeWidgetItem* folderItem = accountItem->child(j);
-            if (folderItem->checkState(0) == Qt::Checked) {
-                checkedItems.append(folderItem);
-            }
-        }
+QStringList MailAccountDialog::getMailFoldersFor(const QString &profileDirPath) {
+    QDir profileDir(profileDirPath);
+    QStringList mailFolders = profileDir.entryList({"*Mail"}, QDir::Dirs);
+    std::transform(mailFolders.begin(), mailFolders.end(), mailFolders.begin(),
+            [=](const QString &folder) { return profileDir.absoluteFilePath(folder); });
+    return mailFolders;
+}
+
+QString MailAccountDialog::getProfileName(const QString &profileDirName) {
+    return profileDirName.mid(profileDirName.indexOf('.') + 1);
+}
+
+void AccountsTreeWidget::paintEvent(QPaintEvent* event) {
+    if (model() && model()->rowCount() > 0) {
+        QTreeView::paintEvent(event);
+        return;
     }
-    return checkedItems;
+    QPainter painter(viewport());
+    QFont font = painter.font();
+    font.setPointSizeF(font.pointSizeF() * 1.5);
+    painter.setFont(font);
+    painter.setPen(Qt::gray);
+    QRect textRect = painter.fontMetrics().boundingRect(viewport()->rect(),
+            Qt::AlignCenter | Qt::TextWordWrap, _emptyText);
+    textRect.moveCenter(viewport()->rect().center());
+    painter.drawText(textRect, Qt::AlignCenter | Qt::TextWordWrap, _emptyText);
 }

--- a/src/mailaccountdialog.ui
+++ b/src/mailaccountdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MailAccountDialog</class>
- <widget class="QWizard" name="MailAccountDialog">
+ <widget class="QDialog" name="MailAccountDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,137 +11,128 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Mail Accounts</string>
+   <string>Select Accounts</string>
   </property>
-  <property name="wizardStyle">
-   <enum>QWizard::AeroStyle</enum>
-  </property>
-  <widget class="QWizardPage" name="profilesDirPage">
-   <property name="title">
-    <string>Thunderbird Profiles Directory</string>
-   </property>
-   <property name="subTitle">
-    <string>Select the directory that contains the Thunderbird profiles.</string>
-   </property>
-   <attribute name="pageId">
-    <string notr="true">MailAccountDialog::PageId::profilesDirPage</string>
-   </attribute>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QLineEdit" name="tbProfilesPathEdit">
-      <property name="placeholderText">
-       <string>Thunderbird Profiles Directory</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="tbProfilesBrowseButton">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Select the directory that contains the Thunderbird profiles.</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="tbProfilesPathEdit">
+        <property name="placeholderText">
+         <string>Thunderbird Profiles Directory</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="tbProfilesBrowseButton">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Select the mail accounts you want to monitor.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="AccountsTreeWidget" name="accountsList">
+     <property name="tabKeyNavigation">
+      <bool>true</bool>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <property name="emptyText" stdset="0">
+      <string>No mail profiles were found.
+Please make sure you selected the correct profiles directory.</string>
+     </property>
+     <attribute name="headerDefaultSectionSize">
+      <number>300</number>
+     </attribute>
+     <column>
       <property name="text">
-       <string>Browse</string>
+       <string>Email Folder</string>
       </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QWizardPage" name="profilePage">
-   <property name="title">
-    <string>Thunderbird Profile</string>
-   </property>
-   <property name="subTitle">
-    <string>Select theThunderbird profile, that contains the mail account which you want to monitor.</string>
-   </property>
-   <attribute name="pageId">
-    <string notr="true">MailAccountDialog::PageId::profilePage</string>
-   </attribute>
-   <layout class="QHBoxLayout" name="horizontalLayout_2">
-    <item>
-     <widget class="QLabel" name="label_2">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
+     </column>
+     <column>
       <property name="text">
-       <string>Selected Profile:</string>
+       <string>Notification Color</string>
       </property>
-     </widget>
-    </item>
-    <item>
-     <spacer name="horizontalSpacer">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeType">
-       <enum>QSizePolicy::Preferred</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>40</width>
-        <height>20</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <widget class="QComboBox" name="profileSelector">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QWizardPage" name="accountsPage">
-   <property name="title">
-    <string>Select Accounts</string>
-   </property>
-   <property name="subTitle">
-    <string>Select the mail accounts you want to monitor.</string>
-   </property>
-   <attribute name="pageId">
-    <string notr="true">MailAccountDialog::PageId::accountsPage</string>
-   </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QTreeWidget" name="accountsList">
-      <property name="tabKeyNavigation">
-       <bool>true</bool>
-      </property>
-      <property name="showDropIndicator" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="columnCount">
-       <number>2</number>
-      </property>
-      <attribute name="headerDefaultSectionSize">
-       <number>300</number>
-      </attribute>
-      <column>
-       <property name="text">
-        <string>Email Folder</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Notification Color</string>
-       </property>
-      </column>
-     </widget>
-    </item>
-    <item>
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AccountsTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>mailaccountdialog.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>MailAccountDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>283</x>
+     <y>384</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>6</x>
+     <y>144</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>MailAccountDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>389</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>4</x>
+     <y>223</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -585,10 +585,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MailAccountDialog</name>
     <message>
-        <source>Mail Accounts</source>
-        <translation>Email Konten</translation>
-    </message>
-    <message>
         <source>Select the directory that contains the Thunderbird profiles.</source>
         <translation>Wählen Sie bitte das Verzeichnis aus, das die Thunderbird Profile enthält.</translation>
     </message>
@@ -599,18 +595,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Browse</source>
         <translation>Durchsuchen</translation>
-    </message>
-    <message>
-        <source>Thunderbird Profile</source>
-        <translation>Thunderbird Profil</translation>
-    </message>
-    <message>
-        <source>Select theThunderbird profile, that contains the mail account which you want to monitor.</source>
-        <translation>Wählen Sie das Thunderbird Profil aus, welches das Email Konto enthält, das Sie überwachen wollen.</translation>
-    </message>
-    <message>
-        <source>Selected Profile:</source>
-        <translation>Ausgewähltes Profil:</translation>
     </message>
     <message>
         <source>Select Accounts</source>
@@ -633,30 +617,6 @@ p, li { white-space: pre-wrap; }
         <translation>Wähle das Verzeichnis der Thunderbird Profile</translation>
     </message>
     <message>
-        <source>Invalid Thunderbird profile directory</source>
-        <translation>Ungültiges Thunderbird Profil-Verzeichnis</translation>
-    </message>
-    <message>
-        <source>Please enter the path to a valid directory.</source>
-        <translation>Bitte geben Sie einen Pfad zu einem gültigen Verzeichnis ein.</translation>
-    </message>
-    <message>
-        <source>The Thunderbird profile directory contains no profiles.</source>
-        <translation>Das Thunderbird Profil-Verzeichnis enthält keine Profile.</translation>
-    </message>
-    <message>
-        <source>Invalid Thunderbird profile</source>
-        <translation>Ungültiges Thunderbird Profil</translation>
-    </message>
-    <message>
-        <source>Please select a valid Thunderbird profile.</source>
-        <translation>Bitte wählen Sie ein gültiges Thunderbird Profil.</translation>
-    </message>
-    <message>
-        <source>The selected Thunderbird profile does not exist.</source>
-        <translation>Das gewählte Thunderbird Profil existiert nicht mehr.</translation>
-    </message>
-    <message>
         <source>No folder selected</source>
         <translation>Kein Ordner ausgewählt</translation>
     </message>
@@ -669,6 +629,16 @@ Wollen Sie fortfahren?</translation>
     <message>
         <source>Email Folder</source>
         <translation>Email Ordner</translation>
+    </message>
+    <message>
+        <source>%1 (Profile)</source>
+        <translation>%1 (Profil)</translation>
+    </message>
+    <message>
+        <source>No mail profiles were found.
+Please make sure you selected the correct profiles directory.</source>
+        <translation>Es wurden keine Mail Ordner gefunden.
+Bitte stellen Sie sicher, dass Sie den richtigen Ordner mit den Profilen ausgewählt haben.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -563,75 +563,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MailAccountDialog</name>
     <message>
-        <source>Mail Accounts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thunderbird Profiles Directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select the directory that contains the Thunderbird profiles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thunderbird Profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select theThunderbird profile, that contains the mail account which you want to monitor.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Selected Profile:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select Accounts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select the mail accounts you want to monitor.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notification Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Choose the Thunderbird profiles path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid Thunderbird profile directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please enter the path to a valid directory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The Thunderbird profile directory contains no profiles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid Thunderbird profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please select a valid Thunderbird profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The selected Thunderbird profile does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -644,7 +576,44 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Select Accounts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select the directory that contains the Thunderbird profiles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Thunderbird Profiles Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select the mail accounts you want to monitor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Email Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Profile)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No mail profiles were found.
+Please make sure you selected the correct profiles directory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This improves the AddAccount dialog added by #145. Issues like #229 and #218 showed that the users where confused by the dialog being split into three parts, especially if the first two pages were skipped because Birdtray found empty Thunderbird profiles at the standard locations.

The new Dialog only consists of a single page, which allows to enter the Thunderbird profiles directory and select the mail folders to add. Because everything is on one page, the user can immediately see if the path is wrong. We also allow the user to input a path to a specific profile directory and automatically fix it (closes #206).
The new dialog also adds the ability to simultaneously add mail folders from different Thunderbird profiles.

<details>
<summary>Images</summary>

![The new dialog](https://user-images.githubusercontent.com/6966049/73126792-30e37700-3fb7-11ea-8bf2-0e34613e7f61.PNG)
![The new dialog with a message if an invalid profiles path was selected](https://user-images.githubusercontent.com/6966049/73126793-3476fe00-3fb7-11ea-9a71-ec9a5591e127.PNG)
</details>