### PR TITLE
Fix parsing mork files with changesets

### DIFF
--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -814,7 +814,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
     return EXIT_SUCCESS;
 }
 
-int MailMorkParser::getMorkUnreadCount() {
+unsigned int MailMorkParser::getNumUnreadMessages() {
     unsigned int unread = 0;
     
     // First we parse the unreadChildren column (generic view)

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -317,7 +317,7 @@ inline void MorkParser::parseComment()
 //	=============================================================
 //	MorkParser::parseCell
 
-void MorkParser::parseCell()
+void MorkParser::parseCell(bool isInCutMode)
 {
     //bool bColumnOid = false;
     bool bValueOid = false;
@@ -430,8 +430,7 @@ void MorkParser::parseCell()
     }
     else
     {
-        if ( "" != Text )
-        {
+        if (!Text.isEmpty() && !(isInCutMode && (*currentCells_).contains(ColumnId))) {
             // Rows
             int ValueId = Text.toInt( 0, 16 );
 
@@ -605,7 +604,7 @@ void MorkParser::parseRow( int TableId, int TableScope )
             switch ( cur )
             {
             case '(':
-                parseCell();
+                parseCell(cutMode);
                 break;
             case '[':
                 parseMeta( ']' );

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -553,6 +553,12 @@ inline void MorkParser::setCurrentRow( int TableScope, int TableId, int RowScope
     {
         RowScope = defaultScope_;
     }
+    
+    if (!TableId) {
+        QPair<int, int> rowMapping = rowMappings.value(abs(RowId)).value(RowScope, {0, 0});
+        TableScope = rowMapping.first;
+        TableId = rowMapping.second;
+    }
 
     if ( !TableScope )
     {
@@ -607,6 +613,9 @@ void MorkParser::parseRow( int TableId, int TableScope )
         }
 
         cur = nextChar();
+    }
+    if (TableId != 0) {
+        rowMappings[abs(Id)][Scope == 0 ? defaultScope_ : Scope] = {TableScope, TableId};
     }
 }
 

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -568,7 +568,7 @@ inline void MorkParser::setCurrentRow( int TableScope, int TableId, int RowScope
 void MorkParser::parseRow( int TableId, int TableScope )
 {
     QString TextId;
-    int Id = 0, Scope = 0;
+    int Id = 0, Scope = TableScope;
     nowParsing_ = NPRows;
 
     char cur = nextChar();

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -591,7 +591,11 @@ void MorkParser::parseRow( int TableId, int TableScope )
     }
 
     parseScopeId( TextId, &Id, &Scope );
+    bool cutMode = Id < 0;
     setCurrentRow( TableScope, TableId, Scope, Id );
+    if (cutMode) {
+        (*currentCells_).clear();
+    }
 
     // Parse the row
     while ( cur != ']' && cur )

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -161,6 +161,7 @@ protected: // Data
     // All mork file data
     TableScopeMap mork_;
     MorkCells *currentCells_;
+    QMap<int, QMap<int, QPair<int, int>>> rowMappings;
 
     // Error status of last operation
     QString mErrorMessage;

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -177,4 +177,13 @@ protected: // Data
     enum { NPColumns, NPValues, NPRows } nowParsing_;
 };
 
+
+/**
+ * A mork parse for mail databases.
+ */
+class MailMorkParser : public MorkParser {
+public:
+    int getMorkUnreadCount();
+};
+
 #endif // __MorkParser_h__

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -146,7 +146,7 @@ protected: // Members
     void    parse();
     void    parseDict();
     void    parseComment();
-    void    parseCell();
+    void    parseCell(bool isInCutMode = false);
     void    parseTable();
     void    parseMeta( char c );
     void    parseRow( int TableId, int TableScope );

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -183,7 +183,10 @@ protected: // Data
  */
 class MailMorkParser : public MorkParser {
 public:
-    int getMorkUnreadCount();
+    /**
+     * @return The number of unread emails in the mork file.
+     */
+    unsigned int getNumUnreadMessages();
 };
 
 #endif // __MorkParser_h__

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -283,70 +283,14 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
 
 int UnreadMonitor::getMorkUnreadCount(const QString &path)
 {
-    MorkParser parser;
+    MailMorkParser parser;
     if (!parser.open(path)) {
         setWarning(tr("Unable to read from %1.").arg(QFileInfo(path).fileName()), path);
         return 0;
     } else {
         clearWarning(path);
     }
-    unsigned int unread = 0;
-
-    // First we parse the unreadChildren column (generic view)
-    const MorkRowMap * rows = parser.rows( 0x80, 0, 0x80 );
-
-    if ( rows )
-    {
-        for ( MorkRowMap::const_iterator rit = rows->begin(); rit != rows->cend(); rit++ )
-        {
-            MorkCells cells = rit.value();
-
-            for ( int colid : cells.keys() )
-            {
-                QString columnName = parser.getColumn( colid );
-
-                if ( columnName == "unreadChildren" )
-                {
-                    bool correct;
-                    unsigned int value = parser.getValue(cells[colid ]).toUInt( &correct, 16 );
-
-                    if ( correct )
-                        unread += value;
-                    else
-                        Utils::debug("Incorrect Mork value: %s", qPrintable( parser.getValue(cells[colid ]) ));                }
-            }
-        }
-    }
-    else
-    {
-        // Now parse the smart inbox
-        rows = parser.rows( 0x80, 0, 0x9F );
-
-        if ( rows )
-        {
-            for ( MorkRowMap::const_iterator rit = rows->begin(); rit != rows->cend(); rit++ )
-            {
-                MorkCells cells = rit.value();
-
-                for ( int colid : cells.keys() )
-                {
-                    QString columnName = parser.getColumn( colid );
-
-                    if ( columnName == "numNewMsgs" )
-                    {
-                        bool correct;
-                        unsigned int value = parser.getValue(cells[colid ]).toInt( &correct, 16 );
-
-                        if ( correct )
-                            unread += value;
-                        else
-                            Utils::debug("Incorrect Mork value: %s", qPrintable( parser.getValue(cells[colid ]) ));
-                    }
-                }
-            }
-        }
-    }
-
+    int unread = parser.getMorkUnreadCount();
     Utils::debug("Unread counter for %s: %d", qPrintable( path ), unread );
     return unread;
 }

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -290,7 +290,7 @@ int UnreadMonitor::getMorkUnreadCount(const QString &path)
     } else {
         clearWarning(path);
     }
-    int unread = parser.getMorkUnreadCount();
+    int unread = static_cast<int>(parser.getNumUnreadMessages());
     Utils::debug("Unread counter for %s: %d", qPrintable( path ), unread );
     return unread;
 }


### PR DESCRIPTION
While working on #245 I noticed that the `numNewMsgs` (`A2`) property was sometimes read incorrectly. One example of this was the following mork file, which I generated with Thunderbird and a test account.
<details>
<summary>The example mork file</summary>

```mork
// <!-- <mdb:mork:z v="1.4"/> -->
< <(a=c)> // (f=iso-8859-1)
  (B8=viewFlags)(B9=viewType)(BA=columnStates)(BB=MRUTime)
  (BC=sortColumns)(BD=customSortCol)(80=ns:msg:db:row:scope:msgs:all)
  (81=subject)(82=sender)(83=message-id)(84=references)(85=recipients)
  (86=date)(87=size)(88=flags)(89=priority)(8A=label)(8B=statusOfset)
  (8C=numLines)(8D=ccList)(8E=bccList)(8F=msgThreadId)(90=threadId)
  (91=threadFlags)(92=threadNewestMsgDate)(93=children)
  (94=unreadChildren)(95=threadSubject)(96=msgCharSet)
  (97=ns:msg:db:table:kind:msgs)(98=ns:msg:db:table:kind:thread)
  (99=ns:msg:db:table:kind:allthreads)
  (9A=ns:msg:db:row:scope:threads:all)(9B=threadParent)(9C=threadRoot)
  (9D=msgOffset)(9E=offlineMsgSize)
  (9F=ns:msg:db:row:scope:dbfolderinfo:all)
  (A0=ns:msg:db:table:kind:dbfolderinfo)(A1=numMsgs)(A2=numNewMsgs)
  (A3=folderSize)(A4=expungedBytes)(A5=folderDate)(A6=highWaterKey)
  (A7=mailboxName)(A8=UIDValidity)(A9=totPendingMsgs)
  (AA=unreadPendingMsgs)(AB=expiredMark)(AC=version)(AD=forceReparse)
  (AE=fixedBadRefThreading)(AF=folderName)(B0=charSetOverride)
  (B1=charSet)(B2=searchStr)(B3=searchFolderUri)(B4=searchOnline)
  (B5=searchFolderFlag)(B6=sortType)(B7=sortOrder)>

<(80=1)(81=0)(83=24)(84=AND (subject,contains,Email\))(85
    =mailbox://me@localhost/Inbox)(86=1581100303)(87
    ={"threadCol":{"visible":true},"attachmentCol":{"visible":true},"flaggedCo\
l":{"visible":true},"subjectCol":{"visible":true},"unreadButtonColHeader":{"vi\
sible":true},"senderCol":{"visible":false},"recipientCol":{"visible":false},"c\
orrespondentCol":{"visible":true},"junkStatusCol":{"visible":true},"dateCol":{\
"visible":true},"locationCol":{"visible":false}})>
{1:^9F {(k^A0:c)(s=9u)} 
  [1(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)(^BA^87)]}

@$${6{@
[-1:^9F(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)
    (^BA^87)(^A2=1)(^A1=1)]
@$$}6}@

@$${7{@
<(8A=1581100304)(88=12)(89=)>[-1:^9F(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)
    (^B3^85)(^B4=0)(^BB^8A)(^BA^87)(^A2=1)(^A1=1)(^B6=12)(^B7=1)(^BC=)]
@$$}7}@

@$${8{@
@$$}8}@
```
</details>

The mork file contains a `ns:msg:db:row:scope:dbfolderinfo:all` (`9F`) table without the `numNewMsgs` (`A2`) property, so the parser was not reading the correct value, which is `1`.
```mork
{1:^9F {(k^A0:c)(s=9u)} 
  [1(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)(^BA^87)]}
```

But the mork file contains multiple [changesets (a.k.a. groups)](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Mork#Groups_a.k.a._Changesets) with rows that are not enclosed by a table:
```mork
@$${6{@
[-1:^9F(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)
    (^BA^87)(^A2=1)(^A1=1)]
@$$}6}@
```
But these changesets were not correctly applied by the parser. This pull request fixes the problems that caused the parser to parse the mork file incorrectly:

* If no scope for a row is given, it inherits the scope of the enclosing table. ([Reference](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Mork#Rows))
* If a row is encountered that is not enclosed by a table, check if an existing row with the same id and scope exists and update it. I unfortunately couldn't find any documentation about these rows without a table in changesets, but a row is uniquely identified by its id and scope even across different tables. ([Reference](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Mork#Rows)).

I also created a new class `MailMorkParser` and moved the `getMorkUnreadCount` method there to allow to test the parser.