### PR TITLE
Fix a hang on startup if a mail account was deleted

### DIFF
--- a/src/mailaccountdialog.cpp
+++ b/src/mailaccountdialog.cpp
@@ -154,6 +154,9 @@ void MailAccountDialog::loadAccounts(QTreeWidgetItem* profileTreeItem,
                 (void) msfFileIterator.next();
                 QFileInfo msfFile = msfFileIterator.fileInfo();
                 QString name = Utils::getMailFolderName(msfFile);
+                if (name.isNull()) {
+                    continue;
+                }
                 auto* folderItem = new QTreeWidgetItem(accountItem, {name});
                 if (QString::compare(
                         msfFile.completeBaseName(), "INBOX", Qt::CaseInsensitive) == 0) {

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -34,6 +34,12 @@ QVariant ModelAccountTree::data(const QModelIndex &index, int role) const {
             QFileInfo accountMorkFile(mAccounts[index.row()]);
             QString folderName = Utils::getMailFolderName(accountMorkFile);
             QString accountName = Utils::getMailAccountName(accountMorkFile);
+            if (accountName.isNull()) {
+                accountName = accountMorkFile.fileName();
+            }
+            if (folderName.isNull()) {
+                return accountName;
+            }
             return accountName + " [" + folderName + "]";
         }
         case Qt::ToolTipRole: {

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -314,7 +314,6 @@ void TrayIcon::updateIcon()
             } else {
                 name = accountName + " [" + mailFolderName + "]";
             }
-            
             const QString &warning = warningsIterator.value();
             toolTip << name + ": " + warning;
         }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -306,8 +306,15 @@ void TrayIcon::updateIcon()
                 continue;
             }
             QFileInfo accountMorkFile(path);
-            QString name = Utils::getMailAccountName(accountMorkFile)
-                           + " [" + Utils::getMailFolderName(accountMorkFile) + "]";
+            QString accountName = Utils::getMailAccountName(accountMorkFile);
+            QString mailFolderName = Utils::getMailFolderName(accountMorkFile);
+            QString name;
+            if (accountName.isNull() || mailFolderName.isNull()) {
+                name = path;
+            } else {
+                name = accountName + " [" + mailFolderName + "]";
+            }
+            
             const QString &warning = warningsIterator.value();
             toolTip << name + ": " + warning;
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -260,7 +260,9 @@ QString Utils::getMailFolderName(const QFileInfo &morkFile) {
         }
         name = QCoreApplication::translate(
                 "EmailFolders", dirName.toUtf8().constData()) + '/' + name;
-        parentDir.cdUp();
+        if (!parentDir.cdUp()) {
+            return QString();
+        }
     }
     return name;
 }
@@ -269,7 +271,9 @@ QString Utils::getMailAccountName(const QFileInfo &morkFile) {
     QDir parentDir = morkFile.dir();
     QString name;
     while ((name = parentDir.dirName()).endsWith(".sbd")) {
-        parentDir.cdUp();
+        if (!parentDir.cdUp()) {
+            return QString();
+        }
     }
     return name;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,7 +59,7 @@ class Utils
          * Get the mail folder name from the mork path.
          *
          * @param morkPath The file info for a msf file.
-         * @return The mail folder name.
+         * @return The mail folder name or a null string.
          */
         static QString getMailFolderName(const QFileInfo &morkFile);
         
@@ -67,7 +67,7 @@ class Utils
          * Get the mil account name from a mork path
          *
          * @param morkPath The file info for a msf file.
-         * @return The mail account name.
+         * @return The mail account name or a null string.
          */
         static QString getMailAccountName(const QFileInfo &morkFile);
         


### PR DESCRIPTION
If a mail account got deleted but we were watching it, the file watcher failed, which generated a warning. That warning is added as a tool-tip to the system tray in `TrayIcon::updateIcon`, which tries to prepend the account name in front of the warning. The `parentDir.cdUp()` in `Utils::getMailAccountName` fails, because the directory does not exist, but the result was getting ignored, leading to an endless loop.

Fixes #397