### PR TITLE
Add deployment via Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         id: check-deploy
         shell: bash
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
             echo ::set-output name=is_deploy::true
             echo "Deployment build detected"
           else
@@ -128,7 +128,7 @@ jobs:
       - name: Check if this is a deployment build
         shell: bash
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Creating release ${{ github.ref }}..."
           else
             echo "Tag does not match: ${{ github.event.ref }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,9 @@ jobs:
             fi
             echo "::set-env name=CMAKE_PREFIX_PATH::$sqliteDir"
             echo "::add-path::$sqliteDir"
-            choco install -y $archParam sqlite --params \"/NoTools\"
+            choco install -y --force $archParam sqlite --params \"/NoTools\"
+            choco install -y --force $archParam openssl.light
+            echo "::add-path::C:\\Program Files\\OpenSSL"
             curl -sS https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip > sqlite-source.zip
             unzip -p sqlite-source.zip sqlite-amalgamation-3300100/sqlite3.h > $sqliteDir/sqlite3.h
             rm sqlite-source.zip
@@ -70,14 +72,124 @@ jobs:
             exit 1
           fi
       - name: Create build environment
-        run: cmake -E make_directory ${{runner.workspace}}/build
+        run: cmake -E make_directory ${{ runner.workspace }}/build
       - name: Configure CMake
         shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_TESTS=ON
+        working-directory: ${{ runner.workspace }}/build
+        run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_TESTS=ON -DDONT_EXECUTE_INSTALLER=ON
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: ${{ runner.workspace }}/build
         run: cmake --build . --config Release --target birdtray
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target run_tests
+      - name: Check if this is a deployment build
+        id: check-deploy
+        shell: bash
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
+            echo ::set-output name=is_deploy::true
+            echo "Deployment build detected"
+          else
+            echo "Not a deployment build, skipping deploy steps"
+          fi
+      - name: Install installer dependencies
+        if: steps.check-deploy.outputs.is_deploy == 'true'
+        run: choco install -y nsis;
+      - name: Create installer
+        if: steps.check-deploy.outputs.is_deploy == 'true'
+        working-directory: ${{ runner.workspace }}/build
+        run: cmake --build . --config Release --target install
+      - name: Find installer
+        if: steps.check-deploy.outputs.is_deploy == 'true'
+        id: find_installer_file
+        shell: bash
+        run: |
+          installerFile=`find . -name "Birdtray-*.exe" -exec basename {} \;`
+          echo ::set-output name=installer_file::$installerFile
+          echo "Found installer: $installerFile"
+          mkdir installer/cache
+          mv installer/$installerFile installer/cache
+      - name: Cache installer
+        uses: actions/upload-artifact@v1
+        if: steps.check-deploy.outputs.is_deploy == 'true'
+        with:
+          name: installer-${{ runner.os }}-${{ matrix.arch }}-${{ github.sha }}
+          path: installer/cache/${{ steps.find_installer_file.outputs.installer_file }}
+
+  release:
+    name: Create Release
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && contains(github.ref, '.')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if this is a deployment build
+        shell: bash
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Creating release ${{ github.ref }}..."
+          else
+            echo "Tag does not match: ${{ github.event.ref }}"
+            exit 1
+          fi
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+      - name: Write upload url file
+        run: echo "${{ steps.create_release.outputs.upload_url }}" > upload_url.txt
+      - name: Cache upload url
+        uses: actions/upload-artifact@v1
+        with:
+          name: upload_url
+          path: upload_url.txt
+
+  deploy:
+    name: Deploy
+    needs: [build, release]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x86, x64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download installer
+        uses: actions/download-artifact@v1
+        with:
+          name: installer-${{ runner.os }}-${{ matrix.arch }}-${{ github.sha }}
+          path: installer
+      - name: Find installer
+        id: find_installer_file
+        shell: bash
+        run: |
+          value=`find installer -name "Birdtray-*.exe" -exec basename {} \;`
+          echo ::set-output name=installer_file::$value
+      - name: Fetch the upload url
+        uses: actions/download-artifact@v1
+        with:
+          name: upload_url
+      - name: Read the upload url
+        id: get_upload_url
+        shell: bash
+        run: |
+          value=`cat upload_url/upload_url.txt`
+          echo ::set-output name=upload_url::$value
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+          asset_path: ./installer/${{ steps.find_installer_file.outputs.installer_file }}
+          asset_name: ${{ steps.find_installer_file.outputs.installer_file }}
+          asset_content_type: application/x-msdownload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,20 +179,41 @@ endif()
 
 # Installation
 if(WIN32)
-    # Find ssl libraries
-    find_library(SSL_LIBRARY NAMES ssl)
-    get_filename_component(SSL_PATH ${SSL_LIBRARY} DIRECTORY)
-    if(SSL_LIBRARY)
-        STRING(REGEX REPLACE "/" "\\\\\\\\" SSL_PATH ${SSL_PATH})
+    if(POLICY CMP0087)
+        cmake_policy(SET CMP0087 NEW)
     endif()
 
