### PR TITLE
Display the changelog as markdown on Qt 5.14.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x64]
-        qt_version: [5.6, 5.9, 5.13.2]
+        qt_version: [5.6, 5.9, 5.14.1]
         include:
           - os: windows-latest
             arch: x86

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -31,7 +31,6 @@ UpdateDialog::~UpdateDialog() {
 void UpdateDialog::show(const QString &newVersion, const QString &changelog,
                         qulonglong estimatedSize) {
     ui->newVersionLabel->setText(newVersion);
-    ui->newVersionLabel->setText(newVersion);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     ui->changelogLabel->setMarkdown(Utils::formatGithubMarkdown(changelog));
 #else

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -31,7 +31,12 @@ UpdateDialog::~UpdateDialog() {
 void UpdateDialog::show(const QString &newVersion, const QString &changelog,
                         qulonglong estimatedSize) {
     ui->newVersionLabel->setText(newVersion);
-    ui->changelogLabel->setText(changelog);
+    ui->newVersionLabel->setText(newVersion);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    ui->changelogLabel->setMarkdown(Utils::formatGithubMarkdown(changelog));
+#else
+    ui->changelogLabel->setText(Utils::formatGithubMarkdown(changelog));
+#endif
     if (estimatedSize == (qulonglong) -1) {
         downloadButton->setText(tr("Download"));
     } else {

--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -26,78 +26,6 @@
    <property name="bottomMargin">
     <number>16</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Current version:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>A new version of Birdtray is available.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QLabel" name="newVersionLabel">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QScrollArea" name="bodyLabel">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>668</width>
-        <height>163</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="changelogLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="currentVersionLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_5">
      <property name="sizePolicy">
@@ -111,10 +39,30 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="6" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Current version:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>A new version of Birdtray is available.</string>
      </property>
     </widget>
    </item>
@@ -125,10 +73,37 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="1">
     <widget class="QLabel" name="estimatedSizeLabel">
      <property name="text">
       <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="newVersionLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="currentVersionLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTextBrowser" name="changelogLabel">
+     <property name="openExternalLinks">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -268,3 +268,15 @@ QString Utils::getMailAccountName(const QFileInfo &morkFile) {
     return name;
 }
 
+QString Utils::formatGithubMarkdown(const QString& markdown) {
+    QString input = markdown;
+    static QRegularExpression githubMentionRegex(R"(((?<![^\s\n]))@(\S+))");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    return input.replace(githubMentionRegex, R"(\1[@\2](https://github.com/\2))");
+#else
+    static QRegularExpression markdownLinksRegex(R"(\[(.+?)\]\((\S+?)\))");
+    return input.replace(githubMentionRegex, R"(@\1\2 (https://github.com/\2))")
+                .replace(markdownLinksRegex, R"(\1 (\2))");
+#endif
+}
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,18 @@ class Utils
          * @return The mail account name.
          */
         static QString getMailAccountName(const QFileInfo &morkFile);
+        
+        /**
+         * Format a Github markdown string:
+         *
+         * - Add links to the Github account pages for "@name" mentions.
+         * - for old Qt versions without markdown support, change links
+         *   from `[text](url)` to `text (url)`.
+         *
+         * @param markdown The markdown string.
+         * @return A reference to the new markdown string with t the links.
+         */
+        static QString formatGithubMarkdown(const QString& markdown);
 };
 
 #endif // UTILS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 set(TESTS
         src/test_morkparser.cpp
+        src/test_utils.cpp
         )
 
 add_executable(tests src/TestResources.cpp src/TestResources.h ${TESTS})

--- a/tests/src/test_utils.cpp
+++ b/tests/src/test_utils.cpp
@@ -59,7 +59,6 @@ TEST(UtilsTest, formatGithubMarkdown_links) {
                               "markdown links with a textual representation.";
 #endif
         EXPECT_STREQ(qPrintable(Utils::formatGithubMarkdown(caseData[0])), expected) << message;
-        
     }
 }
 

--- a/tests/src/test_utils.cpp
+++ b/tests/src/test_utils.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include <utils.h>
+
+
+using namespace testing;
+
+TEST(UtilsTest, formatGithubMarkdown_mentions) {
+    const char* cases[][4] = {
+            {"@test",
+             "[@test](https://github.com/test)", "@test (https://github.com/test)",
+             "Expected formatGithubMarkdown to add a link to the Github account in the mention."},
+            {"Some stuff\n@test and more",
+             "Some stuff\n[@test](https://github.com/test) and more",
+             "Some stuff\n@test (https://github.com/test) and more",
+             "Expected formatGithubMarkdown to add a link to the Github account in the mention."},
+            {"Some stuff @test and more",
+             "Some stuff [@test](https://github.com/test) and more",
+             "Some stuff @test (https://github.com/test) and more",
+             "Expected formatGithubMarkdown to add a link to the Github account in the mention."},
+            {"stuff@test", "stuff@test", "stuff@test",
+             "Expected formatGithubMarkdown not to mistake an email address for a mention."},
+            {"", "", "", "Expected formatGithubMarkdown to handle empty strings."},
+            {"@test-me",
+             "[@test-me](https://github.com/test-me)", "@test-me (https://github.com/test-me)",
+             "Expected formatGithubMarkdown to add a link to the Github account "
+             "if the name contains non-alphabetical letters."},
+            {"@test1me",
+             "[@test1me](https://github.com/test1me)", "@test1me (https://github.com/test1me)",
+             "Expected formatGithubMarkdown to add a link to the Github account "
+             "if the name contains non-alphabetical letters."},
+    };
+    for (auto &caseData : cases) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        const char* expected = caseData[1];
+#else
+        const char* expected = caseData[2];
+#endif
+        EXPECT_STREQ(qPrintable(Utils::formatGithubMarkdown(caseData[0])), expected) << caseData[3];
+    }
+    EXPECT_TRUE(Utils::formatGithubMarkdown(QString()).isNull())
+                    << "Expected formatGithubMarkdown to handle null strings.";
+}
+
+TEST(UtilsTest, formatGithubMarkdown_links) {
+    const char* cases[][2] = {
+            {"[text](url)", "text (url)"},
+            {"stuff [some text](url?param=1)", "stuff some text (url?param=1)"},
+            {"stuff\n[text](url)", "stuff\ntext (url)"},
+            {"sun[day](url)more", "sunday (url)more"}, // Not the best, but doesn't need to be
+            {"[text] (url)", "[text] (url)"},
+    };
+    for (auto &caseData : cases) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        const char* expected = caseData[0];
+        const char* message = "Expected formatGithubMarkdown not to change markdown links.";
+#else
+        const char* expected = caseData[1];
+        const char* message = "Expected formatGithubMarkdown to replace "
+                              "markdown links with a textual representation.";
+#endif
+        EXPECT_STREQ(qPrintable(Utils::formatGithubMarkdown(caseData[0])), expected) << message;
+        
+    }
+}
+


### PR DESCRIPTION
Qt version from 5.14.0 onwards support displaying markdown text.
Use this feature when compiling with an adequate Qt version and display the changelog as markdown.
![Changelog with markdown with Qt 5.14.1](https://user-images.githubusercontent.com/6966049/77853570-04312300-71e5-11ea-9a60-790e68a93b37.png)
On older Qt versions, we convert the markdown to a pure text form as best as possible:
![Changelog without markdown on older Qt versions](https://user-images.githubusercontent.com/6966049/77856194-c8528980-71f5-11ea-93fe-fdb2d006e987.png)
To take advantage of the markdown feature, we bump the newest Qt on Github Actions to 5.14.1.
