### PR TITLE
Fix two bugs in the general settings tab UI

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -123,14 +123,13 @@ DialogSettings::DialogSettings( QWidget *parent)
 
     // Icon
     btnNotificationIcon->setIcon( settings->getNotificationIcon() );
-
-    if ( !settings->mNotificationIconUnread.isNull() )
-    {
-        boxNotificationIconUnread->setChecked( true );
-        btnNotificationIconUnread->setIcon( settings->mNotificationIconUnread );
+    if (!settings->mNotificationIconUnread.isNull()) {
+        boxNotificationIconUnread->setChecked(true);
+        btnNotificationIconUnread->setIcon(settings->mNotificationIconUnread);
+    } else {
+        boxNotificationIconUnread->setChecked(false);
+        btnNotificationIconUnread->setDisabled(true);
     }
-    else
-        boxNotificationIconUnread->setChecked( false );
 }
 
 void DialogSettings::accept()

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -57,7 +57,8 @@ DialogSettings::DialogSettings( QWidget *parent)
     borderWidthSlider->setValue(static_cast<int>(settings->mNotificationBorderWidth) * 2);
     notificationFont->setCurrentFont( settings->mNotificationFont );
     notificationFontWeight->setValue( settings->mNotificationFontWeight * 2 );
-    sliderBlinkingSpeed->setValue( settings->mBlinkSpeed );
+    sliderBlinkingSpeed->setValue( settings->mBlinkSpeed == 0 ?
+            0 : sliderBlinkingSpeed->maximum() + 1 - static_cast<int>(settings->mBlinkSpeed) );
     boxLaunchThunderbirdAtStart->setChecked( settings->mLaunchThunderbird );
     boxShowHideThunderbird->setChecked( settings->mShowHideThunderbird );
     boxHideWhenMinimized->setChecked( settings->mHideWhenMinimized );
@@ -141,7 +142,8 @@ void DialogSettings::accept()
     // A width of 100 is way to much, nobody will want to go beyond 50.
     settings->mNotificationBorderWidth = qRound(borderWidthSlider->value() / 2.0);
     settings->mNotificationFont = notificationFont->currentFont();
-    settings->mBlinkSpeed = sliderBlinkingSpeed->value();
+    settings->mBlinkSpeed = sliderBlinkingSpeed->value() == 0 ?
+            0 : sliderBlinkingSpeed->maximum() + 1 - sliderBlinkingSpeed->value();
     settings->mLaunchThunderbird = boxLaunchThunderbirdAtStart->isChecked();
     settings->mShowHideThunderbird = boxShowHideThunderbird->isChecked();
     settings->mThunderbirdCmdLine = Utils::splitCommandLine( leThunderbirdCmdLine->text() );


### PR DESCRIPTION
This fixes two bugs in the general tab in the settings:

* The unread notification icon choose button was selectable even tough the checkbox was not set: 
![Checkbox is not checked, button is selectable](https://user-images.githubusercontent.com/6966049/81022384-c2dc0500-8e6d-11ea-805a-34a8dc47eaae.png)
* The `Blinking speed` slider was inverted:
![Blink speed slider](https://user-images.githubusercontent.com/6966049/81022996-624dc780-8e6f-11ea-8d59-3735cf424eef.PNG)

 