### PR TITLE
Add options for console log output

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -56,11 +56,11 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv)
         return;
     }
     
-    // This also initializes log
+    Log::initialize(commandLineParser.value("log"));
+
     Log::debug( "Birdtray version %d.%d.%d started", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH );
 
     ensureSystemTrayAvailable();
-    
     // Load settings
     settings = new Settings();
     if (commandLineParser.isSet("reset-settings")) {
@@ -68,6 +68,7 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv)
     } else {
         settings->load();
     }
+
     if (!translationLoadedSuccessfully) {
         Log::debug("Failed to load translation for %s", qPrintable(QLocale::system().name()));
     }
@@ -167,6 +168,7 @@ void BirdtrayApp::parseCmdArguments() {
             {{"s", SHOW_THUNDERBIRD_COMMAND}, tr("Show the Thunderbird window.")},
             {{"H", HIDE_THUNDERBIRD_COMMAND}, tr("Hide the Thunderbird window.")},
             {{"r", "reset-settings"}, tr("Reset the settings to the defaults.")},
+            {{"l", "log"}, tr("Write log to a file."), tr("FILE")}
     });
     commandLineParser.process(*this);
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -99,4 +99,7 @@ void Log::add(const QString &text)
     // Add it to the open log window, if any
     if ( !mDialog.isNull() )
         mDialog.data()->add( logline );
+
+    // Log message to stderr
+    qDebug( "%s", qPrintable(logline) );
 }

--- a/src/log.h
+++ b/src/log.h
@@ -4,11 +4,12 @@
 #include <QMutex>
 #include <QPointer>
 #include <QStringList>
+#include <QFile>
 
 class DialogLogOutput;
 
 // Logger
-class Log
+class Log final
 {
     public:
         // Adds a log entry and terminates an app, writing the log buffer to log.txt
@@ -19,6 +20,9 @@ class Log
 
         // Shows the logging widget
         static void    showLogger();
+
+        // Initializes log with/without a file output
+        static void    initialize( const QString& path = "" );
 
     private:
         // Only keep this number of last log lines in buffer
@@ -33,14 +37,15 @@ class Log
         void    add( const QString& text );
 
         // Internal stuff
-        Log();
-        ~Log();
+        Log()  = default;
+        ~Log() = default;
         Log( const Log& l) = delete;
         Log operator= ( const Log& l) = delete;
 
         // All historic log entries are stored here, guarded by mMutex
         QStringList     mEntries;
         QMutex          mMutex;
+        QFile           mOutputFile;
 
         // Auto-set to null when log dialog is closed
         QPointer<DialogLogOutput>   mDialog;


### PR DESCRIPTION
Add -l/--log CLI option (higher priority) and checkbox to choose
where to write Birdtray logs.

In some cases (i.e. debugging or automated log collection) having log written to stdout, stderr or file may be significantly more convenient.