### PR TITLE
Fix the config path for Windows and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Birdtray is a system tray new mail notification for Thunderbird, which does not require extensions. [![Build Status](https://github.com/gyunaev/birdtray/workflows/Build/badge.svg)](https://github.com/gyunaev/birdtray/action)
+# Birdtray is a system tray new mail notification for Thunderbird, which does not require extensions. [![Build Status](https://github.com/gyunaev/birdtray/workflows/Build/badge.svg?event=push)](https://github.com/gyunaev/birdtray/action)
 
 Birdtray is a free system tray notification for new mail for Thunderbird. It supports Linux and Windows (credit for adding and maintaining Windows support goes to @Abestanis). Patches to support other platforms are welcome.
 
@@ -87,7 +87,7 @@ Once you change settings, often you need to restart birdtray for the new setting
 `$HOME/.var/app/com.ulduzsoft.Birdtray/config/ulduzsoft/birdtray-config.json`
 
 #### Windows Installation
-`%AppData%\Local\ulduzsoft\birdtray\birdtray-config.json`
+`%LocalAppData%\ulduzsoft\birdtray\birdtray-config.json`
 
 ## Troubleshooting
 

--- a/src/log.h
+++ b/src/log.h
@@ -12,10 +12,10 @@ class Log
 {
     public:
         // Adds a log entry and terminates an app, writing the log buffer to log.txt
-        static void    fatal( const QString& str );
+        Q_NORETURN static void    fatal( const QString& str );
 
         // Adds a debug log entry
-        static void    debug( const char * fmt, ... );
+        static void    debug( const char * fmt, ... ) Q_ATTRIBUTE_FORMAT_PRINTF(1, 2);
 
         // Shows the logging widget
         static void    showLogger();

--- a/src/processhandle.cpp
+++ b/src/processhandle.cpp
@@ -17,7 +17,6 @@ static int registerExitReasonMetaType() Q_DECL_NOTHROW {
         // Don't translate the message, because it gets marked as vanished
         // by the lupdate tool on non-Windows platforms.
         Log::fatal("Failed to register ExitReason meta type.");
-        return 0; // to shut up warning
     }
 }
 

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -32,7 +32,7 @@ TrayIcon::TrayIcon(bool showSettings)
     mMenuIgnoreUnreads = 0;
     mThunderbirdProcess = 0;
 #ifdef Q_OS_WIN
-    mThunderbirdUpdaterProcess = ProcessHandle::create(Utils::getThunderbirdUpdaterName());
+    mThunderbirdUpdaterProcess = ProcessHandle::create("updater.exe");
     connect( mThunderbirdUpdaterProcess, &ProcessHandle::finished,
             this, &TrayIcon::tbUpdaterProcessFinished );
 #endif /* Q_OS_WIN */

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -166,16 +166,6 @@ QString Utils::getBirdtrayVersion() {
     return QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_PATCH);
 }
 
-QString Utils::getThunderbirdUpdaterName() {
-#ifdef Q_OS_WIN
-    return "updater.exe";
-#elif defined(Q_OS_MAC)
-    return "updater.app";
-#else
-    return "updater";
-#endif
-}
-
 QString Utils::stdWToQString(const std::wstring &str) {
 #ifdef _MSC_VER
     return QString::fromUtf16((const ushort*) str.c_str());

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,11 +23,6 @@ class Utils
          * @return The version of Birdtray as a string.
          */
         static QString getBirdtrayVersion();
-        
-        /**
-         * @return The name of the Thunderbird updater executable.
-         */
-        static QString getThunderbirdUpdaterName();
 
         /**
          * Convert a std::wstring to a QString.


### PR DESCRIPTION
Sorry, this pull request contains a couple of small changes that are not really related to each other. But they all felt to small to create a separate pull request for each of them.

This pull request changes the following:
* Fix the path to the Birdtray config on Windows in the README.
* Use only push events from master for the Github Actions badge. Previously, if a pull request was made from the master branch of a fork to this repository, the commits on the pull request would affect the badge.
* Use the Qt attributes from `Utils::fatal` and `Utils::debug` that you missed when you reimplemented the functions in `Log`.
* Remove `Utils::getThunderbirdUpdaterName`, because the function is never used on non-Windows platforms.