### PR TITLE
Sys tray icon is automatically added by QSystemTrayIcon (Fixes #357)

### DIFF
--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -62,7 +62,6 @@ BirdtrayApp::BirdtrayApp(int &argc, char** argv) : QApplication(argc, argv)
 
     Log::debug( "Birdtray version %d.%d.%d started", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH );
 
-    ensureSystemTrayAvailable();
     // Load settings
     settings = new Settings();
     if (commandLineParser.isSet("reset-settings")) {
@@ -253,20 +252,5 @@ void BirdtrayApp::onSecondInstanceCommand(QLocalSocket* clientSocket) {
         trayIcon->hideThunderbird();
     } else if (line == SETTINGS_COMMAND) {
         trayIcon->showSettings();
-    }
-}
-
-void BirdtrayApp::ensureSystemTrayAvailable() {
-    int passed = 0;
-    while (!QSystemTrayIcon::isSystemTrayAvailable()) {
-        if (passed == 0) {
-            qDebug("Waiting for system tray to become available");
-        }
-        passed++;
-        if (passed > 120) {
-            Log::fatal( QApplication::tr("Sorry, system tray cannot be controlled "
-                                          "through this add-on on your operating system.") );
-        }
-        QThread::msleep(500);
     }
 }

--- a/src/birdtrayapp.h
+++ b/src/birdtrayapp.h
@@ -154,10 +154,6 @@ private:
      */
     void onSecondInstanceCommand(QLocalSocket* clientSocket);
     
-    /**
-     * Wait for the system tray to become available and exit if it doesn't within 60 seconds.
-     */
-    static void ensureSystemTrayAvailable();
 };
 
 


### PR DESCRIPTION
Birdtray fails to start while waiting for the SystemTray to become available.

Per the QT documentation for QT4 & 5: https://doc.qt.io/qt-5/qsystemtrayicon.html#isSystemTrayAvailable	 

The system tray icon will be automatically added if the system tray is visible (even if it was
not available at launch).

Fixes issue #357