### PR TITLE
Add migration from sqlite folders to mork paths

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -379,7 +379,7 @@ void Settings::fromQSettings( QSettings * psettings )
     delete psettings;
     if (!profilePath.isNull() && std::any_of(mFolderNotificationColors.keyBegin(),
             mFolderNotificationColors.keyEnd(),
-            [](const QString &path) {return !path.endsWith(".msf");})) {
+            [](const QString &path) { return !path.endsWith(".msf"); })) {
         bool foundMigrationProblem = false;
         QDir profileDir(profilePath);
         for (const QString &path : mFolderNotificationColors.keys()) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -7,6 +7,8 @@
 #include <QtCore/QStandardPaths>
 #include <QCoreApplication>
 #include <QMessageBox>
+#include <QtCore/QUrl>
+#include <QtCore/QDirIterator>
 
 #include "settings.h"
 #include "utils.h"
@@ -373,8 +375,85 @@ void Settings::fromQSettings( QSettings * psettings )
     if (!settings.value(READ_INSTALL_CONFIG_KEY, false).toBool()) {
         loadInstallerConfiguration();
     }
-
+    QString profilePath = psettings->value("common/profilepath").toString();
     delete psettings;
+    if (!profilePath.isNull() && std::any_of(mFolderNotificationColors.keyBegin(),
+            mFolderNotificationColors.keyEnd(),
+            [](const QString &path) {return !path.endsWith(".msf");})) {
+        bool foundMigrationProblem = false;
+        QDir profileDir(profilePath);
+        for (const QString &path : mFolderNotificationColors.keys()) {
+            if (path.endsWith(".msf")) {
+                continue;
+            }
+            QUrl uri(path);
+            QString scheme;
+            QString account;
+            QString folder;
+            if (uri.isValid()) {
+                scheme = uri.scheme();
+                account = uri.host();
+                folder = uri.path();
+            } else {
+                QString decodedPath = QUrl::fromPercentEncoding(path.toUtf8());
+                scheme = decodedPath.section('/', 0, 0);
+                scheme.chop(1);
+                account = decodedPath.section('/', 2, 2);
+                int index;
+                if ((index = account.indexOf('@')) != -1) {
+                    account = account.mid(index + 1);
+                }
+                folder = decodedPath.section('/', 3);
+                if (!folder.isEmpty()) {
+                    folder = '/' + folder;
+                }
+            }
+            const QString mailFolder = scheme == "mailbox" ? "Mail" :
+                                       scheme[0].toUpper() + scheme.mid(1) + "Mail";
+            account = Utils::decodeIMAPutf7(account);
+            QDir accountDir(profileDir.absoluteFilePath(mailFolder) + '/' + account);
+            
+            QStringList mockFiles;
+            if (!folder.isNull() && !folder.isEmpty()) {
+                mockFiles << accountDir.absoluteFilePath(
+                        Utils::decodeIMAPutf7(folder).mid(1).split('/').join(".sbd/") + ".msf");
+            } else {
+                QDirIterator it(accountDir.absolutePath(), {"*.msf"},
+                        QDir::Files, QDirIterator::Subdirectories);
+                if (!it.hasNext()) {
+                    foundMigrationProblem = true;
+                }
+                while (it.hasNext()) {
+                    mockFiles << it.next();
+                }
+            }
+            for (const QString &mockFile: mockFiles) {
+                if (!QFile::exists(mockFile)) {
+                    foundMigrationProblem = true;
+                } else if (!mFolderNotificationColors.contains(mockFile)) {
+                    mFolderNotificationColors[mockFile] = mFolderNotificationColors[path];
+                    mFolderNotificationList.append(mockFile);
+                }
+            }
+            mFolderNotificationColors.remove(path);
+            mFolderNotificationList.removeAll(path);
+        }
+        if (foundMigrationProblem) {
+            QMessageBox::warning(nullptr,
+                    QCoreApplication::tr("Sqlite based accounts migrated"), QCoreApplication::tr(
+                            "You had configured monitoring of one or more mail folders using "
+                            "the Sqlite parser. This method has been removed. Your configurations "
+                            "has been migrated to the Mork parser, but some configured mail "
+                            "folders could not be found."));
+        } else {
+            QMessageBox::information(nullptr,
+                    QCoreApplication::tr("Sqlite based accounts migrated"), QCoreApplication::tr(
+                            "You had configured monitoring of one or more mail accounts using "
+                            "the Sqlite parser. This method has been removed. Your configurations "
+                            "has been migrated to the Mork parser. Please verify that all accounts "
+                            "were mapped correctly."));
+        }
+    }
 }
 
 bool Settings::getStartThunderbirdCmdline( QString& executable, QStringList &arguments )

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -579,6 +579,18 @@ Bitte stellen Sie sicher, dass Sie den richtigen Ordner mit den Profilen ausgew�
         <source>Cannot load default system tray icon.</source>
         <translation>Das Standard-Systemleistensymbol konnte nicht geladen werden.</translation>
     </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert, allerdings konnten eine paar der konfigurierten Email-Ordner nicht gefunden werden.</translation>
+    </message>
+    <message>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Sqlite basierende Konten migriert</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert. Bitte überprüfen Sie, dass alle Ordner richtig übernommen wurden.</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -559,6 +559,18 @@ Please make sure you selected the correct profiles directory.</source>
         <source>Unexpected end of group.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sqlite based accounts migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -579,6 +579,18 @@ Assicurati di aver selezionato la directory corretta dei profili.</translation>
         <source>Unexpected end of group.</source>
         <translation>Termine inaspettato del gruppo.</translation>
     </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sqlite based accounts migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -578,6 +578,18 @@ Please make sure you selected the correct profiles directory.</source>
         <source>Unexpected end of group.</source>
         <translation>Onverwacht groepseinde.</translation>
     </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sqlite based accounts migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>


### PR DESCRIPTION
This attempts to automatically migrate watched accounts settings from the `Sqlite` parser, which was removed in #181, to the mork parser. The user will be notified that their configuration was migrated and if there were any problems.

If you want to merge this, @gyunaev, we should do this today, because this adds new translation strings, which will break [our promise to not add any new translation starting from April 2 to the release](https://github.com/gyunaev/birdtray/issues/297#issuecomment-606891006).