### PR TITLE
Fix the update checker not detecting Birdtray releases when the tag starts with a "v"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         id: check-deploy
         shell: bash
         run: |
-          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
             echo ::set-output name=is_deploy::true
             echo "Deployment build detected"
           else
@@ -112,7 +112,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && contains(github.ref, '.')
+    if: github.event_name == 'push' && contains(github.ref, '.')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -120,7 +120,7 @@ jobs:
       - name: Check if this is a deployment build
         shell: bash
         run: |
-          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Creating release ${{ github.ref }}..."
           else
             echo "Tag does not match: ${{ github.event.ref }}"

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -19,7 +19,7 @@
 
 #define LATEST_VERSION_INFO_URL "https://api.github.com/repos/gyunaev/birdtray/releases/latest"
 #define GENERIC_DOWNLOAD_URL "https://github.com/gyunaev/birdtray/releases/latest"
-#define VERSION_TAG_REGEX "^(RELEASE_)?(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
+#define VERSION_TAG_REGEX R"(^(RELEASE_|v)?(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$)"
 
 AutoUpdater::AutoUpdater(QObject* parent) :
         QObject(parent),


### PR DESCRIPTION
The old tags all didn't start with a `v`, which is why the `v` was not included in the regex.
It is good practise to start the release tags with a `v` and it also helps to prevent false runs of the `Create Release` workflow, so I would like to add the `v` to release tags from now on.

For the `1.8.0` release we can't do that, because the update checker in existing installations wouldn't recognize the tag and the users won't get a notification dialog. We should use the tag `1.8.0` for this release.
After the release, we can revert commit 10eff85 and start using tags starting with a `v`.