### PR TITLE
Enforce vX.X.X as the version pattern for the git tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         id: check-deploy
         shell: bash
         run: |
-          if [[ '${{ github.event.ref }}' =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
             echo ::set-output name=is_deploy::true
             echo "Deployment build detected"
           else
@@ -137,7 +137,7 @@ jobs:
       - name: Check if this is a deployment build
         shell: bash
         run: |
-          if [[ '${{ github.event.ref }}' =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Creating release ${{ github.ref }}..."
           else
             echo "Tag does not match: ${{ github.event.ref }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') && contains(github.ref, '.')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && contains(github.ref, '.')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/contrib/rpm/birdtray.spec
+++ b/contrib/rpm/birdtray.spec
@@ -4,7 +4,7 @@ Release:      1%{?dist}
 Epoch:        0
 License:      GPLv3
 Group:        System Environment/Shells
-Source0:      https://github.com/gyunaev/%{name}/archive/%{version}.tar.gz
+Source0:      https://github.com/gyunaev/%{name}/archive/v%{version}.tar.gz
 URL:          https://github.com/gyunaev/birdtray
 BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: cmake3 gcc-c++ desktop-file-utils

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -19,7 +19,7 @@
 
 #define LATEST_VERSION_INFO_URL "https://api.github.com/repos/gyunaev/birdtray/releases/latest"
 #define GENERIC_DOWNLOAD_URL "https://github.com/gyunaev/birdtray/releases/latest"
-#define VERSION_TAG_REGEX R"(^(RELEASE_|v)?(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$)"
+#define VERSION_TAG_REGEX R"(^v(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$)"
 
 AutoUpdater::AutoUpdater(QObject* parent) :
         QObject(parent),


### PR DESCRIPTION
As discussed in #298 I would like for us to use `vX.X.X` as the format for release git tags. This is the recommended and most commonly used format and it helps to prevent false positives in the GitHub Actions workflow that checks if it should create release files.

@rnc Could you please verify that my changes to the `spec` file are correct?
@gyunaev Please merge this before creating the new release. When you create the new release, please use `v1.9.0` as the git tag.