### PR TITLE
Add linguistic problem matchers

### DIFF
--- a/.github/problem-matchers/linguist.json
+++ b/.github/problem-matchers/linguist.json
@@ -1,0 +1,31 @@
+{
+  "__comment": "Matches warnings and errors from the linguist tools",
+  "problemMatcher": [
+    {
+      "owner": "linguist",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^Parse error at\\s+(.*):(\\d+):(\\d+):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    },
+    {
+      "owner": "linguist",
+      "pattern": [
+        {
+          "regexp": "^(?:lrelease|lupdate)\\s+(warning|error):(?:.*)at\\s+(.*):(\\d+):(\\d+):\\s+(.*)$",
+          "severity": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/linguist.json
+++ b/.github/problem-matchers/linguist.json
@@ -2,7 +2,7 @@
   "__comment": "Matches warnings and errors from the linguist tools",
   "problemMatcher": [
     {
-      "owner": "linguist",
+      "owner": "linguist-old",
       "severity": "error",
       "pattern": [
         {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,9 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
         run: cmake --build . --config Release --target birdtray
       - name: Remove build problem matchers
-        run: echo "::remove-matcher owner=linguist::"
+        run: |
+          echo "::remove-matcher owner=linguist::"
+          echo "::remove-matcher owner=linguist-old::"
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target run_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,9 +70,13 @@ jobs:
         shell: bash
         working-directory: ${{ runner.workspace }}/build
         run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_TESTS=ON -DDONT_EXECUTE_INSTALLER=ON
+      - name: Register build problem matchers
+        run: echo "::add-matcher::.github/problem-matchers/linguist.json"
       - name: Build
         working-directory: ${{ runner.workspace }}/build
         run: cmake --build . --config Release --target birdtray
+      - name: Remove build problem matchers
+        run: echo "::remove-matcher owner=linguist::"
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target run_tests


### PR DESCRIPTION
This allows GitHub Actions to produce comments like the following on pull request:

![Error comment by GitHub actions on pull request](https://user-images.githubusercontent.com/6966049/94598867-e9bd2c80-028f-11eb-8531-75a83cff68bd.png)

It might make it easier for translators to spot errors in their files and correct them without requiring a review from us.