### PR TITLE
Detect missing C++ Runtime on Windows

### DIFF
--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -212,6 +212,45 @@ FunctionEnd
 !define SelectSection '!insertmacro SelectSection'
 !define UnselectSection '!insertmacro UnselectSection'
 
+!ifndef UNINSTALL_BUILDER
+
+# Check if a Visual C++ Redistributable is installed.
+# $0 - ARCH: The path of the directory (x64 or x86).
+# Returns:
+# $0 - IS_INSTALLED: 1 (true) if a Visual C++ Redistributable is installed and 0 (false) if not.
+Function IsVisualRedistributableInstalled
+    Exch $0
+    ${if} ${RunningX64}
+        ReadRegDword $0 HKLM "SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\$0" \
+            "Installed"
+    ${else}
+        ReadRegDword $0 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\$0" "Installed"
+    ${endif}
+    Exch $0
+FunctionEnd
+!macro IsVisualRedistributableInstalled VAR ARCH
+    Push ${ARCH}
+    Call IsVisualRedistributableInstalled
+    Pop ${VAR}
+!macroend
+!define IsVisualRedistributableInstalled "!insertmacro IsVisualRedistributableInstalled"
+
+
+# Open an url in a browser window.
+# $0 - URL: The url to open.
+Function OpenURL
+    Exch $0
+    Exec "rundll32 url.dll,FileProtocolHandler $0"
+    DetailPrint "$(OpenUrl)"
+    Pop $0
+FunctionEnd
+!macro OpenURL URL
+    Push ${URL}
+    Call OpenURL
+!macroend
+!define OpenURL "!insertmacro OpenURL"
+!endif # UNINSTALL_BUILDER
+
 # === Macros === #
 
 # Check that the program is suitable for the platform.

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -215,7 +215,7 @@ FunctionEnd
 !ifndef UNINSTALL_BUILDER
 
 # Check if a Visual C++ Redistributable is installed.
-# $0 - ARCH: The path of the directory (x64 or x86).
+# $0 - ARCH: The architecture of the C++ Redistributable (x64 or x86).
 # Returns:
 # $0 - IS_INSTALLED: 1 (true) if a Visual C++ Redistributable is installed and 0 (false) if not.
 Function IsVisualRedistributableInstalled

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -397,7 +397,7 @@ Section "-Check VC Installed" # Hidden section, check if the Visual Redistributa
         VCNotFound:
         DetailPrint "$(MissingVcRuntime_UnableToRun)"
         MessageBox MB_OK|MB_ICONEXCLAMATION "$(MissingVcRuntime_UnableToRunDialog)" /SD IDOK
-        SetErrorLevel 1157
+        SetErrorLevel 1157 # ERROR_DLL_NOT_FOUND
 
         Done:
     ${endif}
@@ -658,7 +658,7 @@ Function FinishPagePre
     ${IsVisualRedistributableInstalled} $R0 ${ARCH}
     ${if} $R0 != 1
         SendMessage $mui.FinishPage.Run ${BM_SETCHECK} ${BST_UNCHECKED} 0 # uncheck 'run software'
-        ShowWindow $mui.FinishPage.Run 0 # hide the checkbox
+        ShowWindow $mui.FinishPage.Run 0 # Hide the checkbox
     ${endif}
     !endif # UNINSTALL_BUILDER
 FunctionEnd

--- a/src/translations/installer_de.ts
+++ b/src/translations/installer_de.ts
@@ -189,6 +189,38 @@
         <translation>Das Deinstallationsprogramm wurde mit Administrator-Rechten gestartet, aber es scheint keine ${PRODUCT_NAME}-Installation beim Administrator vorhanden zu sein. Wollen Sie die Deinstallation als Nutzer ohne Administrator-Rechten neustarten?</translation>
     </message>
     <message>
+        <source>OpenUrl</source>
+        <translation>Öffne $0 im Standardbrowser...</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime</source>
+        <translation>Die Visual C++ Runtime ${ARCH} konnte nicht gefunden werden.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Dialog</source>
+        <translation>Die folgende benötigte Komponente wurde auf diesem Computer nicht gefunden:$\r$\nVisual C++ Runtime ${ARCH}$\r$\nWollen Sie das Installationsprogramm für die Komponente herunterladen?</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Retry</source>
+        <translation>Starten Sie bitte das Installationsprogramm, nachdem es heruntergeladen wurde. Wenn die Installation abgeschlossen ist, klicken Sie bitte auf OK, um den Installationsstatus erneut zu überprüfen.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Found</source>
+        <translation>Die erforderliche Komponente wurde erfolgreich auf Ihrem Computer gefunden.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_StillNotFound</source>
+        <translation>Die erforderliche Komponente konnte nicht auf Ihrem Computer gefunden werden. Bitte suchen Sie Online nach Visual C++ ${ARCH} Downloads für Visual Studio 2015 und höher.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRun</source>
+        <translation>${PRODUCT_NAME} wird nicht starten können.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRunDialog</source>
+        <translation>${PRODUCT_NAME} wird nicht starten können, da eine erforderliche Komponente fehlt.</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>Englisch</translation>
     </message>

--- a/src/translations/installer_en.ts
+++ b/src/translations/installer_en.ts
@@ -189,6 +189,38 @@
         <translation>The uninstaller is started with administrator privileges but there seems to be no ${PRODUCT_NAME} installation for the administrator. Do you want to restart the uninstaller without admin privileges?</translation>
     </message>
     <message>
