### PR TITLE
Fix error message when uninstalling a local user installation on Windows

### DIFF
--- a/src/translations/installer_de.ts
+++ b/src/translations/installer_de.ts
@@ -185,6 +185,10 @@
         <translation>${PRODUCT_NAME} Einstellungen</translation>
     </message>
     <message>
+        <source>UninstallRestartAsUserQuestion</source>
+        <translation>Das Deinstallationsprogramm wurde mit Administrator-Rechten gestartet, aber es scheint keine ${PRODUCT_NAME}-Installation beim Administrator vorhanden zu sein. Wollen Sie die Deinstallation als Nutzer ohne Administrator-Rechten neustarten?</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>Englisch</translation>
     </message>

--- a/src/translations/installer_en.ts
+++ b/src/translations/installer_en.ts
@@ -189,6 +189,10 @@
         <translation>${PRODUCT_NAME} settings</translation>
     </message>
     <message>
+        <source>UninstallRestartAsUserQuestion</source>
+        <translation>The uninstaller is started with administrator privileges but there seems to be no ${PRODUCT_NAME} installation for the administrator. Do you want to restart the uninstaller without admin privileges?</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>English</translation>
     </message>

--- a/src/translations/installer_nl.ts
+++ b/src/translations/installer_nl.ts
@@ -189,6 +189,10 @@
         <translation>${PRODUCT_NAME} settings</translation>
     </message>
     <message>
+        <source>UninstallRestartAsUserQuestion</source>
+        <translation>The uninstaller is started with administrator privileges but there seems to be no ${PRODUCT_NAME} installation for the administrator. Do you want to restart the uninstaller without admin privileges?</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>Engels</translation>
     </message>


### PR DESCRIPTION
A Windows bug causes the uninstaller to always be started with admin rights when uninstalling from the `Apps and Features` setting page. That caused the uninstallation of per-user installations to fail, because the unistaller looked in the `%Appdata%` folder of the admin account instead of the `%Appdata%` folder of the user ([Original issue description on the `NsisMultiUser` library](https://github.com/Drizin/NsisMultiUser/issues/6)). Closes #268.

To fix this we detect if there is no installation for the current user if we are the admin. In that case we ask if the user wants to restart the uninstaller without admin permissions.

![Restart without admin privileges dialog](https://user-images.githubusercontent.com/6966049/76692278-8a316380-6654-11ea-80bf-ca0454ae4351.png)
