### PR TITLE
Bump version to 1.8.1

### DIFF
--- a/contrib/rpm/birdtray.spec
+++ b/contrib/rpm/birdtray.spec
@@ -1,5 +1,5 @@
 Name:         birdtray
-Version:      1.8.0
+Version:      1.8.1
 Release:      1%{?dist}
 Epoch:        0
 License:      GPLv3

--- a/src/res/com.ulduzsoft.Birdtray.appdata.xml
+++ b/src/res/com.ulduzsoft.Birdtray.appdata.xml
@@ -41,6 +41,7 @@
   <launchable type="desktop-id">com.ulduzsoft.Birdtray.desktop</launchable>
 
   <releases>
+      <release date="2020-04-23" version="1.8.1" urgency="medium"/>
       <release date="2020-04-18" version="1.8.0" urgency="medium"/>
       <release date="2019-12-03" version="1.7.0" urgency="medium"/>
       <release date="2019-05-21" version="1.6" urgency="medium"/>

--- a/src/version.h
+++ b/src/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 8
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 
 #endif // VERSION_H


### PR DESCRIPTION
Bump the Birdtray version to 1.8.1.
Because we didn't add any new strings, we don't need to notify the active translation maintainers.

@gyunaev Please merge this pull request last.
Don't forget to push the `1.8.1` tag to the master branch after merging this.