### PR TITLE
Rename "uri" to "path" in the settings

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -114,7 +114,7 @@ void Settings::save()
     {
         QJsonObject ac;
         ac[ "color" ] = mFolderNotificationColors[path].name();
-        ac[ "uri" ] = path;
+        ac[ "path" ] = path;
 
         accounts.push_back( ac );
     }
@@ -247,7 +247,7 @@ void Settings::fromJSON( const QJsonObject& settings )
     {
         for ( const QJsonValueRef& a : settings["accounts"].toArray() )
         {
-            QString path = a.toObject().value("uri").toString();
+            QString path = a.toObject().value("path").toString();
             QString color = a.toObject().value("color").toString();
 
             if ( path.isEmpty() )


### PR DESCRIPTION
The field should be called `path`, because it only contains paths to mork files now that #181 was merged.
The json settings are new and a chance for us to fix this discrepancy. #284 was merged only a week ago, apart from the two of us I don't think anybody would be impacted by this.