### PR TITLE
Fix always deleting user settings when uninstalling

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -68,7 +68,8 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define UNINSTALL_REG_PATH \
         "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}$currentUserString"
 !define USER_REG_PATH "Software\ulduzsoft"
-!define USER_SETTINGS_REG_PATH "${USER_REG_PATH}\${PRODUCT_NAME}"
+!define USER_SETTINGS_PATH_ROOT "$LOCALAPPDATA"
+!define USER_SETTINGS_PATH "${USER_SETTINGS_PATH_ROOT}\ulduzsoft\birdtray\birdtray-config.json"
 !define DEFAULT_INSTALL_PATH "$PROGRAMFILES\${PRODUCT_NAME}"
 !define UNINSTALL_FILENAME "uninstall.exe"
 !define UNINSTALL_BUILDER_FILE "uninstall_builder.exe"
@@ -255,12 +256,31 @@ Section "${PRODUCT_NAME}" SectionBirdTray
     ${if} $0 != ""
         DetailPrint "$(UninstallPreviousVersion)"
         !insertmacro STOP_PROCESS ${EXE_NAME} "$(StopBirdtray)" "$(StopBirdtrayError)"
+
+        # Save the config file.  TODO: Remove this after 1.8.1
+        Rename "${USER_SETTINGS_PATH}" "$TEMP\birdtray-config.json"
+
         ClearErrors
         ${if} $0 == "AllUsers"
             Call RunUninstaller
         ${else}
             !insertmacro UAC_AsUser_Call Function RunUninstaller ${UAC_SYNCREGISTERS}
         ${endif}
+
+        # Put the config file back.  TODO: Remove this block after 1.8.1
+        StrCpy $4 "0"
+        ${if} ${errors}
+            StrCpy $4 "1"
+        ${endif}
+        ${if} ${FileExists} "$TEMP\birdtray-config.json"
+            CreateDirectory "${USER_SETTINGS_PATH_ROOT}\ulduzsoft\birdtray"
+            Rename "$TEMP\birdtray-config.json" "${USER_SETTINGS_PATH}"
+        ${endif}
+        ClearErrors
+        ${if} $4 == "1"
+            SetErrors
+        ${endif}
+
         ${if} ${errors} # Stay in installer
             MessageBox MB_OKCANCEL|MB_ICONSTOP "$(UninstallPreviousVersionError)" \
                 /SD IDCANCEL IDOK Ignore
@@ -358,9 +378,9 @@ SectionEnd
 SectionGroupEnd
 
 Section "$(AutoCheckUpdateSectionName)" SectionAutoCheckUpdate
+    # TODO: Write directly to the settings JSON
     ${StrCase} $0 "${COMPANY_NAME}" "L"
     ${StrCase} $1 "${PRODUCT_NAME}" "L"
-    DeleteRegValue HKCU "${USER_SETTINGS_REG_PATH}" "hasReadInstallConfig"
     CreateDirectory "$LOCALAPPDATA\$0"
     CreateDirectory "$LOCALAPPDATA\$0\$1"
     FileOpen $2 "$LOCALAPPDATA\$0\$1\${INSTALL_CONFIG_FILE}" a
@@ -440,8 +460,6 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
     ${UnStrCase} $0 "${COMPANY_NAME}" "L"
     ${UnStrCase} $1 "${PRODUCT_NAME}" "L"
     !insertmacro DeleteRetryAbort "$LOCALAPPDATA\$0\$1\${INSTALL_CONFIG_FILE}"
-    RMDir /r "$LOCALAPPDATA\$0\$1"
-    RMDir /r "$LOCALAPPDATA\$0"
 
     # Clean up "AutoRun"
     DeleteRegValue SHCTX "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"
@@ -460,8 +478,15 @@ Section "un.${PRODUCT_NAME}" UNSectionBirdTray
 SectionEnd
 
 Section /o "un.$(UserSettingsSectionName)" UNSectionUserSettings
-    DeleteRegKey HKCU "${USER_SETTINGS_REG_PATH}"
-    DeleteRegKey /ifempty HKCU "${USER_REG_PATH}"
+    Delete "${USER_SETTINGS_PATH}"
+    ${GetParent} "${USER_SETTINGS_PATH}" $R0
+    ${do}
+        RMDir $R0
+        ${if} ${errors}
+            ${break}
+        ${endif}
+        ${GetParent} $R0 $R0
+    ${LoopUntil} $R0 == "${USER_SETTINGS_PATH_ROOT}"
 SectionEnd
 
 Section -un.Post UNSectionSystem


### PR DESCRIPTION
Ok, this is a pretty bad bug. When uninstalling (and uninstalling during an upgrade), the user is presented with a choice to delete the user settings. This is unchecked by default, but because of the recent migration to JSON settings in `1.8.0`, doesn't work anymore, because the it still deletes the settings in the registry.
But that is not the bad part. The installer stores the user choices in a file at `%LOCALAPPDATA%\ulduzsoft\birdtray`. During uninstall, the folder `%LOCALAPPDATA%\ulduzsoft` and everything in it is deleted **unconditionally**. Unfortunately, since #284, the user settings are also stored in this directory and thus will also get deleted.

To fix this, when upgrading we copy the user settings to a temporary directory before we execute the uninstaller that was bundled with Birdtray `1.8.0`. After the uninstaller is complete, we copy the settings back. This way, the settings are never deleted.

We will have to remove that workaround after `1.8.1`, because it breaks the `delete user settings` option during uninstall. We should add a big warning to the changelog to let people know that they must update to `1.8.1` if they had installed `1.8.0`.