### PR TITLE
Cache Qt on Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt ${{ matrix.qt_version }}
-        uses: ouuan/install-qt-action@v2.3.1
+        uses: jurplel/install-qt-action@v2
         with:
           version: ${{ matrix.qt_version }}
           arch: ${{ matrix.qt_compile_suite }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
             qt_version: 5.6
           - os: windows-latest
             qt_version: 5.9
-          # We only compile for the current architecture of the runner for linux
+          # We only compile for the current architecture of the runner for Linux
           - os: ubuntu-latest
             arch: x86
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ runner.temp }}/Qt
-          key: ${{ runner.os }}-Qt-${{ matrix.qt_version }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-Qt-${{ matrix.qt_version }}
       - name: Install Qt ${{ matrix.qt_version }}
         uses: jurplel/install-qt-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,19 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Qt ${{ matrix.qt_version }}
+        id: cache-qt
+        uses: actions/cache@v1
+        with:
+          path: ${{ runner.temp }}/Qt
+          key: ${{ runner.os }}-Qt-${{ matrix.qt_version }}
       - name: Install Qt ${{ matrix.qt_version }}
         uses: jurplel/install-qt-action@v2
         with:
           version: ${{ matrix.qt_version }}
           arch: ${{ matrix.qt_compile_suite }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          dir: ${{ runner.temp }}/Qt
       - name: Install additional dependencies
         shell: bash
         env:


### PR DESCRIPTION
We now cache Qt on Github Actions, which improves the build time:

![Less Build time using the cache](https://user-images.githubusercontent.com/6966049/76692856-bc46c380-665c-11ea-980d-28a9097f6d85.png)


This also reverts #255, as the `jurplel/install-qt-action` seems to have stabilized.