### PR TITLE
Add unit test(s)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,10 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON
+        run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_TESTS=ON
       - name: Build
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target birdtray
+      - name: Tests
+        working-directory: ${{runner.workspace}}/build
+        run: cmake --build . --config Release --target run_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,13 @@ jobs:
             export sqliteDir=C:\\ProgramData\\chocolatey\\lib\\SQLite\\tools
             if [ "$ARCH" == "x86" ]; then
               echo "::set-env name=CMAKE_PLATFORM_ARG::-A Win32"
+              export archParam="--forcex86"
             else
               echo "::set-env name=CMAKE_PLATFORM_ARG::-A x64"
             fi
             echo "::set-env name=CMAKE_PREFIX_PATH::$sqliteDir"
-            choco install -y sqlite --params \"/NoTools\"
+            echo "::add-path::$sqliteDir"
+            choco install -y $archParam sqlite --params \"/NoTools\"
             curl -sS https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip > sqlite-source.zip
             unzip -p sqlite-source.zip sqlite-amalgamation-3300100/sqlite3.h > $sqliteDir/sqlite3.h
             rm sqlite-source.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,21 +17,21 @@ set(PLATFORM_SOURCES)
 set(PLATFORM_HEADERS)
 set(EXECUTABLE_OPTIONS)
 
-option( OPT_THUNDERBIRD_CMDLINE "Default Thunderbird startup command-line" [])
-option( OPT_THUNDERBIRD_PROFILE "Default Thunderbird profile path" [])
+option(OPT_THUNDERBIRD_CMDLINE "Default Thunderbird startup command-line" [])
+option(OPT_THUNDERBIRD_PROFILE "Default Thunderbird profile path" [])
 
-if (OPT_THUNDERBIRD_CMDLINE)
+if(OPT_THUNDERBIRD_CMDLINE)
     message(STATUS "Setting Thunderbird command-line to ${OPT_THUNDERBIRD_CMDLINE}")
     add_definitions(-DOPT_THUNDERBIRD_CMDLINE="${OPT_THUNDERBIRD_CMDLINE}")
 endif(OPT_THUNDERBIRD_CMDLINE)
 
-if (OPT_THUNDERBIRD_PROFILE)
-    message(STATUS "Setting Thunderbird command line to ${OPT_THUNDERBIRD_PROFILE}")
+if(OPT_THUNDERBIRD_PROFILE)
+    message(STATUS "Setting Thunderbird profile path to ${OPT_THUNDERBIRD_PROFILE}")
     add_definitions(-DOPT_THUNDERBIRD_PROFILE="${OPT_THUNDERBIRD_PROFILE}")
 endif(OPT_THUNDERBIRD_PROFILE)
 
 if(NOT Qt5LinguistTools_FOUND)
-    message(STATUS "Qt5LinguistTools package not found: translations will not be available")
+    message(STATUS "Qt5LinguistTools package not found: Translations will not be available")
 endif(NOT Qt5LinguistTools_FOUND)
 
 if(WIN32)
@@ -39,7 +39,8 @@ if(WIN32)
     ENABLE_LANGUAGE(RC)
     add_definitions(-DUNICODE -DNOMINMAX)
     set(PLATFORM_SOURCES src/windowtools_win.cpp src/birdtrayeventfilter.cpp
-            src/processhandle.cpp src/res/birdtray.rc)
+            src/processhandle.cpp)
+    set(PLATFORM_EXE_SOURCES src/res/birdtray.rc)
     set(PLATFORM_HEADERS src/windowtools_win.h src/birdtrayeventfilter.h src/processhandle.h)
     find_package(Qt5WinExtras CONFIG REQUIRED)
     list(APPEND REQUIRED_MODULES Qt5::WinExtras)
@@ -51,10 +52,8 @@ else()
     set(PLATFORM_HEADERS src/windowtools_x11.h)
 endif(WIN32)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
