### PR TITLE
Attach to the parent console if the --debug parameter is present on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,13 @@ int main(int argc, char *argv[]) {
 #ifdef Q_OS_WIN
     for (int i = 1; i < argc; i++) {
         if (strcmp("--debug", argv[i]) == 0) {
-            AttachConsole(ATTACH_PARENT_PROCESS);
-            // reopen the std I/O streams to redirect I/O to the parents console.
-            freopen("CON", "w", stdout);
-            freopen("CON", "w", stderr);
-            freopen("CON", "r", stdin);
+            if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+                // reopen the std I/O streams to redirect I/O to the parents console.
+                FILE* newFile = nullptr;
+                freopen_s(&newFile, "CON", "w", stdout);
+                freopen_s(&newFile, "CON", "w", stderr);
+                freopen_s(&newFile, "CON", "r", stdin);
+            }
             break;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,24 @@
 #include <QApplication>
 #include "birdtrayapp.h"
-
+#ifdef Q_OS_WIN
+#  include <windows.h>
+#  include <cstdio>
+#  include <cstring>
+#endif /* Q_OS_WIN  */
 
 int main(int argc, char *argv[]) {
+#ifdef Q_OS_WIN
+    for (int i = 1; i < argc; i++) {
+        if (strcmp("--debug", argv[i]) == 0) {
+            AttachConsole(ATTACH_PARENT_PROCESS);
+            // reopen the std I/O streams to redirect I/O to the parents console.
+            freopen("CON", "w", stdout);
+            freopen("CON", "w", stderr);
+            freopen("CON", "r", stdin);
+            break;
+        }
+    }
+#endif /* Q_OS_WIN */
     BirdtrayApp app(argc, argv);
     return QApplication::exec();
 }


### PR DESCRIPTION
Previously, it was not possible to view the debug output of Birdtray on Windows without attaching to the process with a debugger. On Windows, a program can either be compiled as a GUI application or a command line application. A command line application will automatically send its output to an attached console, but will also automatically create a console if it is started without one, meaning that Birdtray would open a cmd window if it was started. Because of this Birdtray is compiled as a GUI application, which doesn't create a console, but also doesn't automatically attach to one.

We now attach to the parent console, if there is one and if the `--debug` parameter was specified.
This means that the output is now visible on the console (closes #244), but unfortunately the command line still starts Birdtray in a detached mode and doesn't wait for any output. That means that the Birdtray output will appear after the new prompt. To avoid that, one can launch Birdtray using the [start command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/start):
```cmd
start /w birdtray.exe --debug <arguments>
```
![terminal](https://user-images.githubusercontent.com/6966049/74082925-0980b580-4a5f-11ea-97fe-2bd5423b095d.PNG)