### PR TITLE
Make tray icon size consistent

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -491,7 +491,12 @@ void DialogSettings::changeIcon(QToolButton *button)
         return;
     }
 
-    button->setIcon( test );
+    Settings* settings = BirdtrayApp::get()->getSettings();
+
+    // Force scale icon to the expected size
+    button->setIcon( test.scaled(
+            settings->mIconSize.width(), settings->mIconSize.height(),
+            Qt::KeepAspectRatio, Qt::SmoothTransformation) );
 }
 
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -29,7 +29,7 @@ Settings::Settings(bool verboseOutput)
 #endif
 
     mVerboseOutput = verboseOutput;
-    mIconSize = QSize( 128, 128 );
+    mIconSize = QSize( ICON_SIZE, ICON_SIZE );
     mNotificationDefaultColor = QColor("#0000FF");
     mNotificationBorderColor = QColor("#FFFFFF");
     mNotificationBorderWidth = 15;

--- a/src/settings.h
+++ b/src/settings.h
@@ -15,6 +15,10 @@ class QSettings;
 class Settings
 {
     public:
+
+        // Icon size constant
+        static constexpr int ICON_SIZE = 128;
+
         explicit Settings(bool verboseOutput);
         ~Settings();
 


### PR DESCRIPTION
Fix inconsistent drawing of unread counter across different sizes of icons by
scaling icons to a predefined size.

In case of small icons (24x24, 32x32), unread count and border may be rendered incorrectly.
In addition, default icon size was used for the custom unread icon, so it caused image to be either too small or too big.

This solution scales an icon to a fixed size (original 128x128 is used) before drawing it. It may be an overhead, but it should work with existing configurations.

However I have a different solution [here](https://github.com/dvalter/birdtray/tree/icon-scaling-fix-v2), which scales icons before applying them to Settings from DialogSettings. The only downside I see is requirement for user to re-apply settings for changes to take effect.