+        <source>OpenUrl</source>
+        <translation>Opening $0 in default browser...</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime</source>
+        <translation>Unable to find Visual C++ Runtime ${ARCH}.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Dialog</source>
+        <translation>The following required component was not found on this computer:$\r$\nVisual C++ Runtime ${ARCH}$\r$\nDo you want to download the installer for the component?</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Retry</source>
+        <translation>Once the download completes, please execute the downloaded installer. When the installer is finished, press OK to check the installation status again.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Found</source>
+        <translation>The required component was successfully detected on your computer.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_StillNotFound</source>
+        <translation>The required component was not found on your computer. Please search online for Visual C++ ${ARCH} downloads for Visual Studio 2015 and higher.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRun</source>
+        <translation>${PRODUCT_NAME} will not be able to run.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRunDialog</source>
+        <translation>${PRODUCT_NAME} will not be able to start because a required component is missing.</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>English</translation>
     </message>

--- a/src/translations/installer_it.ts
+++ b/src/translations/installer_it.ts
@@ -189,6 +189,38 @@
         <translation>The uninstaller is started with administrator privileges but there seems to be no ${PRODUCT_NAME} installation for the administrator. Do you want to restart the uninstaller without admin privileges?</translation>
     </message>
     <message>
+        <source>OpenUrl</source>
+        <translation>Opening $0 in default browser...</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime</source>
+        <translation>Unable to find Visual C++ Runtime ${ARCH}.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Dialog</source>
+        <translation>The following required component was not found on this computer:$\r$\nVisual C++ Runtime ${ARCH}$\r$\nDo you want to download the installer for the component?</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Retry</source>
+        <translation>Once the download completes, please execute the downloaded installer. When the installer is finished, press OK to check the installation status again.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Found</source>
+        <translation>The required component was successfully detected on your computer.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_StillNotFound</source>
+        <translation>The required component was not found on your computer. Please search online for Visual C++ ${ARCH} downloads for Visual Studio 2015 and higher.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRun</source>
+        <translation>${PRODUCT_NAME} will not be able to run.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRunDialog</source>
+        <translation>${PRODUCT_NAME} will not be able to start because a required component is missing.</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>Inglese</translation>
     </message>

--- a/src/translations/installer_nl.ts
+++ b/src/translations/installer_nl.ts
@@ -189,6 +189,38 @@
         <translation>The uninstaller is started with administrator privileges but there seems to be no ${PRODUCT_NAME} installation for the administrator. Do you want to restart the uninstaller without admin privileges?</translation>
     </message>
     <message>
+        <source>OpenUrl</source>
+        <translation>Opening $0 in default browser...</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime</source>
+        <translation>Unable to find Visual C++ Runtime ${ARCH}.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Dialog</source>
+        <translation>The following required component was not found on this computer:$\r$\nVisual C++ Runtime ${ARCH}$\r$\nDo you want to download the installer for the component?</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Retry</source>
+        <translation>Once the download completes, please execute the downloaded installer. When the installer is finished, press OK to check the installation status again.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_Found</source>
+        <translation>The required component was successfully detected on your computer.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_StillNotFound</source>
+        <translation>The required component was not found on your computer. Please search online for Visual C++ ${ARCH} downloads for Visual Studio 2015 and higher.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRun</source>
+        <translation>${PRODUCT_NAME} will not be able to run.</translation>
+    </message>
+    <message>
+        <source>MissingVcRuntime_UnableToRunDialog</source>
+        <translation>${PRODUCT_NAME} will not be able to start because a required component is missing.</translation>
+    </message>
+    <message>
         <source>Lang_en</source>
         <translation>Engels</translation>
     </message>


### PR DESCRIPTION
On a freshly installed Windows machine with no other programs, there will not be a C++ runtime and Birdtray will fail to start. The C++ runtime is shared by all programs on a Windows PC. If you install any other program (e.g. `Chrome` or `Firefox`), most of them will install the C++ runtime. That is why this is not a big problem and almost nobody encountered it, but it caused #220.

The installer for `1.7.0` contained an installer for the C++ runtime, but never installed it. Because the runtime installer made up a significant portion of the size of the Birdtray installer (~10Mb, 50% of the installer) and it is never used by 99.9% of the people using the installer, I decided the best option is to not include the C++ runtime installer in the Birdtray installer. Instead display a message and open the link to download the C++ runtime installer from the Microsoft servers. This will keep the installer size down and does not automatically downloads and runs an executable from the internet.

<details>
<summary>Images</summary>

!["C++ runtime not found"-dialog](https://user-images.githubusercontent.com/6966049/77263946-ae66f300-6c99-11ea-8378-32b219faeff9.PNG)

If the user clicks `No`, they get the following warning. In that case they can install the runtime manually:
!["Birdtray not runnable warning"-dialog](https://user-images.githubusercontent.com/6966049/77254484-8491da00-6c61-11ea-99df-fa43f8532b83.PNG)

If the user clicks `Yes`, the direct url to download the C++ runtime installer is opened in the default browser and the following message is displayed:
!["Waiting for installation"-dialog](https://user-images.githubusercontent.com/6966049/77254509-b30fb500-6c61-11ea-9ed0-2e6e47f3380f.PNG)

If the C++ runtime is still not detected after that, the user is represented with the following dialog:
!["C++ runtime still not found"-dialog](https://user-images.githubusercontent.com/6966049/77254530-dfc3cc80-6c61-11ea-962b-074bbd1ac7e4.PNG)

In that case and if the user decided not to download the C++ runtime installer before, they don't get the option to start Birdtray from the installer:
!["Installation finished"-page without the option to start Birdtray](https://user-images.githubusercontent.com/6966049/77254554-0255e580-6c62-11ea-8c9c-d717391ffd09.PNG)

Otherwise, they get a dialog that the C++ runtime was successfully detected.
![C++ runtime detected dialog](https://user-images.githubusercontent.com/6966049/77254578-2adddf80-6c62-11ea-926a-817fa7d62671.PNG)
</details>