+    option(DONT_EXECUTE_INSTALLER "Only create the Windows installer but don't execute it" OFF)
+    set(INSTALL_ARG --install)
+    if (DONT_EXECUTE_INSTALLER)
+        set(INSTALL_ARG)
+    endif()
+
+    # Find ssl libraries
+    find_package(OpenSSL QUIET)
+    message("OPENSSL_SSL_LIBRARY: ${OPENSSL_SSL_LIBRARY}")
+    get_filename_component(SSL_PATH ${OPENSSL_SSL_LIBRARY} DIRECTORY)
+    if(SSL_PATH)
+        STRING(REGEX REPLACE "/" "\\\\\\\\" SSL_PATH ${SSL_PATH})
+    else()
+        set(SSL_PATH "C:\\\\Program Files\\\\OpenSSL")
+    endif()
+    message("SSL_PATH: ${SSL_PATH}")
+
     # Create installer
-    STRING(REGEX REPLACE "/" "\\\\\\\\" BIRDTRAY_EXE ${CMAKE_BINARY_DIR}/birdtray.exe)
     STRING(REGEX REPLACE "/" "\\\\\\\\" SQLITE3_PATH ${SQLITE3_LIBRARY})
-    install(CODE "execute_process(
+    STRING(REGEX REPLACE ".lib$" ".dll" SQLITE3_PATH ${SQLITE3_PATH})
+    install(CODE "if(NOT POLICY CMP0087)
+            message(FATAL_ERROR \"The install target requires cmake 3.14 or newer\")
+        endif()
+        execute_process(
         COMMAND cmd /C buildInstaller.bat
-            \"${BIRDTRAY_EXE}\" \"${SQLITE3_PATH}\" \"${SSL_PATH}\" --install
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/installer)")
+            \"$<TARGET_FILE:birdtray>\" \"${SQLITE3_PATH}\" \"${SSL_PATH}\" ${INSTALL_ARG}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/installer
+        RESULT_VARIABLE INSTALL_RESULT)
+        if(NOT \${INSTALL_RESULT} EQUAL \"0\")
+            message(FATAL_ERROR \"Install command failed with exit code \${INSTALL_RESULT}\")
+        endif()")
 else()
     include(GNUInstallDirs)
     install(TARGETS birdtray RUNTIME DESTINATION bin)

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -169,7 +169,7 @@ FunctionEnd
 !macro ValidPath VAR PATH BAD_CHARACTERS
     Push `${PATH}`
     Push `${BAD_CHARACTERS}`
-    call ValidPath
+    Call ValidPath
     Pop `${VAR}`
 !macroend
 !define ValidPath "!insertmacro ValidPath"
@@ -203,7 +203,7 @@ Function IsDirEmpty
 FunctionEnd
 !macro IsDirEmpty VAR DIR
     Push ${DIR}
-    call IsDirEmpty
+    Call IsDirEmpty
     Pop ${VAR}
 !macroend
 !define IsDirEmpty "!insertmacro IsDirEmpty"

--- a/installer/getExeArch.nsi
+++ b/installer/getExeArch.nsi
@@ -2,6 +2,7 @@
 !include LogicLib.nsh
 !define SCS_64BIT_BINARY 6
 
+Unicode true
 SetCompress off
 Name "getExeArch"
 OutFile "GetExeArch.exe"

--- a/installer/makeInstallerTranslations.nsi
+++ b/installer/makeInstallerTranslations.nsi
@@ -3,13 +3,15 @@
 !addincludedir nsisDependencies\Include
 !addincludedir .
 
+#Unicode true # TODO: xml plugin does not support unicode, maybe use http://wiz0u.free.fr/prog/nsisXML/
+SetCompress off
+
 !include XML.nsh
 !include LogicLib.nsh
 !include StrFunc.nsh
 !Include StrUtils.nsh
 ${StrCase}
 
-SetCompress off
 Name "makeTranslationsList"
 OutFile "${INSTALLER_TRANSLATIONS_BUILDER_FILE}"
 SilentInstall silent

--- a/installer/makeTranslationsList.nsi
+++ b/installer/makeTranslationsList.nsi
@@ -1,3 +1,4 @@
+Unicode true
 SetCompress off
 Name "makeTranslationsList"
 OutFile "makeTranslationsList.exe"

--- a/installer/makeUninstallList.nsi
+++ b/installer/makeUninstallList.nsi
@@ -1,3 +1,4 @@
+Unicode true
 SetCompress off
 Name "makeUninstallList"
 OutFile "makeUninstallList.exe"


### PR DESCRIPTION
With this pull request, we can automatically create a **draft** release (that is hidden to non project maintainers) here on Github that contains prebuilt installers for Win x86 and x64. We just need to push a tag with the following pattern `v[0-9]+\.[0-9]+\.[0-9]+` (e.g. `v1.8.0`). This means this can only be done by someone with direct access to this repository, or when someone merges a pull request with the tag. A git push to a pull request should not be allowed to create a draft release, because it will have a `github.event_name` = `pull_request`. We should test this though after the merge to make sure.

We also now require a Cmake `3.14` for Windows users that want to use the cmake install target. That is probably not affecting a single person.