### PR TITLE
Fix compiling Birdtray with CMake versions pre 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ endif(WIN32)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 add_definitions(-DQT_DEPRECATED_WARNINGS)
+if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    # AUTO_UIC places generated header files in CMAKE_CURRENT_BINARY_DIR before 3.8.0.
+    set(CMAKE_INCLUDE_CURRENT_DIR ON)
+endif()
 
 set(SOURCES
         src/colorbutton.cpp


### PR DESCRIPTION
Commit b3ae40d removed a command that told CMake to include the `CMAKE_CURRENT_BINARY_DIR`.
As it turns out, this is required for CMake versions prior to 3.8, because they store the header files generated from the `*.ui` in the `CMAKE_CURRENT_BINARY_DIR`. This is the relevant entry from the [CMake 3.8 changelog](https://cmake.org/cmake/help/v3.8/release/3.8.html#other-changes):

> When using AUTOMOC or AUTOUIC, generated moc_*, *.moc and ui_* are placed in the <CMAKE_CURRENT_BINARY_DIR>/<TARGETNAME>_autogen/include directory which is automatically added to the target’s INCLUDE_DIRECTORIES. It is therefore not necessary anymore to have CMAKE_CURRENT_BINARY_DIR in the target’s INCLUDE_DIRECTORIES.

Closes #319.