### PR TITLE
Add Qt5Svg dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ To build Birdtray from source, you would need the following components:
 - Cmake
 - Qt 5.6 or higher with "x11extras-dev" or "x11extras-devel"  module installed (it is usually NOT installed by default);
 
-On Debian you need to install the following packages: ``qt5-default libqt5x11extras5-dev qttools5-dev``
+On Debian you need to install the following packages: ``qt5-default libqt5x11extras5-dev qttools5-dev libqt5svg5-dev``
 
-On OpenSuSE you need to install ``libqt5-qtbase-devel libqt5-qtx11extras-devel ``
+On OpenSuSE you need to install ``libqt5-qtbase-devel libqt5-qtx11extras-devel libqt5-qtsvg-devel``
 
-On Fedora (30 or later) you need to install ``qt5-qtbase-devel qt5-qtx11extras-devel``
+On Fedora (30 or later) you need to install ``qt5-qtbase-devel qt5-qtx11extras-devel qt5-qtsvg-devel``
 
 To build, please do the following:
 

--- a/contrib/rpm/birdtray.spec
+++ b/contrib/rpm/birdtray.spec
@@ -8,7 +8,7 @@ Source0:      https://github.com/gyunaev/%{name}/archive/RELEASE_%{version}.tar.
 URL:          https://github.com/gyunaev/birdtray
 BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: cmake3 gcc-c++ desktop-file-utils
-BuildRequires: sqlite-devel qt5-qtbase-devel qt5-qtx11extras-devel
+BuildRequires: sqlite-devel qt5-qtbase-devel qt5-qtx11extras-devel qt5-qtsvg-devel
 
 #%if 0%{?fedora} || 0%{?rhel} >= 8
 #Recommends:      thunderbird


### PR DESCRIPTION
Previous PR added dependency to Qt5Svg. In many distros it requires a separate package.