### PR TITLE
Add a "Translators" dialog

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -47,6 +47,7 @@ DialogSettings::DialogSettings( QWidget *parent)
             this, &DialogSettings::onCheckUpdateFinished );
 
     connect( btnShowLogWindow, &QPushButton::clicked, this, &DialogSettings::onShowLogWindow );
+    connect( translatorsButton, &QPushButton::clicked, &DialogSettings::onTranslatorsDialog );
 
     // Setup parameters
     btnNotificationColor->setColor( settings->mNotificationDefaultColor );
@@ -315,6 +316,29 @@ void DialogSettings::buttonChangeUnreadIcon()
 void DialogSettings::onBorderWidthChanged(int value) {
     borderWidthLabel->setText(value == 0 ? tr("None") : QString::number(value) + '%');
 }
+
+void DialogSettings::onTranslatorsDialog() {
+    QFile translatorsListFile(":/res/translators.md");
+    translatorsListFile.open(QFile::ReadOnly);
+    QString translatorsList = QTextStream(&translatorsListFile).readAll();
+    translatorsListFile.close();
+    translatorsList.replace("# Active maintainers", "# " + tr("Active maintainers"))
+                   .replace("# Contributors", "# " + tr("Contributors"));
+    QDialog translatorsDialog;
+    translatorsDialog.setWindowTitle(tr("Translators"));
+    QHBoxLayout layout(&translatorsDialog);
+    QTextBrowser content(&translatorsDialog);
+    content.setOpenExternalLinks(true);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    content.setMarkdown(Utils::formatGithubMarkdown(translatorsList));
+#else
+    content.setText(Utils::addGithubMentionLinksToMarkdown(translatorsList));
+#endif
+    layout.addWidget(&content);
+    translatorsDialog.setLayout(&layout);
+    translatorsDialog.exec();
+}
+
 
 void DialogSettings::changeIcon(QToolButton *button)
 {

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -332,7 +332,7 @@ void DialogSettings::onTranslatorsDialog() {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     content.setMarkdown(Utils::formatGithubMarkdown(translatorsList));
 #else
-    content.setText(Utils::addGithubMentionLinksToMarkdown(translatorsList));
+    content.setText(Utils::formatGithubMarkdown(translatorsList));
 #endif
     layout.addWidget(&content);
     translatorsDialog.setLayout(&layout);

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -325,6 +325,7 @@ void DialogSettings::onTranslatorsDialog() {
     translatorsList.replace("# Active maintainers", "# " + tr("Active maintainers"))
                    .replace("# Contributors", "# " + tr("Contributors"));
     QDialog translatorsDialog;
+    translatorsDialog.resize(400, 300);
     translatorsDialog.setWindowTitle(tr("Translators"));
     QHBoxLayout layout(&translatorsDialog);
     QTextBrowser content(&translatorsDialog);

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -71,6 +71,11 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
          * @param value The new border width.
          */
         void onBorderWidthChanged(int value);
+        
+        /**
+         * Show the translators dialog.
+         */
+        static void onTranslatorsDialog();
 
     private:
         void    changeIcon(QToolButton * button );

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="tabBarAutoHide">
       <bool>false</bool>
@@ -952,6 +952,37 @@ p, li { white-space: pre-wrap; }
           <bool>true</bool>
          </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_14">
+         <item>
+          <widget class="QLabel" name="translationLabel">
+           <property name="text">
+            <string>Translations are powered by the community:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="translatorsButton">
+           <property name="text">
+            <string>Translators</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/src/res/translators.md
+++ b/src/res/translators.md
@@ -1,0 +1,7 @@
+# Active maintainers
+* @Vistaus
+* @albanobattistella
+* @Abestanis
+
+# Contributors
+* @to-ba

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -2,5 +2,6 @@
     <qresource prefix="/">
         <file>res/thunderbird.png</file>
         <file>res/birdtray.ico</file>
+        <file>res/translators.md</file>
     </qresource>
 </RCC>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -447,6 +447,22 @@ p, li { white-space: pre-wrap; }
         <source> seconds</source>
         <translation> Sekunden</translation>
     </message>
+    <message>
+        <source>Translations are powered by the community:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Active maintainers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -449,19 +449,19 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Translations are powered by the community:</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Übersetzungen werden von Freiwilligen bereitgestellt:</translation>
     </message>
     <message>
         <source>Translators</source>
-        <translation type="unfinished"></translation>
+        <translation>Übersetzer</translation>
     </message>
     <message>
         <source>Active maintainers</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktive Übersetzer</translation>
     </message>
     <message>
         <source>Contributors</source>
-        <translation type="unfinished"></translation>
+        <translation>Mitwirkende</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -396,6 +396,38 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>No new updates found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show log window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force index file re-read every</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translations are powered by the community:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Active maintainers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -447,6 +447,22 @@ p, li { white-space: pre-wrap; }
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Translations are powered by the community:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Active maintainers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -447,6 +447,22 @@ p, li { white-space: pre-wrap; }
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Translations are powered by the community:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Active maintainers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MailAccountDialog</name>


### PR DESCRIPTION
This adds a new dialog that can be accessed via the `About` tab in the settings. The dialog lists everybody that added or contributed to a translation of Birdtray. We keep those contributors at the top who agreed to get notified before every release to keep their translation updated. This also gives us a list of who to contact prior to a new release. We also don't need to ask new contributors if they want to get notified before a release, they can decide for themself when they add their names to the list. And if someone no longer wants to actively maintain a translation, they can move their name to the second list.

<details>
<summary>Images</summary>

![New "Translators" button in the "About" tab](https://user-images.githubusercontent.com/6966049/77858199-29805a00-7202-11ea-8c47-fbc8d0e4ab75.png)
![The "translators" dialog on newer Qt versions](https://user-images.githubusercontent.com/6966049/77862067-699f0700-7219-11ea-9d16-3014ef168598.png)
</details>

<details>
<summary>Older versions of Qt don't support displaying markdown</summary>

![The "translators" dialog on older Qt versions](https://user-images.githubusercontent.com/6966049/77862058-57bd6400-7219-11ea-843e-e038c967406d.png)
</details>


@Vistaus, @albanobattistella, @to-ba If you want you can add your real names and/or email addresses here.