-include_directories(${SQLITE3_INCLUDE_DIRS} src)
 add_definitions(-DQT_DEPRECATED_WARNINGS)
 
 set(SOURCES
@@ -64,7 +63,6 @@ set(SOURCES
         src/dialogaddeditaccount.cpp
         src/dialogaddeditnewemail.cpp
         src/dialogsettings.cpp
-        src/main.cpp
         src/modelaccounttree.cpp
         src/modelnewemails.cpp
         src/morkparser.cpp
@@ -139,21 +137,35 @@ if(Qt5LinguistTools_FOUND)
     list(APPEND GEN_TRANSLATION_FILES ${GEN_DYN_TRANSLATION_FILES})
 endif(Qt5LinguistTools_FOUND)
 
-add_executable(birdtray ${EXECUTABLE_OPTIONS}
+add_library(birdtray_lib STATIC
         ${SOURCES} ${PLATFORM_SOURCES} ${RESOURCES_SOURCES} ${GEN_TRANSLATION_FILES}
         ${HEADERS} ${PLATFORM_HEADERS})
-target_link_libraries(birdtray ${REQUIRED_MODULES})
+target_include_directories(birdtray_lib PUBLIC ${SQLITE3_INCLUDE_DIRS} src)
+target_link_libraries(birdtray_lib PUBLIC ${REQUIRED_MODULES})
+
+add_executable(birdtray
+        ${EXECUTABLE_OPTIONS} src/main.cpp ${PLATFORM_EXE_SOURCES} ${RESOURCES_SOURCES}
+        ${HEADERS} ${PLATFORM_HEADERS})
+target_link_libraries(birdtray birdtray_lib)
+
 if(MSVC)
-    target_compile_options(birdtray PRIVATE /utf-8)
+    target_compile_options(birdtray_lib PUBLIC /utf-8)
 endif()
 
 option(COMPILER_WARNINGS_AS_ERRORS "Fail the build on compiler warnings" OFF)
 if(COMPILER_WARNINGS_AS_ERRORS)
     if(MSVC)
-        target_compile_options(birdtray PRIVATE /W4 /WX)
+        target_compile_options(birdtray_lib PUBLIC /W4 /WX)
     else()
-        target_compile_options(birdtray PRIVATE -Wall -Wextra -Wpedantic -Werror)
+        target_compile_options(birdtray_lib PUBLIC -Wall -Wextra -Wpedantic -Werror)
     endif()
+endif()
+
+# Tests
+option(BUILD_WITH_TESTS "Build and add a test target. This requires GTest." OFF)
+if(BUILD_WITH_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
 endif()
 
 # Installation
@@ -183,9 +195,9 @@ else()
         install(FILES src/res/icons/${size}/com.ulduzsoft.Birdtray.png
                 DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/${size}x${size}/apps)
     endforeach()
-    install (FILES src/res/birdtray.svg
-             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps 
-             RENAME com.ulduzsoft.Birdtray.svg)
+    install(FILES src/res/birdtray.svg
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps
+            RENAME com.ulduzsoft.Birdtray.svg)
     install(DIRECTORY ${CMAKE_BINARY_DIR}/translations
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ulduzsoft/birdtray)
 endif()

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -814,7 +814,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
     return EXIT_SUCCESS;
 }
 
-int MailMorkParser::getMorkUnreadCount() {
+unsigned int MailMorkParser::getNumUnreadMessages() {
     unsigned int unread = 0;
     
     // First we parse the unreadChildren column (generic view)

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -317,7 +317,7 @@ inline void MorkParser::parseComment()
 //	=============================================================
 //	MorkParser::parseCell
 
-void MorkParser::parseCell()
+void MorkParser::parseCell(bool isInCutMode)
 {
     //bool bColumnOid = false;
     bool bValueOid = false;
@@ -430,8 +430,7 @@ void MorkParser::parseCell()
     }
     else
     {
-        if ( "" != Text )
-        {
+        if (!Text.isEmpty() && !(isInCutMode && (*currentCells_).contains(ColumnId))) {
             // Rows
             int ValueId = Text.toInt( 0, 16 );
 
@@ -605,7 +604,7 @@ void MorkParser::parseRow( int TableId, int TableScope )
             switch ( cur )
             {
             case '(':
-                parseCell();
+                parseCell(cutMode);
                 break;
             case '[':
                 parseMeta( ']' );

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -553,6 +553,12 @@ inline void MorkParser::setCurrentRow( int TableScope, int TableId, int RowScope
     {
         RowScope = defaultScope_;
     }
+    
+    if (!TableId) {
+        QPair<int, int> rowMapping = rowMappings.value(abs(RowId)).value(RowScope, {0, 0});
+        TableScope = rowMapping.first;
+        TableId = rowMapping.second;
+    }
 
     if ( !TableScope )
     {
@@ -607,6 +613,9 @@ void MorkParser::parseRow( int TableId, int TableScope )
         }
 
         cur = nextChar();
+    }
+    if (TableId != 0) {
+        rowMappings[abs(Id)][Scope == 0 ? defaultScope_ : Scope] = {TableScope, TableId};
     }
 }
 

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -568,7 +568,7 @@ inline void MorkParser::setCurrentRow( int TableScope, int TableId, int RowScope
 void MorkParser::parseRow( int TableId, int TableScope )
 {
     QString TextId;
-    int Id = 0, Scope = 0;
+    int Id = 0, Scope = TableScope;
     nowParsing_ = NPRows;
 
     char cur = nextChar();

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -591,7 +591,11 @@ void MorkParser::parseRow( int TableId, int TableScope )
     }
 
     parseScopeId( TextId, &Id, &Scope );
+    bool cutMode = Id < 0;
     setCurrentRow( TableScope, TableId, Scope, Id );
+    if (cutMode) {
+        (*currentCells_).clear();
+    }
 
     // Parse the row
     while ( cur != ']' && cur )

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -161,6 +161,7 @@ protected: // Data
     // All mork file data
     TableScopeMap mork_;
     MorkCells *currentCells_;
+    QMap<int, QMap<int, QPair<int, int>>> rowMappings;
 
     // Error status of last operation
     QString mErrorMessage;

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -177,4 +177,13 @@ protected: // Data
     enum { NPColumns, NPValues, NPRows } nowParsing_;
 };
 
+
+/**
+ * A mork parse for mail databases.
+ */
+class MailMorkParser : public MorkParser {
+public:
+    int getMorkUnreadCount();
+};
+
 #endif // __MorkParser_h__

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -146,7 +146,7 @@ protected: // Members
     void    parse();
     void    parseDict();
     void    parseComment();
-    void    parseCell();
+    void    parseCell(bool isInCutMode = false);
     void    parseTable();
     void    parseMeta( char c );
     void    parseRow( int TableId, int TableScope );

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -183,7 +183,10 @@ protected: // Data
  */
 class MailMorkParser : public MorkParser {
 public:
-    int getMorkUnreadCount();
+    /**
+     * @return The number of unread emails in the mork file.
+     */
+    unsigned int getNumUnreadMessages();
 };
 
 #endif // __MorkParser_h__

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -283,70 +283,14 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
 
 int UnreadMonitor::getMorkUnreadCount(const QString &path)
 {
-    MorkParser parser;
+    MailMorkParser parser;
     if (!parser.open(path)) {
         setWarning(tr("Unable to read from %1.").arg(QFileInfo(path).fileName()), path);
         return 0;
     } else {
         clearWarning(path);
     }
-    unsigned int unread = 0;
-
-    // First we parse the unreadChildren column (generic view)
-    const MorkRowMap * rows = parser.rows( 0x80, 0, 0x80 );
-
-    if ( rows )
-    {
-        for ( MorkRowMap::const_iterator rit = rows->begin(); rit != rows->cend(); rit++ )
-        {
-            MorkCells cells = rit.value();
-
-            for ( int colid : cells.keys() )
-            {
-                QString columnName = parser.getColumn( colid );
-
-                if ( columnName == "unreadChildren" )
-                {
-                    bool correct;
-                    unsigned int value = parser.getValue(cells[colid ]).toUInt( &correct, 16 );
-
-                    if ( correct )
-                        unread += value;
-                    else
-                        Utils::debug("Incorrect Mork value: %s", qPrintable( parser.getValue(cells[colid ]) ));                }
-            }
-        }
-    }
-    else
-    {
-        // Now parse the smart inbox
-        rows = parser.rows( 0x80, 0, 0x9F );
-
-        if ( rows )
-        {
-            for ( MorkRowMap::const_iterator rit = rows->begin(); rit != rows->cend(); rit++ )
-            {
-                MorkCells cells = rit.value();
-
-                for ( int colid : cells.keys() )
-                {
-                    QString columnName = parser.getColumn( colid );
-
-                    if ( columnName == "numNewMsgs" )
-                    {
-                        bool correct;
-                        unsigned int value = parser.getValue(cells[colid ]).toInt( &correct, 16 );
-
-                        if ( correct )
-                            unread += value;
-                        else
-                            Utils::debug("Incorrect Mork value: %s", qPrintable( parser.getValue(cells[colid ]) ));
-                    }
-                }
-            }
-        }
-    }
-
+    int unread = parser.getMorkUnreadCount();
     Utils::debug("Unread counter for %s: %d", qPrintable( path ), unread );
     return unread;
 }

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -290,7 +290,7 @@ int UnreadMonitor::getMorkUnreadCount(const QString &path)
     } else {
         clearWarning(path);
     }
-    int unread = parser.getMorkUnreadCount();
+    int unread = static_cast<int>(parser.getNumUnreadMessages());
     Utils::debug("Unread counter for %s: %d", qPrintable( path ), unread );
     return unread;
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,70 @@
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.10)
+
+find_package(GTest QUIET)
+if (NOT GTEST_FOUND)
+    message("Unable to find GTest on the system, downloading it...")
+    add_subdirectory(deps/GTest)
+endif()
+
+
+set(TESTS
+        src/test_morkparser.cpp
+        )
+
+add_executable(tests src/TestResources.cpp src/TestResources.h ${TESTS})
+target_include_directories(tests PRIVATE src)
+target_link_libraries(tests GTest::GTest GMock::GMock GMock::Main birdtray_lib)
+gtest_discover_tests(tests)
+
+add_custom_target(run_tests COMMENT "Run the Birdtray tests")
+add_custom_command(TARGET run_tests
+        POST_BUILD COMMAND $<TARGET_FILE:tests>)

--- a/tests/deps/GTest/CMakeLists.txt
+++ b/tests/deps/GTest/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+# Call CMake to download and Google Test
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+# Build the downloaded google test
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Prevent installation of GTest with your project
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(INSTALL_GMOCK OFF CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+        ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+        EXCLUDE_FROM_ALL)
+
+# Add aliases for GTest and GMock libraries
+if(NOT TARGET GTest::GTest)
+    add_library(GTest::GTest ALIAS gtest)
+    add_library(GTest::Main ALIAS gtest_main)
+endif()
+
+if(NOT TARGET GTest::GMock)
+    add_library(GMock::GMock ALIAS gmock)
+    add_library(GMock::Main ALIAS gmock_main)
+endif()

--- a/tests/deps/GTest/CMakeLists.txt.in
+++ b/tests/deps/GTest/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+    GIT_REPOSITORY    https://github.com/google/googletest.git
+    GIT_TAG           release-1.10.0
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+)

--- a/tests/res/0_Unread_Trash.msf
+++ b/tests/res/0_Unread_Trash.msf
@@ -1,0 +1,40 @@
+// <!-- <mdb:mork:z v="1.4"/> -->
+< <(a=c)> // (f=iso-8859-1)
+  (B8=applyToFlaggedMessages)(B9=useServerRetention)(BA=sortType)
+  (BB=sortOrder)(BC=viewFlags)(BD=viewType)(BE=columnStates)(BF=MRUTime)
+  (C0=sortColumns)(C1=customSortCol)(80=ns:msg:db:row:scope:msgs:all)
+  (81=subject)(82=sender)(83=message-id)(84=references)(85=recipients)
+  (86=date)(87=size)(88=flags)(89=priority)(8A=label)(8B=statusOfset)
+  (8C=numLines)(8D=ccList)(8E=bccList)(8F=msgThreadId)(90=threadId)
+  (91=threadFlags)(92=threadNewestMsgDate)(93=children)
+  (94=unreadChildren)(95=threadSubject)(96=msgCharSet)
+  (97=ns:msg:db:table:kind:msgs)(98=ns:msg:db:table:kind:thread)
+  (99=ns:msg:db:table:kind:allthreads)
+  (9A=ns:msg:db:row:scope:threads:all)(9B=threadParent)(9C=threadRoot)
+  (9D=msgOffset)(9E=offlineMsgSize)
+  (9F=ns:msg:db:row:scope:dbfolderinfo:all)
+  (A0=ns:msg:db:table:kind:dbfolderinfo)(A1=numMsgs)(A2=numNewMsgs)
+  (A3=folderSize)(A4=expungedBytes)(A5=folderDate)(A6=highWaterKey)
+  (A7=mailboxName)(A8=UIDValidity)(A9=totPendingMsgs)
+  (AA=unreadPendingMsgs)(AB=expiredMark)(AC=version)(AD=forceReparse)
+  (AE=fixedBadRefThreading)(AF=folderName)(B0=charSetOverride)
+  (B1=charSet)(B2=retainBy)(B3=daysToKeepHdrs)(B4=numHdrsToKeep)
+  (B5=daysToKeepBodies)(B6=useServerDefaults)(B7=cleanupBodies)>
+
+<(80=1)(81=0)(82=104)(83=Trash)(84=5da79884)(85=Deleted)(86=1571266346)
+  (87=12)(88=)(89
+    ={"threadCol":{"visible":true,"ordinal":"1"},"flaggedCol":{"visible":true,\
+"ordinal":"3"},"attachmentCol":{"visible":true,"ordinal":"5"},"subjectCol":{"v\
+isible":true,"ordinal":"7"},"unreadButtonColHeader":{"visible":true,"ordinal":\
+"9"},"senderCol":{"visible":false,"ordinal":"11"},"recipientCol":{"visible":fa\
+lse,"ordinal":"13"},"correspondentCol":{"visible":true,"ordinal":"15"},"junkSt\
+atusCol":{"visible":true,"ordinal":"17"},"receivedCol":{"visible":false,"ordin\
+al":"19"},"dateCol":{"visible":true,"ordinal":"21"},"statusCol":{"visible":fal\
+se,"ordinal":"23"},"sizeCol":{"visible":false,"ordinal":"25"},"tagsCol":{"visi\
+ble":false,"ordinal":"27"},"accountCol":{"visible":false,"ordinal":"29"},"prio\
+rityCol":{"visible":false,"ordinal":"31"},"unreadCol":{"visible":false,"ordina\
+l":"33"},"totalCol":{"visible":false,"ordinal":"35"},"locationCol":{"visible":\
+false,"ordinal":"37"},"idCol":{"visible":false,"ordinal":"39"}})>
+{1:^9F {(k^A0:c)(s=9)} 
+  [1(^AC=1)(^AD=0)(^AE=1)(^88^82)(^A7^83)(^A3=0)(^A5^84)(^AF^85)(^B9=1)
+    (^BF^86)(^BA=12)(^BB=1)(^BC=0)(^BD=0)(^C0=)(^BE^89)]}

--- a/tests/res/1_Unread_Filter.msf
+++ b/tests/res/1_Unread_Filter.msf
@@ -1,0 +1,44 @@
+// <!-- <mdb:mork:z v="1.4"/> -->
+< <(a=c)> // (f=iso-8859-1)
+  (B8=viewFlags)(B9=viewType)(BA=columnStates)(BB=MRUTime)
+  (BC=sortColumns)(BD=customSortCol)(80=ns:msg:db:row:scope:msgs:all)
+  (81=subject)(82=sender)(83=message-id)(84=references)(85=recipients)
+  (86=date)(87=size)(88=flags)(89=priority)(8A=label)(8B=statusOfset)
+  (8C=numLines)(8D=ccList)(8E=bccList)(8F=msgThreadId)(90=threadId)
+  (91=threadFlags)(92=threadNewestMsgDate)(93=children)
+  (94=unreadChildren)(95=threadSubject)(96=msgCharSet)
+  (97=ns:msg:db:table:kind:msgs)(98=ns:msg:db:table:kind:thread)
+  (99=ns:msg:db:table:kind:allthreads)
+  (9A=ns:msg:db:row:scope:threads:all)(9B=threadParent)(9C=threadRoot)
+  (9D=msgOffset)(9E=offlineMsgSize)
+  (9F=ns:msg:db:row:scope:dbfolderinfo:all)
+  (A0=ns:msg:db:table:kind:dbfolderinfo)(A1=numMsgs)(A2=numNewMsgs)
+  (A3=folderSize)(A4=expungedBytes)(A5=folderDate)(A6=highWaterKey)
+  (A7=mailboxName)(A8=UIDValidity)(A9=totPendingMsgs)
+  (AA=unreadPendingMsgs)(AB=expiredMark)(AC=version)(AD=forceReparse)
+  (AE=fixedBadRefThreading)(AF=folderName)(B0=charSetOverride)
+  (B1=charSet)(B2=searchStr)(B3=searchFolderUri)(B4=searchOnline)
+  (B5=searchFolderFlag)(B6=sortType)(B7=sortOrder)>
+
+<(80=1)(81=0)(83=24)(84=AND (subject,contains,Email\))(85
+    =mailbox://me@localhost/Inbox)(86=1581100303)(87
+    ={"threadCol":{"visible":true},"attachmentCol":{"visible":true},"flaggedCo\
+l":{"visible":true},"subjectCol":{"visible":true},"unreadButtonColHeader":{"vi\
+sible":true},"senderCol":{"visible":false},"recipientCol":{"visible":false},"c\
+orrespondentCol":{"visible":true},"junkStatusCol":{"visible":true},"dateCol":{\
+"visible":true},"locationCol":{"visible":false}})>
+{1:^9F {(k^A0:c)(s=9u)} 
+  [1(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)(^BA^87)]}
+
+@$${6{@
+[-1:^9F(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)(^B3^85)(^B4=0)(^BB^86)
+    (^BA^87)(^A2=1)(^A1=1)]
+@$$}6}@
+
+@$${7{@
+<(8A=1581100304)(88=12)(89=)>[-1:^9F(^AC=1)(^AD=0)(^AE=1)(^88=24)(^B2^84)
+    (^B3^85)(^B4=0)(^BB^8A)(^BA^87)(^A2=1)(^A1=1)(^B6=12)(^B7=1)(^BC=)]
+@$$}7}@
+
+@$${8{@
+@$$}8}@

--- a/tests/res/6_Unread_Inbox.msf
+++ b/tests/res/6_Unread_Inbox.msf
@@ -1,0 +1,221 @@
+// <!-- <mdb:mork:z v="1.4"/> -->
+< <(a=c)> // (f=iso-8859-1)
+  (B8=sortColumns)(B9=customSortCol)(BA=retainBy)(BB=daysToKeepHdrs)
+  (BC=numHdrsToKeep)(BD=daysToKeepBodies)(BE=useServerDefaults)
+  (BF=cleanupBodies)(C0=applyToFlaggedMessages)(C1=useServerRetention)
+  (C2=storeToken)(C3=dateReceived)(C4=ProtoThreadFlags)(C5=junkscore)
+  (C6=keywords)(C7=imageSize)(C8=recipient_names)(C9=gloda-id)
+  (CA=gloda-dirty)(80=ns:msg:db:row:scope:msgs:all)(81=subject)
+  (82=sender)(83=message-id)(84=references)(85=recipients)(86=date)
+  (87=size)(88=flags)(89=priority)(8A=label)(8B=statusOfset)(8C=numLines)
+  (8D=ccList)(8E=bccList)(8F=msgThreadId)(90=threadId)(91=threadFlags)
+  (92=threadNewestMsgDate)(93=children)(94=unreadChildren)
+  (95=threadSubject)(96=msgCharSet)(97=ns:msg:db:table:kind:msgs)
+  (98=ns:msg:db:table:kind:thread)(99=ns:msg:db:table:kind:allthreads)
+  (9A=ns:msg:db:row:scope:threads:all)(9B=threadParent)(9C=threadRoot)
+  (9D=msgOffset)(9E=offlineMsgSize)
+  (9F=ns:msg:db:row:scope:dbfolderinfo:all)
+  (A0=ns:msg:db:table:kind:dbfolderinfo)(A1=numMsgs)(A2=numNewMsgs)
+  (A3=folderSize)(A4=expungedBytes)(A5=folderDate)(A6=highWaterKey)
+  (A7=mailboxName)(A8=UIDValidity)(A9=totPendingMsgs)
+  (AA=unreadPendingMsgs)(AB=expiredMark)(AC=version)(AD=forceReparse)
+  (AE=fixedBadRefThreading)(AF=folderName)(B0=charSetOverride)
+  (B1=charSet)(B2=sortType)(B3=sortOrder)(B4=viewFlags)(B5=viewType)
+  (B6=columnStates)(B7=MRUTime)>
+<(80=1)(95=fffffffe)(90=5da771c8)(81=0)>
+[1:m(^9C=1)(^90^95)(^92^90)(^91=0)(^93=1)(^94=1)]
+<(9C=2)(9A=5da77398)>[2:m(^9C=2)(^90=2)(^92^9A)(^91=0)(^93=1)(^94=1)]
+<(93=3)(A1=5da7761d)>[3:m(^9C=3)(^90=3)(^92^A1)(^91=0)(^93=1)(^94=1)]
+<(8A=4)(A7=5da77a58)>[4:m(^9C=4)(^90=4)(^92^A7)(^91=0)(^93=1)(^94=1)]
+<(B0=5)(AE=5da7806d)>[5:m(^9C=5)(^90=5)(^92^AE)(^91=0)(^93=1)(^94=1)]
+<(B8=6)(B6=5da780a1)>[6:m(^9C=6)(^90=6)(^92^B6)(^91=0)(^93=1)(^94=1)]
+
+<(8B=2c)(8C=Me <me@localhost>)(8D=me@localhost)(8E=Test)(8F
+    =94b860ac-719e-9c98-dd9a-6a97febc20f4@localhost)(91=utf-8)(92=301)
+  (94=ffffffff)(BB=0|me@localhost)(C5=20)(97=769)(98=Test 3)(99
+    =67925738-7de9-d82e-2888-23e0c0d59793@localhost)(9B=2dd)(C6=21)
+  (9D=5de)(9E=1502)(9F=Test4)(A0
+    =c92b332a-686d-28c5-b097-c888620ffebf@localhost)(A2=2dc)(D4=25)
+  (A3=8ba)(A4=2234)(A5=c9727913-d8e1-2646-4601-98d0c0560700@localhost)
+  (A6=5da77a59)(A8=2db)(D2=23)(A9=b95)(AA=2965)(AB=test@localhost)(AC
+    =Email for Test)(AD=67a2d127-536c-6a69-3fde-5c12f795cbee@localhost)
+  (AF=2ed)(BC=0|test@localhost)(D1=22)(B1=e82)(B2=3714)(B3
+    =test@localhost.com)(B4=Test from localhost.com)(B5
+    =6bf525fb-117e-3f23-2939-f95154db423f@localhost)(B7=302)(BD
+    =0|test@localhost.com)(D3=24)>
+{1:^80 {(k^97:c)(s=9)} 
+  [1(^9D=0)(^C2=0)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^8D)(^81^8E)
+    (^83^8F)(^C3^90)(^86^90)(^96^91)(^87^92)(^8C=3)(^9B^94)(^8F^95)
+    (^C4=0)(^C8^BB)(^CA=0)(^C9=20)]
+  [2(^9D^92)(^C2^97)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^8D)(^81^98)
+    (^83^99)(^C3^9A)(^86^9A)(^96^91)(^87^9B)(^8C=2)(^9B^94)(^8F=2)(^C4=0)
+    (^C8^BB)(^C9=21)(^CA=0)]
+  [3(^9D^9D)(^C2^9E)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^8D)(^81^9F)
+    (^83^A0)(^C3^A1)(^86^A1)(^96^91)(^87^A2)(^8C=2)(^9B^94)(^8F=3)(^C4=0)
+    (^C8^BB)(^C9=25)(^CA=0)]
+  [4(^9D^A3)(^C2^A4)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^8D)(^81^8E)
+    (^83^A5)(^C3^A6)(^86^A7)(^96^91)(^87^A8)(^8C=2)(^9B^94)(^8F=4)(^C4=0)
+    (^C8^BB)(^C9=23)(^CA=0)]
+  [5(^9D^A9)(^C2^AA)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^AB)(^81^AC)
+    (^83^AD)(^C3^AE)(^86^AE)(^96^91)(^87^AF)(^8C=2)(^9B^94)(^8F=5)(^C4=0)
+    (^C8^BC)(^C9=22)]
+  [6(^9D^B1)(^C2^B2)(^88=0)(^89=4)(^8A=0)(^8B=2c)(^82^8C)(^85^B3)(^81^B4)
+    (^83^B5)(^C3^B6)(^86^B6)(^96^91)(^87^B7)(^8C=2)(^9B^94)(^8F=6)(^C4=0)
+    (^C8^BD)(^C9=24)(^CA=0)]}
+{2:^80 {(k^98:c)(s=9)2:m } 2 }
+{FFFFFFFE:^80 {(k^98:c)(s=9)1:m } 1 }
+{3:^80 {(k^98:c)(s=9)3:m } 3 }
+{4:^80 {(k^98:c)(s=9)4:m } 4 }
+{5:^80 {(k^98:c)(s=9)5:m } 5 }
+{6:^80 {(k^98:c)(s=9)6:m } 6 }
+{FFFFFFFD:^9A {(k^99:c)(s=9)} [FFFFFFFE(^95^8E)]
+  [2(^95^98)]
+  [3(^95^9F)]
+  [4(^95^8E)]
+  [5(^95^AC)]
+  [6(^95^B4)]}
+
+<(82=1004)(83=Inbox)(B9=1184)(10E=5db0df44)(134=1573920285)(86=12)(87=)
+  (89
+    ={"threadCol":{"visible":true,"ordinal":"1"},"flaggedCol":{"visible":true,\
+"ordinal":"3"},"attachmentCol":{"visible":true,"ordinal":"5"},"subjectCol":{"v\
+isible":true,"ordinal":"7"},"unreadButtonColHeader":{"visible":true,"ordinal":\
+"9"},"senderCol":{"visible":false,"ordinal":"11"},"recipientCol":{"visible":fa\
+lse,"ordinal":"13"},"correspondentCol":{"visible":true,"ordinal":"15"},"junkSt\
+atusCol":{"visible":true,"ordinal":"17"},"receivedCol":{"visible":false,"ordin\
+al":"19"},"dateCol":{"visible":true,"ordinal":"21"},"statusCol":{"visible":fal\
+se,"ordinal":"23"},"sizeCol":{"visible":false,"ordinal":"25"},"tagsCol":{"visi\
+ble":false,"ordinal":"27"},"accountCol":{"visible":false,"ordinal":"29"},"prio\
+rityCol":{"visible":false,"ordinal":"31"},"unreadCol":{"visible":false,"ordina\
+l":"33"},"totalCol":{"visible":false,"ordinal":"35"},"locationCol":{"visible":\
+false,"ordinal":"37"},"idCol":{"visible":false,"ordinal":"39"}})>
+{1:^9F {(k^A0:c)(s=9)} 
+  [1(^AC=1)(^AD=0)(^AE=1)(^88^82)(^A7^83)(^A3^B9)(^A5^10E)(^B7^134)
+    (^B2=12)(^B3=1)(^B4=0)(^B5=0)(^B8=)(^B6^89)(^C1=1)(^A1=6)(^A2=6)
+    (^A6=6)]}
+
+@$${1{@
+<(135=1573920575)>[1:^9F(^B7^135)]
+@$$}1}@
+
+@$${3{@
+<(136=1573920612)>[1:^9F(^B7^136)]
+@$$}3}@
+
+@$${5{@
+<(137=1573920921)>[1:^9F(^B7^137)]
+@$$}5}@
+
+@$${7{@
+<(138=1573920964)>[1:^9F(^B7^138)]
+@$$}7}@
+
+@$${9{@
+<(139=1573921017)>[1:^9F(^B7^139)]
+@$$}9}@
+
+@$${B{@
+<(13A=1573921515)>[1:^9F(^B7^13A)]
+@$$}B}@
+
+@$${D{@
+<(13B=1573921567)>[1:^9F(^B7^13B)]
+@$$}D}@
+
+@$${F{@
+<(13C=1573922182)>[1:^9F(^B7^13C)]
+@$$}F}@
+
+@$${11{@
+<(13D=1573922313)>[1:^9F(^B7^13D)]
+@$$}11}@
+
+@$${13{@
+<(13E=1573922435)>[1:^9F(^B7^13E)]
+@$$}13}@
+
+@$${15{@
+<(13F=1573922651)>[1:^9F(^B7^13F)]
+@$$}15}@
+
+@$${17{@
+<(140=1573927895)>[1:^9F(^B7^140)]
+@$$}17}@
+
+@$${19{@
+<(141=1574215235)>[1:^9F(^B7^141)]
+@$$}19}@
+
+@$${1A{@
+@$$}1A}@
+
+@$${1B{@
+@$$}1B}@
+
+@$${1D{@
+<(142=1574215689)>[1:^9F(^B7^142)]
+@$$}1D}@
+
+@$${1E{@
+@$$}1E}@
+
+@$${20{@
+<(143=1578439102)>[1:^9F(^B7^143)]
+@$$}20}@
+
+@$${21{@
+@$$}21}@
+
+@$${22{@
+@$$}22}@
+
+@$${24{@
+<(144=1578440234)>[1:^9F(^B7^144)]
+@$$}24}@
+
+@$${25{@
+@$$}25}@
+
+@$${27{@
+<(145=1578441475)>[1:^9F(^B7^145)]
+@$$}27}@
+
+@$${28{@
+@$$}28}@
+
+@$${2A{@
+<(146=1578600852)>[1:^9F(^B7^146)]
+@$$}2A}@
+
+@$${2B{@
+@$$}2B}@
+
+@$${2C{@
+@$$}2C}@
+
+@$${2E{@
+<(147=1578602168)>[1:^9F(^B7^147)]
+@$$}2E}@
+
+@$${2F{@
+@$$}2F}@
+
+@$${30{@
+@$$}30}@
+
+@$${32{@
+<(148=1579570352)>[1:^9F(^B7^148)]
+@$$}32}@
+
+@$${33{@
+@$$}33}@
+
+@$${34{@
+< <(a=c)> // (f=iso-8859-1)
+  (CB=mailbox://me@localhost/InboxSmart)>
+{-FFFFFFFF:^80 {(k^CB:c)(s=9u)} 5 }
+@$$}34}@
+
+@$${35{@
+<(149=1581100663)>[1:^9F(^B7^149)]
+@$$}35}@

--- a/tests/src/TestResources.cpp
+++ b/tests/src/TestResources.cpp
@@ -1,0 +1,14 @@
+#include "TestResources.h"
+#include <QtCore/QDir>
+
+
+QString TestResources::getAbsoluteResourcePath(const QString &name) {
+    return getResourceBasePath() + QDir::separator() + QDir::toNativeSeparators(name);
+}
+
+QString TestResources::getResourceBasePath() {
+    QDir sourceFile(__FILE__);
+    sourceFile.cdUp();
+    sourceFile.cdUp();
+    return QDir::toNativeSeparators(sourceFile.absoluteFilePath("res"));
+}

--- a/tests/src/TestResources.h
+++ b/tests/src/TestResources.h
@@ -1,0 +1,29 @@
+#ifndef BIRDTRAY_TEST_RESOURCE_H
+#define BIRDTRAY_TEST_RESOURCE_H
+
+
+#include <QtCore/QString>
+
+/**
+ * A class for handling resources for the tests.
+ */
+class TestResources {
+public:
+    /**
+     * Get the absolute path to a test resource file.
+     *
+     * @param name The name of the test resource file.
+     * @return The absolute path to the test resource.
+     */
+    static QString getAbsoluteResourcePath(const QString& name);
+
+private:
+    
+    /**
+     * @return The absolute path to the test resource directory.
+     */
+    static QString getResourceBasePath();
+};
+
+
+#endif /* BIRDTRAY_TEST_RESOURCE_H */

--- a/tests/src/test_morkparser.cpp
+++ b/tests/src/test_morkparser.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <morkparser.h>
+#include "TestResources.h"
+
+using namespace testing;
+
+TEST(MailMorkParser, correctUnreadCount) {
+    std::pair<const char*, int> cases[] = {
+            std::make_pair("6_Unread_Inbox.msf", 6),
+            std::make_pair("1_Unread_Filter.msf", 1),
+            std::make_pair("0_Unread_Trash.msf", 0),
+    };
+    for (const auto testCase : cases) {
+        MailMorkParser parser;
+        QString path = TestResources::getAbsoluteResourcePath(std::get<0>(testCase));
+        int expectedUnreadCount = std::get<1>(testCase);
+        if (!parser.open(path)) {
+            ADD_FAILURE() << "Expected the MailMorkParser to be able to open " << qPrintable(path);
+            continue;
+        }
+        EXPECT_EQ(parser.getNumUnreadMessages(), expectedUnreadCount)
+                        << "Expected the MailMorkParser to be able to "
+                           "read the correct unread value from " << qPrintable(path);
+    }
+}

--- a/tests/src/test_morkparser.cpp
+++ b/tests/src/test_morkparser.cpp
@@ -5,7 +5,7 @@
 using namespace testing;
 
 TEST(MailMorkParser, correctUnreadCount) {
-    std::pair<const char*, int> cases[] = {
+    std::pair<const char*, unsigned int> cases[] = {
             std::make_pair("6_Unread_Inbox.msf", 6),
             std::make_pair("1_Unread_Filter.msf", 1),
             std::make_pair("0_Unread_Trash.msf", 0),
@@ -13,7 +13,7 @@ TEST(MailMorkParser, correctUnreadCount) {
     for (const auto testCase : cases) {
         MailMorkParser parser;
         QString path = TestResources::getAbsoluteResourcePath(std::get<0>(testCase));
-        int expectedUnreadCount = std::get<1>(testCase);
+        unsigned int expectedUnreadCount = std::get<1>(testCase);
         if (!parser.open(path)) {
             ADD_FAILURE() << "Expected the MailMorkParser to be able to open " << qPrintable(path);
             continue;


### PR DESCRIPTION
This pull request adds unit tests 🎉. It is based on top of #257, which is why it also includes the changes for it.
In order to use the same compiled code in the Birdtray executable and the test executable, we now compile the main Birdtray code (everything except `main.cpp`) as a static library and link that with the two executables.

The tests are disabled by default. One needs to add the command line parameter `-DBUILD_WITH_TESTS=ON` when configuring the project with Cmake to enable the test. Doing so will add a `run_tests` target that can be used to compile and execute the tests.

We use [GTest](https://github.com/google/googletest) as the testing framework. If it is not installed on the system, it will be automatically downloaded by Cmake.

Currently, there is only one unit test that verifies that the mork parser reads the correct number of unread emails from a few test mork files.