### PR TITLE
Validate the desktop file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         run: cmake --build . --config Release --target run_tests
       - name: Validate desktop file
         working-directory: ${{ github.workspace }}
-        if: runner.os == Linux
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           output=$(desktop-file-validate src/res/com.ulduzsoft.Birdtray.desktop)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -qq;
-            sudo apt install -qq libx11-dev qt5-qtsvg-devel desktop-file-utils
+            sudo apt install -qq libx11-dev libqt5svg5-dev libx11-xcb-dev desktop-file-utils
           elif [ "$RUNNER_OS" == "Windows" ]; then
             if [ "$ARCH" == "x86" ]; then
               echo "::set-env name=CMAKE_PLATFORM_ARG::-A Win32"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -qq;
-            sudo apt install -qq libx11-dev
+            sudo apt install -qq libx11-dev qt5-qtsvg-devel desktop-file-utils
           elif [ "$RUNNER_OS" == "Windows" ]; then
             if [ "$ARCH" == "x86" ]; then
               echo "::set-env name=CMAKE_PLATFORM_ARG::-A Win32"
@@ -76,6 +76,10 @@ jobs:
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target run_tests
+      - name: Verify desktop file
+        working-directory: ${{ github.workspace }}
+        if: ${{ runner.os }} == Linux
+        run: desktop-file-validate src/res/com.ulduzsoft.Birdtray.desktop
       - name: Check if this is a deployment build
         id: check-deploy
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,10 +76,16 @@ jobs:
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target run_tests
-      - name: Verify desktop file
+      - name: Validate desktop file
         working-directory: ${{ github.workspace }}
-        if: ${{ runner.os }} == Linux
-        run: desktop-file-validate src/res/com.ulduzsoft.Birdtray.desktop
+        if: runner.os == Linux
+        shell: bash
+        run: |
+          output=$(desktop-file-validate src/res/com.ulduzsoft.Birdtray.desktop)
+          if [ ! -z "$output" ]; then
+            echo "$output";
+            exit 1;
+          fi
       - name: Check if this is a deployment build
         id: check-deploy
         shell: bash

--- a/src/res/com.ulduzsoft.Birdtray.desktop
+++ b/src/res/com.ulduzsoft.Birdtray.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Birdtray
 Keywords=Email;E-mail;Newsgroup;Feed;RSS
 Keywords[ast]=Corréu;Corréu-e;Noticies;Discusiones;Mensaxes;Canales;RSS
@@ -28,5 +27,5 @@ Terminal=false
 X-MultipleArgs=false
 Type=Application
 Icon=com.ulduzsoft.Birdtray
-Categories=Application;Network;Email;
+Categories=Network;Email;
 StartupNotify=true


### PR DESCRIPTION
This adds a step to the Github Actions CI that validates the `com.ulduzsoft.Birdtray.desktop` file using the [`desktop-file-validate`](http://manpages.ubuntu.com/manpages/bionic/man1/desktop-file-validate.1.html) tool. Closes #314.