### PR TITLE
Enable CMake policy CMP0092

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0)
 
+if(POLICY CMP0092)
+    cmake_policy(SET CMP0092 NEW)
+endif()
+
 project(Birdtray CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
This fixes warnings emitted by CMake when compiling Birdtray with a MSVC compiler and the `COMPILER_WARNINGS_AS_ERRORS` turned on.
The details of the policy can be found in the [CMake policy documentation](https://cmake.org/cmake/help/git-stage/policy/CMP0092.html).