### PR TITLE
Fix parsing for GitHub mentions in markdown

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -276,12 +276,13 @@ QString Utils::getMailAccountName(const QFileInfo &morkFile) {
 
 QString Utils::formatGithubMarkdown(const QString& markdown) {
     QString input = markdown;
-    static QRegularExpression githubMentionRegex(R"(((?<![^\s\n]))@(\S+))");
+    static QRegularExpression githubMentionRegex(
+            R"((?<!\w)@([a-z\d\-]+))", QRegularExpression::CaseInsensitiveOption);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    return input.replace(githubMentionRegex, R"(\1[@\2](https://github.com/\2))");
+    return input.replace(githubMentionRegex, R"([@\1](https://github.com/\1))");
 #else
     static QRegularExpression markdownLinksRegex(R"(\[(.+?)\]\((\S+?)\))");
-    return input.replace(githubMentionRegex, R"(@\1\2 (https://github.com/\2))")
+    return input.replace(githubMentionRegex, R"(@\1 (https://github.com/\1))")
                 .replace(markdownLinksRegex, R"(\1 (\2))");
 #endif
 }

--- a/tests/src/test_utils.cpp
+++ b/tests/src/test_utils.cpp
@@ -28,6 +28,10 @@ TEST(UtilsTest, formatGithubMarkdown_mentions) {
              "[@test1me](https://github.com/test1me)", "@test1me (https://github.com/test1me)",
              "Expected formatGithubMarkdown to add a link to the Github account "
              "if the name contains non-alphabetical letters."},
+            {"(@test1me)",
+             "([@test1me](https://github.com/test1me))", "(@test1me (https://github.com/test1me))",
+             "Expected formatGithubMarkdown to add a link to the Github account "
+             "if the name contains non-alphabetical letters."},
     };
     for (auto &caseData : cases) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
@@ -48,6 +52,7 @@ TEST(UtilsTest, formatGithubMarkdown_links) {
             {"stuff\n[text](url)", "stuff\ntext (url)"},
             {"sun[day](url)more", "sunday (url)more"}, // Not the best, but doesn't need to be
             {"[text] (url)", "[text] (url)"},
+            {"([text](url))", "(text (url))"},
     };
     for (auto &caseData : cases) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)


### PR DESCRIPTION
The regex was too strict, `(@name)` was not recognized as a GitHub mention. This [can be seen in the latest changelog](https://github.com/gyunaev/birdtray/pull/295#issuecomment-621337376).
We relax the regex and add some additional tests.