### PR TITLE
Fix duplicated watched mail folders

### DIFF
--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -110,6 +110,11 @@ void ModelAccountTree::addAccount(const QString &uri, const QColor &color)
     if (uri.isEmpty()) {
         return;
     }
+    int existingIndex = mAccounts.indexOf(uri);
+    if (existingIndex != -1) {
+        editAccount(createIndex(existingIndex, 0), uri, color);
+        return;
+    }
     // Only this line changed
     beginInsertRows( QModelIndex(), mColors.size(), mColors.size() + 1 );
 


### PR DESCRIPTION
This removes the ability to watch the same mail folder multiple times. Fixes #231.
This bug was possible, because we store the information about the number of watched folders twice in the settings; Once as the actual data (`accounts/accountX[Color|URI]`) and once as a number (`accounts/count`).
The duplication of information is what allowed this bug, which is why this pull request removes the `accounts/count` value, so the actual data is the single source of truth. However, we still read the `accounts/count` for old installations, to keep backwards compatibility.