### PR TITLE
Resolve building RPM within Fedora COPR

### DIFF
--- a/contrib/rpm/birdtray.spec
+++ b/contrib/rpm/birdtray.spec
@@ -4,11 +4,11 @@ Release:      1%{?dist}
 Epoch:        0
 License:      GPLv3
 Group:        System Environment/Shells
-Source0:      https://github.com/gyunaev/%{name}/archive/RELEASE_%{version}.tar.gz
+Source0:      https://github.com/gyunaev/%{name}/archive/%{version}.tar.gz
 URL:          https://github.com/gyunaev/birdtray
 BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: cmake3 gcc-c++ desktop-file-utils
-BuildRequires: sqlite-devel qt5-qtbase-devel qt5-qtx11extras-devel qt5-qtsvg-devel
+BuildRequires: sqlite-devel qt5-qtbase-devel qt5-qtx11extras-devel qt5-qtsvg-devel qt5-linguist
 
 #%if 0%{?fedora} || 0%{?rhel} >= 8
 #Recommends:      thunderbird
@@ -20,7 +20,7 @@ Summary: Birdtray is a free system tray notification for new mail for Thunderbir
 Birdtray is a system tray new mail notification for Thunderbird, which does not require extensions.
 
 %prep
-%setup -q -n %{name}-RELEASE_%{version}
+%setup -q -n %{name}-%{version}
 
 %build
 mkdir %{_target_platform}


### PR DESCRIPTION
Some minor fixes to resolve building directly from the github release archive in order to build https://copr.fedorainfracloud.org/coprs/rnc/Birdtray/