### PR TITLE
Improve the translations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+src/translations/main_*.ts text eol=lf
+src/translations/dynamic_*.ts text eol=lf
+src/translations/installer_*.ts text eol=crlf

--- a/.github/problem-matchers/translations.json
+++ b/.github/problem-matchers/translations.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "checkTranslation",
+      "pattern": [
+        {
+          "regexp": "^\\[(.*)\\]\\s+(.*):(\\d+):(\\d+):\\s+(.*)$",
+          "severity": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/scripts/checkTranslation.py
+++ b/.github/scripts/checkTranslation.py
@@ -578,9 +578,9 @@ class TranslationHandler(ContentHandler):
     @staticmethod
     def _escapeText(text):
         """
-        Escape the text so it can be printed without messing uo the error or warning format.
-        :param text: THe text to escape.
-        :return: THe escaped text.
+        Escape the text so it can be printed without messing up the error or warning format.
+        :param text: The text to escape.
+        :return: The escaped text.
         """
         return text.replace('\n', '\\n').replace('\t', '\\t')
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Lint the translations
         run: |
           set +e
-          .github/scripts/checkTranslation.py src/translations/dynamic_*[!e][!n].ts src/translations/main_*[!e][!n].ts
+          .github/scripts/checkTranslation.py src/translations/dynamic_*[!e][!n].ts src/translations/main_*[!e][!n].ts -i unfinished_translation
           ret=$?
           .github/scripts/checkTranslation.py src/translations/installer_*[!e][!n].ts -p '(?P<match>\d+)' '(?P<match>\$\{.*?\})' '(?P<match>\$\\[rn])' '(?P<match>\$\d+)'
           exit $(( $ret + $? ))

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Lint the translations
         run: |
           set +e
+          echo "::add-matcher::.github/problem-matchers/translations.json"
           .github/scripts/checkTranslation.py src/translations/dynamic_*.ts src/translations/main_*.ts -e src/translations/*_en.ts -i unfinished_translation
           ret=$?
           .github/scripts/checkTranslation.py src/translations/installer_*.ts -e src/translations/*_en.ts -p '(?P<match>\d+)' '(?P<match>\$\{.*?\})' '(?P<match>\$\\[rn])' '(?P<match>\$\d+)'

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -3,10 +3,10 @@ name: Check the translations
 on:
   push:
     paths:
-      - 'src/translations/**.ts'
+      - 'src/translations/*'
   pull_request:
     paths:
-      - 'src/translations/**.ts'
+      - 'src/translations/*'
 
 jobs:
   check:
@@ -17,7 +17,75 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Installer translations special checks
+      - name: Check translation filenames
+        shell: python
+        run: |
+          import os
+          import sys
+          haveError = False
+          for fileName in os.listdir(os.path.join('src', 'translations')):
+              filePath = os.path.join('src', 'translations', fileName)
+              if not fileName.endswith('.ts'):
+                  haveError = True
+                  print(f'::error file={filePath},line=1,col=1::Invalid translation filename: ' +
+                        f'Must end with the "ts" extension.')
+              if not any(fileName.startswith(prefix)
+                         for prefix in ['main_', 'dynamic_', 'installer_']):
+                  haveError = True
+                  print(f'::error file={filePath},line=1,col=1::Invalid translation filename: ' +
+                        f'Must start with "main_", "dynamic_" or "installer_".')
+          sys.exit(1 if haveError else 0)
+      - name: All translations are registered in CMakeLists.txt
+        shell: python
+        run: |
+          import os
+          import re
+          import sys
+          from glob import iglob
+          with open('CMakeLists.txt') as cMakeListsFile:
+              cMakeListsContent = cMakeListsFile.read()
+
+          def checkTranslations(cMakeVariable, translationFileNames):
+              match = re.search(
+                  rf'set\(\s*{cMakeVariable}(?P<start>\s*)(?P<translation>(?:.+?\s+)+?)\s*\)',
+                  cMakeListsContent)
+              if match is None:
+                  print(f'::error file=CMakeLists.txt,line=1,col=1::' +
+                        f'Unable to find {cMakeVariable} variable')
+                  sys.exit(1)
+              mainTranslationFiles = [path.replace('/', os.path.sep)
+                                      for path in match.group('translation').split()]
+              line = cMakeListsContent[:match.start()].count('\n') \
+                  + 1 + match.group('start').count('\n')
+              TRANSLATION_LINE = re.compile(r'^(?P<start>\s*).*?(?P<end>\s*)$')
+              start = None
+              for i, translationLine in enumerate(match.group('translation').split('\n')):
+                  match = TRANSLATION_LINE.match(translationLine)
+                  if match:
+                      lineStart = match.group('start')
+                      lineEnd = match.group('end')
+                      if start is None:
+                          if i != 0 or lineStart != '':
+                              start = lineStart
+                      elif start != lineStart:
+                          print(f'::warning file=CMakeLists.txt,line={line + i},col=1::' +
+                                f'Invalid start indentation, expected {start!r}, got {lineStart!r}')
+                      if len(lineEnd):
+                          print(f'::warning file=CMakeLists.txt,line={line + i},col=1::' +
+                                f'Trailing whitespaces')
+              errorFound = False
+              for translation in iglob(os.path.join('src', 'translations', translationFileNames)):
+                  if translation not in mainTranslationFiles:
+                      errorFound = True
+                      print(f'::error file=CMakeLists.txt,line={line},col=1::' +
+                            f'Translation file {translation} is not registered ' +
+                            f'in the {cMakeVariable} list in CMakeList.txt')
+              return errorFound
+
+          haveError = checkTranslations('MAIN_TRANSLATION_FILES', 'main_*.ts')
+          haveError = checkTranslations('DYN_TRANSLATION_FILES', 'dynamic_*.ts') or haveError
+          sys.exit(1 if haveError else 0)
+      - name: Special checks for installer translations
         shell: python
         run: |
           import os

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -103,6 +103,17 @@ jobs:
           for installerTranslation in iglob(os.path.join('src', 'translations', 'installer_*.ts')):
               language = os.path.splitext(os.path.basename(installerTranslation))[0][10:]
               translations[language] = installerTranslation
+          baseTranslationFile = os.path.join('src', 'translations', 'installer_en.ts')
+          baseTranslation = ElementTree.parse(baseTranslationFile)
+          sourceKeys = [source.text for source in baseTranslation.findall('context/message/source')]
+          for language in translations:
+              languageNameId = 'Lang_' + language
+              languageNameElement = baseTranslation.find(
+                  f'context/message/translation[.=\'{languageNameId}\']')
+              if languageNameElement is None:
+                  haveError = True
+                  print(f'::error file={baseTranslationFile},line=1,col=1::' +
+                        f'Missing translation for language name "{languageNameId}"')
           for translationFilePath in translations.values():
               translation = ElementTree.parse(translationFilePath)
               languageNameElement = translation.find(
@@ -125,13 +136,11 @@ jobs:
                         f'Invalid __LANGUAGE_NAME__: "{languageName}" is not in the list of ' +
                         f'possible language names: ["{languageNamesString}"]')
                   haveError = True
-              for language in translations:
-                  languageNameSource = 'Lang_' + language
-                  languageNameElement = translation.find(
-                      f'context/message/source[.=\'{languageNameSource}\']')
-                  if languageNameElement is None:
+              for sourceKey in sourceKeys:
+                  if next((source for source in translation.iterfind(f'context/message/source')
+                           if source.text == sourceKey), None) is None:
                       print(f'::warning file={translationFilePath},line=1,col=1::' +
-                            f'Missing language name "{languageNameSource}"')
+                            f'Missing translation for source "{sourceKey}"')
           sys.exit(1 if haveError else 0)
       - name: Lint the translations
         run: |

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Lint the translations
         run: |
           set +e
-          .github/scripts/checkTranslation.py src/translations/dynamic_*[!e][!n].ts src/translations/main_*[!e][!n].ts -i unfinished_translation
+          .github/scripts/checkTranslation.py src/translations/dynamic_*.ts src/translations/main_*.ts -e src/translations/*_en.ts -i unfinished_translation
           ret=$?
-          .github/scripts/checkTranslation.py src/translations/installer_*[!e][!n].ts -p '(?P<match>\d+)' '(?P<match>\$\{.*?\})' '(?P<match>\$\\[rn])' '(?P<match>\$\d+)'
+          .github/scripts/checkTranslation.py src/translations/installer_*.ts -e src/translations/*_en.ts -p '(?P<match>\d+)' '(?P<match>\$\{.*?\})' '(?P<match>\$\\[rn])' '(?P<match>\$\d+)'
           exit $(( $ret + $? ))

--- a/src/birdtrayapp.cpp
+++ b/src/birdtrayapp.cpp
@@ -158,7 +158,7 @@ bool BirdtrayApp::loadTranslation(QTranslator &translator, QLocale &locale,
 
 void BirdtrayApp::parseCmdArguments() {
     commandLineParser.setApplicationDescription(
-            tr("A free system tray notification for new mail for Thunderbird"));
+            tr("A free system tray notification for new mail for Thunderbird."));
     commandLineParser.addHelpOption();
     commandLineParser.addVersionOption();
     commandLineParser.addOptions({
@@ -170,7 +170,7 @@ void BirdtrayApp::parseCmdArguments() {
             {{"s", SHOW_THUNDERBIRD_COMMAND}, tr("Show the Thunderbird window.")},
             {{"H", HIDE_THUNDERBIRD_COMMAND}, tr("Hide the Thunderbird window.")},
             {{"r", "reset-settings"}, tr("Reset the settings to the defaults.")},
-            {{"l", "log"}, tr("Write log to a file."), tr("FILE")}
+            {{"l", "log"}, tr("Write log to a file."), tr("file")}
     });
     commandLineParser.process(*this);
 }
@@ -264,8 +264,8 @@ void BirdtrayApp::ensureSystemTrayAvailable() {
         }
         passed++;
         if (passed > 120) {
-            Log::fatal( QApplication::tr("Sorry, system tray cannot be controlled "
-                                          "through this add-on on your operating system.") );
+            Log::fatal(tr("Sorry, the system tray cannot be controlled "
+                          "by this add-on on your operating system."));
         }
         QThread::msleep(500);
     }

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -166,7 +166,7 @@
           <item row="0" column="4" colspan="2">
            <widget class="QSpinBox" name="notificationFontWeight">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="suffix">
              <string notr="true"> %</string>
@@ -388,10 +388,10 @@
          <item>
           <widget class="QLineEdit" name="leProcessRunOnCountChange">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don't need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don't need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="whatsThis">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don't need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don't need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -848,7 +848,7 @@
             <item>
              <widget class="QCheckBox" name="checkUpdateOnStartup">
               <property name="toolTip">
-               <string>Check for new updates when Birdtray starts</string>
+               <string>Check for new updates when Birdtray starts.</string>
               </property>
               <property name="text">
                <string>Check for new updates on startup</string>
@@ -858,7 +858,7 @@
             <item>
              <widget class="QPushButton" name="checkUpdateButton">
               <property name="toolTip">
-               <string>Check for a new Birdtray version</string>
+               <string>Check for a new Birdtray version.</string>
               </property>
               <property name="text">
                <string>Check now</string>

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -37,7 +37,8 @@ void Log::initialize(const QString& path )
     if ( !opened )
     {
         l.unlock();
-        Log::fatal( QObject::tr("Failed to open log file %s: %s").arg(path).arg(self->mOutputFile.errorString()) );
+        Log::fatal(QCoreApplication::translate("Log", "Failed to open log file %s: %s")
+                .arg(path).arg(self->mOutputFile.errorString()));
     }
 }
 
@@ -52,7 +53,10 @@ void Log::fatal( const QString& str )
     QFile file( QStandardPaths::writableLocation( QStandardPaths::TempLocation ) + QDir::separator() + "birdtray-log.txt" );
 
     // Show the dialog
-    QMessageBox::critical(nullptr, QApplication::tr("Fatal"), QObject::tr("Fatal error: %1\n\nLog file is written into file %2") .arg(str) .arg(file.fileName()));
+    QMessageBox::critical(nullptr, QCoreApplication::translate("Log", "Fatal"),
+            QCoreApplication::translate(
+                    "Log", "Fatal error: %1\n\nLog file is written into file %2")
+                    .arg(str).arg(file.fileName()));
 
     self->mMutex.lock();
 

--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -90,9 +90,9 @@ QVariant ModelAccountTree::headerData(int section, Qt::Orientation , int role) c
     if ( role == Qt::DisplayRole )
     {
         if (section == 0) {
-            return QObject::tr("Account");
+            return QCoreApplication::translate("ModelAccountTree", "Account");
         } else {
-            return QObject::tr("Notification color");
+            return QCoreApplication::translate("ModelAccountTree", "Notification color");
         }
     }
 

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -83,7 +83,8 @@ bool MorkParser::open( const QString &path )
     // Open file
     if ( !MorkFile.exists() || !MorkFile.open( QIODevice::ReadOnly ) )
     {
-        mErrorMessage = QCoreApplication::tr("Couldn't open file: ") + MorkFile.errorString();
+        mErrorMessage = QCoreApplication::translate(
+                "MorkParser", "Couldn't open file: ") + MorkFile.errorString();
         return false;
     }
 
@@ -92,7 +93,7 @@ bool MorkParser::open( const QString &path )
 
     if ( !MagicHeader.contains( MorkMagicHeader ) )
     {
-        mErrorMessage = QCoreApplication::tr("Unsupported version.");
+        mErrorMessage = QCoreApplication::translate("MorkParser", "Unsupported version.");
         return false;
     }
 
@@ -172,8 +173,8 @@ void MorkParser::parse()
                 break;
 
             default:
-                throw MorkParserException(QCoreApplication::tr("Invalid format."));
-                break;
+                throw MorkParserException(QCoreApplication::translate(
+                        "MorkParser", "Invalid format."));
             }
         }
 
@@ -226,7 +227,7 @@ void MorkParser::skip( const char * string )
     while ( *string )
     {
         if (*string != nextChar()) {
-            throw MorkParserException(QCoreApplication::tr("Parsing error."));
+            throw MorkParserException(QCoreApplication::translate("MorkParser", "Parsing error."));
         }
         string++;
     }
@@ -242,7 +243,7 @@ QChar MorkParser::readNext()
 QChar MorkParser::peekNext()
 {
     if (morkPos_ >= morkData_.length()) {
-        throw MorkParserException(QCoreApplication::tr("Unexpected EOF."));
+        throw MorkParserException(QCoreApplication::translate("MorkParser", "Unexpected EOF."));
     }
     return QChar( morkData_[ morkPos_ ] );
 }
@@ -306,7 +307,7 @@ inline void MorkParser::parseComment()
     char cur = nextChar();
 
     if ( '/' != cur ) {
-        throw MorkParserException(QCoreApplication::tr("Invalid comment."));
+        throw MorkParserException(QCoreApplication::translate("MorkParser", "Invalid comment."));
     }
 
     while ( cur != '\r' && cur != '\n' && cur )
@@ -617,8 +618,8 @@ void MorkParser::parseRow( int TableId, int TableScope )
                 parseMeta( ']' );
                 break;
             default:
-                throw MorkParserException(QCoreApplication::tr("Format error."));
-                break;
+                throw MorkParserException(QCoreApplication::translate(
+                        "MorkParser", "Format error."));
             }
         }
 
@@ -662,7 +663,8 @@ void MorkParser::parseGroup()
     ofst = morkData_.indexOf( endCommit, morkPos_ );
 
     if (ofst == -1) {
-        throw MorkParserException(QCoreApplication::tr("Unexpected end of group."));
+        throw MorkParserException(QCoreApplication::translate(
+                "MorkParser", "Unexpected end of group."));
     }
     // Transaction succeeded. Copy the transaction data
     QByteArray transaction = morkData_.mid( morkPos_, ofst - morkPos_ );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -148,9 +148,9 @@ void Settings::save()
 
     if ( !file.open(QIODevice::WriteOnly | QIODevice::Truncate) )
     {
-        QMessageBox::critical( 0,
-                               QObject::tr("Could not save the settings"),
-                               QObject::tr("Could not save the settings into file %1:\n%2").arg( file.fileName() ) .arg( file.errorString() ) );
+        QMessageBox::critical(nullptr, tr("Could not save the settings"),
+                tr("Could not save the settings into file %1:\n%2")
+                        .arg(file.fileName()).arg(file.errorString()));
         return;
     }
 
@@ -449,14 +449,14 @@ void Settings::fromQSettings( QSettings * psettings )
         }
         if (foundMigrationProblem) {
             QMessageBox::warning(nullptr,
-                    QCoreApplication::tr("Sqlite based accounts migrated"), QCoreApplication::tr(
+                    tr("Sqlite based accounts migrated"), tr(
                             "You had configured monitoring of one or more mail folders using "
                             "the Sqlite parser. This method has been removed. Your configurations "
                             "has been migrated to the Mork parser, but some configured mail "
                             "folders could not be found."));
         } else {
             QMessageBox::information(nullptr,
-                    QCoreApplication::tr("Sqlite based accounts migrated"), QCoreApplication::tr(
+                    tr("Sqlite based accounts migrated"), tr(
                             "You had configured monitoring of one or more mail accounts using "
                             "the Sqlite parser. This method has been removed. Your configurations "
                             "has been migrated to the Mork parser. Please verify that all accounts "
@@ -483,7 +483,7 @@ bool Settings::getStartThunderbirdCmdline( QString& executable, QStringList &arg
 const QPixmap &Settings::getNotificationIcon() {
     if (mNotificationIcon.isNull()) {
         if (!mNotificationIcon.load(":res/thunderbird.png")) {
-            Log::fatal( QCoreApplication::tr("Cannot load default system tray icon.") );
+            Log::fatal( tr("Cannot load default system tray icon.") );
         }
     }
     return mNotificationIcon;

--- a/src/settings.h
+++ b/src/settings.h
@@ -139,7 +139,7 @@ class Settings
         // If non-zero, specifies an interval in seconds for rereading index files even if they didn't change. 0 disables.
         unsigned int    mIndexFilesRereadIntervalSec;
 
-        // When the number of unread emails changes, birdtray can start this process
+        // When the number of unread emails changes, Birdtray can start this process
         QString                   mProcessRunOnCountChange;
 
         // Load and save them
@@ -166,6 +166,8 @@ class Settings
         void setNotificationIcon(const QPixmap& icon);
 
     private:
+        Q_DECLARE_TR_FUNCTIONS(Settings)
+    
         // Loading from either storage
         void    fromJSON( const QJsonObject& settings );
 

--- a/src/translations/installer_de.ts
+++ b/src/translations/installer_de.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Vorherige ${PRODUCT_NAME}-Version wird deinstalliert</translation>
+        <translation>Vorherige ${PRODUCT_NAME}-Version wird deinstalliert...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Prozess ${EXE_NAME} wird angehalten</translation>
+        <translation>Prozess ${EXE_NAME} wird angehalten...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>

--- a/src/translations/installer_es.ts
+++ b/src/translations/installer_es.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Desinstalando la versión previa de ${PRODUCT_NAME}</translation>
+        <translation>Desinstalando la versión previa de ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Cerrando proceso ${EXE_NAME}</translation>
+        <translation>Cerrando proceso ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -135,8 +135,8 @@ Por favor, cierre todas las instancias y pulse Reintentar para continuar, o Canc
     <message>
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
-        <translation>El direccitorio de instalación no debe contener
-${BAD_PATH_CHARS}.</translation>
+        <translation>El direccitorio de instalación no debe contener:
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_it.ts
+++ b/src/translations/installer_it.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Disinstallazione della versione precedente di ${PRODUCT_NAME}</translation>
+        <translation>Disinstallazione della versione precedente di ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Processo di chiusura ${EXE_NAME}</translation>
+        <translation>Processo di chiusura ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -135,8 +135,8 @@ Chiudi tutte le istanze e fai clic su Riprova per continuare o Annulla per uscir
     <message>
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
-        <translation>Il percorso di installazione non deve contenere
-${BAD_PATH_CHARS}.</translation>
+        <translation>Il percorso di installazione non deve contenere:
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_nl.ts
+++ b/src/translations/installer_nl.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Bezig met deïnstalleren van de vorige versie van ${PRODUCT_NAME}</translation>
+        <translation>Bezig met deïnstalleren van de vorige versie van ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Bezig met afsluiten van ${EXE_NAME}</translation>
+        <translation>Bezig met afsluiten van ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -136,7 +136,7 @@ Sluit alle processen af en klik op &apos;Opnieuw proberen&apos; om door te gaan 
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
         <translation>Het installatiepad mag geen speciale tekens bevatten:
-${BAD_PATH_CHARS}.</translation>
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_pl.ts
+++ b/src/translations/installer_pl.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Odinstalowywanie poprzedniej wersji ${PRODUCT_NAME}</translation>
+        <translation>Odinstalowywanie poprzedniej wersji ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Zamykanie ${EXE_NAME}</translation>
+        <translation>Zamykanie ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -136,7 +136,7 @@ Zamknij wszystkie instancje programu, aby kontynuować, lub Anuluj, aby wyjść.
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
         <translation>Ścieżka docelowa nie może zawierać:
-${BAD_PATH_CHARS}.</translation>
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_pt.ts
+++ b/src/translations/installer_pt.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Desinstalando versão anterior do ${PRODUCT_NAME}</translation>
+        <translation>Desinstalando versão anterior do ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Encerrando processo ${EXE_NAME}</translation>
+        <translation>Encerrando processo ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -136,7 +136,7 @@ Por favor, feche todas as instâncias e clique em Repetir para continuar, ou Can
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
         <translation>O caminho de instalação não pode conter os seguintes caracteres:
-${BAD_PATH_CHARS}.</translation>
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_ru.ts
+++ b/src/translations/installer_ru.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Удаление предыдущей версии ${PRODUCT_NAME}</translation>
+        <translation>Удаление предыдущей версии ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Завершить процесс ${EXE_NAME}</translation>
+        <translation>Завершить процесс ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -135,7 +135,7 @@ Please, close all instances of it and click Retry to continue, or Cancel to exit
     <message>
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
-        <translation>Путь установки не должен содержать
+        <translation>Путь установки не должен содержать:
 ${BAD_PATH_CHARS}</translation>
     </message>
     <message>

--- a/src/translations/installer_sv.ts
+++ b/src/translations/installer_sv.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>Avinstallerar föregående version av ${PRODUCT_NAME}.</translation>
+        <translation>Avinstallerar föregående version av ${PRODUCT_NAME}...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>Stänger processen ${EXE_NAME}.</translation>
+        <translation>Stänger processen ${EXE_NAME}...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -135,8 +135,8 @@ Stäng alla instanser av det och klicka Försök igen för att fortsätta, eller
     <message>
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
-        <translation>Installationssökvägen får inte innehålla något av följande tecken
-${BAD_PATH_CHARS}.</translation>
+        <translation>Installationssökvägen får inte innehålla något av följande tecken:
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>

--- a/src/translations/installer_tr.ts
+++ b/src/translations/installer_tr.ts
@@ -90,7 +90,7 @@
     </message>
     <message>
         <source>Uninstalling previous version of ${PRODUCT_NAME}...</source>
-        <translation>${PRODUCT_NAME} ürününün önceki sürümü kaldırılıyor</translation>
+        <translation>${PRODUCT_NAME} ürününün önceki sürümü kaldırılıyor...</translation>
     </message>
     <message>
         <source>Uninstalling the old ${PRODUCT_NAME} installation failed! Continuing will delete EVERYTHING in $3.</source>
@@ -106,7 +106,7 @@
     </message>
     <message>
         <source>Closing process ${EXE_NAME}...</source>
-        <translation>${EXE_NAME} işlemi kapatılıyor</translation>
+        <translation>${EXE_NAME} işlemi kapatılıyor...</translation>
     </message>
     <message>
         <source>Failed to close ${PRODUCT_NAME}. Please retry or quit ${PRODUCT_NAME} manually to continue with the installation.</source>
@@ -135,8 +135,8 @@ Lütfen bunun tüm örneklerini kapatın ve devam etmek için Yeniden Dene&apos;
     <message>
         <source>The install path must not contain any of:
 ${BAD_PATH_CHARS}</source>
-        <translation>Yükleme yolu şu karakterleri içermemelidir
-${BAD_PATH_CHARS}.</translation>
+        <translation>Yükleme yolu şu karakterleri içermemelidir:
+${BAD_PATH_CHARS}</translation>
     </message>
     <message>
         <source>The install path contains a previously installed ${PRODUCT_NAME} version, which will be replaced.</source>
@@ -282,7 +282,7 @@ Bileşen için yükleyiciyi indirmek istiyor musunuz?</translation>
         <source>Turkish</source>
         <translation>Türkçe</translation>
     </message>
-	<message>
+    <message>
         <source>Polish</source>
         <translation>Lehçe</translation>
     </message>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -41,10 +41,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Ein freies Systemleistenbenachrichtigungsprogramm für neue Mails von Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Den Inhalt der Mork-Datenbank anzeigen.</translation>
     </message>
@@ -85,8 +81,16 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Schreibe Birdtrays Protokoll in eine Datei.</translation>
     </message>
     <message>
-        <source>FILE</source>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Ein freies Systemleistenbenachrichtigungsprogramm für neue Mails von Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
         <translation>datei</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Die Systemleiste kann leider auf Ihrem System nicht durch dieses Add-on gesteuert werden.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Farbe bei mehreren Benachrichtigungen:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das verändert die Schriftdicke, d. h. macht die Schrift fett.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Die Transparenz des Systemleistensymbols festlegen auf</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Beim Start von Birdtray nach Aktualisierungen suchen</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Beim Start auf Aktualisierungen prüfen</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Nach einer neuen Version von Birdtray suchen</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -437,10 +429,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Befehl bei Änderung ungelesener E-Mails:</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sofern angegeben, wird dieser Befehl jedes mal ausgeführt, wenn sich die Anzahl ungelesener E-Mails ändert (auch bei Änderung auf null). Der Befehl wird wie angegeben vom System ausgeführt, wobei %NEW% mit der neuen und %OLD% mit der voherigen Anzahl ungelesener E-Mails ersetzt wird (beide Werte können gleich sein).&lt;/p&gt;&lt;p&gt;Die meisten Nutzer werden diese Funktionalität nicht benötigen und sollten das Feld leer lassen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wähle E-Mail Ordner zur Überwachung aus.&lt;br/&gt;&lt;br/&gt;Wenn der Dialog Ihren E-Mail Ordner nicht anzeigt, klicken Sie &lt;i&gt;Strg + Shift&lt;/i&gt; um einen Dateiauswahlsdialog zu öffnen, mit dem jede mork-Datei hinzugefügt werden kann.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -483,6 +471,41 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation>Ignoriere alle momentan ungelesenen E-Mails, wenn Thunderbird über das Birdtray Symbol augeblendet wird</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das verändert die Schriftdicke, d. h. macht die Schrift fett.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sofern angegeben, wird dieser Befehl jedes mal ausgeführt, wenn sich die Anzahl ungelesener E-Mails ändert (auch bei Änderung auf null). Der Befehl wird wie angegeben vom System ausgeführt, wobei %NEW% mit der neuen und %OLD% mit der voherigen Anzahl ungelesener E-Mails ersetzt wird (beide Werte können gleich sein).&lt;/p&gt;&lt;p&gt;Die meisten Nutzer werden diese Funktionalität nicht benötigen und sollten das Feld leer lassen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Beim Start von Birdtray nach Aktualisierungen suchen.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Nach einer neuen Version von Birdtray suchen.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Die Protokolldatei %s konnte nicht geöffnet werden: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Schwerwiegender Fehler: %1
+
+Das Protokoll wurde in die Datei &quot;%2&quot; geschrieben</translation>
     </message>
 </context>
 <context>
@@ -545,6 +568,17 @@ Bitte stellen Sie sicher, dass Sie den richtigen Ordner mit den Profilen ausgew�
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Konto</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Benachrichtigungsfarbe</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -552,18 +586,7 @@ Bitte stellen Sie sicher, dass Sie den richtigen Ordner mit den Profilen ausgew�
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Fatal</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Die Systemleiste kann leider auf Ihrem System nicht durch dieses Add-on gesteuert werden.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Die Datei konnte nicht geöffnet werden: </translation>
@@ -596,41 +619,9 @@ Bitte stellen Sie sicher, dass Sie den richtigen Ordner mit den Profilen ausgew�
         <source>Unexpected end of group.</source>
         <translation>Unerwartetes Gruppenende.</translation>
     </message>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Das Standard-Systemleistensymbol konnte nicht geladen werden.</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert, allerdings konnten eine paar der konfigurierten Email-Ordner nicht gefunden werden.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Sqlite basierende Konten migriert</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert. Bitte überprüfen Sie, dass alle Ordner richtig übernommen wurden.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Konto</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Benachrichtigungsfarbe</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Schwerwiegender Fehler: %1
-
-Das Protokoll wurde in die Datei &quot;%2&quot; geschrieben</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Die Einstellungen konnten nicht gespeichert werden</translation>
@@ -642,8 +633,20 @@ Das Protokoll wurde in die Datei &quot;%2&quot; geschrieben</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Die Protokolldatei %s konnte nicht geöffnet werden: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Sqlite basierende Konten migriert</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert, allerdings konnten eine paar der konfigurierten Email-Ordner nicht gefunden werden.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Sie hatten die Überwachung von einem oder mehren Email-Ordnern mit der Sqlite Methode konfiguriert. Diese wurde entfernt. Ihre Konfiguration wurde zur Mork-Methode migriert. Bitte überprüfen Sie, dass alle Ordner richtig übernommen wurden.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Das Standard-Systemleistensymbol konnte nicht geladen werden.</translation>
     </message>
 </context>
 <context>
@@ -791,12 +794,12 @@ Das Protokoll wurde in die Datei &quot;%2&quot; geschrieben</translation>
         <translation>Diese Version ignorieren</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Aktualisieren und Neustarten</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca. %1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Aktualisieren und Neustarten</translation>
     </message>
 </context>
 <context>
@@ -816,10 +819,6 @@ Das Protokoll wurde in die Datei &quot;%2&quot; geschrieben</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Die Birdtray-Installationsdatei wird heruntergeladen…</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Aktualisieren und Neustarten</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -38,7 +38,7 @@ OpenSSL might not be installed.</source>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -82,7 +82,11 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FILE</source>
+        <source>file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -171,7 +175,7 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -307,7 +311,7 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
+        <source>Check for new updates when Birdtray starts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,7 +319,7 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check for a new Birdtray version</source>
+        <source>Check for a new Birdtray version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -432,10 +436,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -463,6 +463,27 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For those of you who appreciate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -524,6 +545,17 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -531,22 +563,7 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation type="unfinished"></translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation type="unfinished"></translation>
@@ -579,35 +596,9 @@ Please make sure you selected the correct profiles directory.</source>
         <source>Unexpected end of group.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation type="unfinished"></translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation type="unfinished"></translation>
@@ -618,7 +609,19 @@ Log file is written into file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
+        <source>Sqlite based accounts migrated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -763,11 +766,11 @@ Log file is written into file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Update and Restart</source>
+        <source>ca. %1 Mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>ca. %1 Mb</source>
+        <source>Update and restart</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -787,10 +790,6 @@ Log file is written into file %2</source>
     </message>
     <message>
         <source>Downloading Birdtray installer...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -41,10 +41,6 @@ OpenSSL podría no estar instalado.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Un sistema libre de notificación para la bandeja el sistema para nuevos correos de Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Mostrar el contenido de la base de datos de mork.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL podría no estar instalado.</translation>
         <translation>Escribir el registro en un fichero.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>FICHERO</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Un sistema libre de notificación para la bandeja el sistema para nuevos correos de Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>fichero</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Lo sentimos, la bandeja del sistema no puede ser controlado a través de este complemento en su sistema operativo.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL podría no estar instalado.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Color de notificación múltiple:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cambia el grosor de la fuente, por ejemplo, la hace negrita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL podría no estar instalado.</translation>
         <translation>Mostrar el icono de la bandeja del sistema</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Comprobar actualizaciones cuando bridtray se inicie</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Comprobar actualizaciones en el arranque</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Comprobar si existe una nueva versión de Birdtray</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -440,10 +432,6 @@ OpenSSL podría no estar instalado.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -482,6 +470,41 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Para aquellos que aprecian mi trabajo en Birdtray, que ha sido desarrollado en mi tiempo libre, puede hacerlo aquí: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;¡Gracias por su apoyo continuo!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cambia el grosor de la fuente, por ejemplo, la hace negrita.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Comprobar actualizaciones cuando bridtray se inicie.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Comprobar si existe una nueva versión de Birdtray.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Fallo al abrir el fichero de registro %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Error fatal: %1
+
+El fichero de registro fue escrito en el archivo %2</translation>
     </message>
 </context>
 <context>
@@ -544,6 +567,17 @@ Por favor, asegúrese que ha seleccionado el directorio de perfiles correcto.</t
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Cuenta</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Color de notificación</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -551,22 +585,7 @@ Por favor, asegúrese que ha seleccionado el directorio de perfiles correcto.</t
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Fatal</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Lo sentimos, la bandeja del sistema no puede ser controlado a través de este complemento en su sistema operativo.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>No se pudo leer el icono de la bandeja del sistema por defecto.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>No se pudo abrir el fichero: </translation>
@@ -599,37 +618,9 @@ Por favor, asegúrese que ha seleccionado el directorio de perfiles correcto.</t
         <source>Unexpected end of group.</source>
         <translation>Fin de grupo inesperado.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Tenía configurado el control de una o más carpetas de correos usando el analizador de Sqlite. Este método ha sido eliminado. Tus configuraciones han sido cambiadas al analizador Mork, pero algunas carpetas de correo configurada podría no ser encontrada.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Cuentas basadas en Sqlite cambiadas</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Tenía configurado el control de una o más carpetas de correos usando el analizador de Sqlite. Este método ha sido eliminado. Por favor, verifique si todas sus cuentas fueron correctamente mapeadas.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Cuenta</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Color de notificación</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Error fatal: %1
-
-El fichero de registro fue escrito en el archivo %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>No se pudieron grabar las configuraciones</translation>
@@ -641,8 +632,20 @@ El fichero de registro fue escrito en el archivo %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Fallo al abrir el fichero de registro %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Cuentas basadas en Sqlite cambiadas</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Tenía configurado el control de una o más carpetas de correos usando el analizador de Sqlite. Este método ha sido eliminado. Tus configuraciones han sido cambiadas al analizador Mork, pero algunas carpetas de correo configurada podría no ser encontrada.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Tenía configurado el control de una o más carpetas de correos usando el analizador de Sqlite. Este método ha sido eliminado. Por favor, verifique si todas sus cuentas fueron correctamente mapeadas.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>No se pudo leer el icono de la bandeja del sistema por defecto.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -793,12 +793,12 @@ Por favor, asegúrese que ha seleccionado el directorio de perfiles correcto.</t
         <translation>Ignorar esta versión</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Actualizar y reiniciar</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca. %1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Actualizar y reiniciar</translation>
     </message>
 </context>
 <context>
@@ -818,10 +818,6 @@ Por favor, asegúrese que ha seleccionado el directorio de perfiles correcto.</t
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Descargando instalador de Bridtray...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Actualizar y reiniciar</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -41,10 +41,6 @@ OpenSSL potrebbe non essere installato.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Una notifica gratuita sulla barra delle applicazioni per la nuova posta per Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Visualizza i contenuti del database mork.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>Scrivi il log in un file.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>FILE</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Una notifica gratuita sulla barra delle applicazioni per la nuova posta per Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>file</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Siamo spiacenti, la barra delle applicazioni non può essere controllata tramite questo componente aggiuntivo sul tuo sistema operativo.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL potrebbe non essere installato.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Colore di notifica multipla:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ciò modifica lo spessore del carattere, ovvero rende grassetto il carattere.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>Crea l&apos;icona nella barra delle applicazioni</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Verifica la presenza di nuovi aggiornamenti all&apos;avvio di Birdtray</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Verifica la presenza di nuovi aggiornamenti all&apos;avvio</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Cerca una nuova versione di Birdtray</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -409,11 +401,11 @@ OpenSSL potrebbe non essere installato.</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, the Birdtray icon will show the number of unread emails.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If it is unchecked, no count will be shown, and you will only know about unread emails because of the blinking or different icon, depending on your settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se questa casella è selezionata, l'icona Birdtray mostrerà il numero di e-mail non lette.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se è deselezionato, non verrà visualizzato alcun conteggio e conoscerai solo le email non lette a causa dell'icona lampeggiante o diversa, a seconda delle tue impostazioni.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se questa casella è selezionata, l&apos;icona Birdtray mostrerà il numero di e-mail non lette.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se è deselezionato, non verrà visualizzato alcun conteggio e conoscerai solo le email non lette a causa dell&apos;icona lampeggiante o diversa, a seconda delle tue impostazioni.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se attivata, questa opzione aggiunge il &amp;quot;Ignora le email attualmente non lette&amp;quot; azione nel menu contestuale. Questa azione ti consente di ignorare le e-mail attualmente non lette. Birdtray fingerebbe quindi che non siano rimaste email non lette e mostrerebbe solo le nuove email nel conteggio ignorato.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ad esempio, se c'erano 10 e-mail non lette e hai fatto clic su &amp;quot;Ignora&amp;quot; azione, Birdtray non mostrerà alcun indicatore di e-mail non lette fino a quando il conteggio delle e-mail non lette rimane a 10. Una volta ricevuta la nuova e-mail e il totale di 11 e-mail non lette, Birdtray mostrerà il conteggio delle nuove e-mail come 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;ISe il conteggio delle e-mail non lette è inferiore a &amp;quot;ignored&amp;quot; in totale, l'ignora si azzera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se attivata, questa opzione aggiunge il &amp;quot;Ignora le email attualmente non lette&amp;quot; azione nel menu contestuale. Questa azione ti consente di ignorare le e-mail attualmente non lette. Birdtray fingerebbe quindi che non siano rimaste email non lette e mostrerebbe solo le nuove email nel conteggio ignorato.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ad esempio, se c&apos;erano 10 e-mail non lette e hai fatto clic su &amp;quot;Ignora&amp;quot; azione, Birdtray non mostrerà alcun indicatore di e-mail non lette fino a quando il conteggio delle e-mail non lette rimane a 10. Una volta ricevuta la nuova e-mail e il totale di 11 e-mail non lette, Birdtray mostrerà il conteggio delle nuove e-mail come 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;ISe il conteggio delle e-mail non lette è inferiore a &amp;quot;ignored&amp;quot; in totale, l&apos;ignora si azzera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Translations are powered by the community:</source>
@@ -436,20 +428,16 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>Modifica non letta cmd:</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se non è vuoto, questo comando verrà richiamato ogni volta che il contatore non letto cambia (anche quando diventa zero).Viene richiamato tramite shell, così com'è, con %NEW% sostituito dal nuovo valore di conteggio non letto e %OLD% sostituito con il vecchio valore di conteggio non letto (che potrebbe essere uguale al nuovo).&lt;/p&gt;&lt;p&gt;La maggior parte degli utenti non&apos; necessita di questa funzionalità e dovrebbe lasciarla vuota.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Seleziona le cartelle di posta da guardare.&lt;br/&gt;&lt;br/&gt;Se la finestra di dialogo non&apos; mostra la tua cartella, &lt;i&gt;Ctrl + Shift click&lt;/i&gt;per aprire una finestra di dialogo per la selezione dei file che permette di aggiungere qualsiasi file mork.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
-        <translation>Impossibile caricare l'icona da questo file. Prova a caricare l'icona in uno strumento di modifica delle immagini e a salvarla in un formato diverso.</translation>
+        <translation>Impossibile caricare l&apos;icona da questo file. Prova a caricare l&apos;icona in uno strumento di modifica delle immagini e a salvarla in un formato diverso.</translation>
     </message>
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Quando si fa clic sull'icona Birdtray per nascondere Thunderbird, reimpostare l'icona ignorando tutte le e-mail attualmente non lette</translation>
+        <translation>Quando si fa clic sull&apos;icona Birdtray per nascondere Thunderbird, reimpostare l&apos;icona ignorando tutte le e-mail attualmente non lette</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -482,6 +470,41 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Per quelli di voi che apprezzano il mio lavoro su Birdtray, che si sta sviluppando nel mio tempo libero, potete farlo qui: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Grazie per il continuo supporto!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ciò modifica lo spessore del carattere, ovvero rende grassetto il carattere.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se non è vuoto, questo comando verrà richiamato ogni volta che il contatore non letto cambia (anche quando diventa zero).Viene richiamato tramite shell, così com&apos;è, con %NEW% sostituito dal nuovo valore di conteggio non letto e %OLD% sostituito con il vecchio valore di conteggio non letto (che potrebbe essere uguale al nuovo).&lt;/p&gt;&lt;p&gt;La maggior parte degli utenti non&apos; necessita di questa funzionalità e dovrebbe lasciarla vuota.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Verifica la presenza di nuovi aggiornamenti all&apos;avvio di Birdtray.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Cerca una nuova versione di Birdtray.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Impossibile aprire il file di registro %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Fatale</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Errore irreversibile: %1
+
+Il file di registro è stato scritto nel file %2</translation>
     </message>
 </context>
 <context>
@@ -544,6 +567,17 @@ Assicurati di aver selezionato la directory corretta dei profili.</translation>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Account</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Colore di notifica</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -551,22 +585,7 @@ Assicurati di aver selezionato la directory corretta dei profili.</translation>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Fatale</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Siamo spiacenti, la barra delle applicazioni non può essere controllata tramite questo componente aggiuntivo sul tuo sistema operativo.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Impossibile caricare l&apos;icona della barra delle applicazioni predefinita.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Impossibile aprire il file: </translation>
@@ -599,37 +618,9 @@ Assicurati di aver selezionato la directory corretta dei profili.</translation>
         <source>Unexpected end of group.</source>
         <translation>Termine inaspettato del gruppo.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Hai configurato il monitoraggio di una o più cartelle di posta utilizzando il parser Sqlite. Questo metodo è stato rimosso. Le tue configurazioni sono state migrate al parser Mork, ma non è stato possibile trovare alcune cartelle di posta configurate.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Account basati su sqlite migrati</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Hai configurato il monitoraggio di uno o più account di posta utilizzando il parser Sqlite. Questo metodo è stato rimosso. Le tue configurazioni sono state migrate al parser Mork. Verifica che tutti gli account siano stati mappati correttamente.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Account</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Colore di notifica</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Errore irreversibile: %1
-
-Il file di registro è stato scritto nel file %2</translation>        
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Impossibile salvare le impostazioni</translation>
@@ -641,8 +632,20 @@ Il file di registro è stato scritto nel file %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Impossibile aprire il file di registro %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Account basati su sqlite migrati</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Hai configurato il monitoraggio di una o più cartelle di posta utilizzando il parser Sqlite. Questo metodo è stato rimosso. Le tue configurazioni sono state migrate al parser Mork, ma non è stato possibile trovare alcune cartelle di posta configurate.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Hai configurato il monitoraggio di uno o più account di posta utilizzando il parser Sqlite. Questo metodo è stato rimosso. Le tue configurazioni sono state migrate al parser Mork. Verifica che tutti gli account siano stati mappati correttamente.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Impossibile caricare l&apos;icona della barra delle applicazioni predefinita.</translation>
     </message>
 </context>
 <context>
@@ -790,12 +793,12 @@ Il file di registro è stato scritto nel file %2</translation>
         <translation>Ignora questa versione</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Aggiorna e riavvia</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca. %1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Aggiorna e riavvia</translation>
     </message>
 </context>
 <context>
@@ -815,10 +818,6 @@ Il file di registro è stato scritto nel file %2</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Download del programma di installazione Birdtray...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Aggiorna e riavvia</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -41,10 +41,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Een gratis systeemvakprogramma dat meldingen toont van Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Bekijk de inhoud van de opgegeven mork-databank.</translation>
     </message>
@@ -85,8 +81,16 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
         <translation>Sla een logboek op.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>BESTAND</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Een gratis systeemvakprogramma dat meldingen toont van Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>bestand</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Het systeemvak van uw besturingssysteem kan niet worden beheerd middels deze add-on.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Meldingskleur meerdere accounts:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dit past de dikte van het lettertype aan - maak het bijv. vetgedrukt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -287,8 +287,8 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
     </message>
     <message>
         <source>Please do not change these settings unless you understand what you&apos;re doing.</source>
-        <translation>Pas deze instellingen alleen aan als u weet wat u doet!</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>Pas deze instellingen alleen aan als u weet wat u doet!</translation>
     </message>
     <message>
         <source>Thunderbird window name pattern:</source>
@@ -311,16 +311,8 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
         <translation>Systeemvakpictogram doorzichtig maken</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Controleren op updates tijdens opstarten</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Controleren op updates tijdens opstarten</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Controleer of er een nieuwe Birdtray-versie beschikbaar is</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -390,8 +382,8 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
     </message>
     <message>
         <source>opaque when new mail is present,</source>
-        <translation>ondoorzichtig als er nieuwe e-mails zijn;</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>ondoorzichtig als er nieuwe e-mails zijn;</translation>
     </message>
     <message>
         <source>hide it if no new mail is present.</source>
@@ -438,10 +430,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
         <translation>Ongelezen wijziging-opdracht:</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Als dit niet leeggelaten wordt, dan wordt de opdracht aangeroepen telkens als de ongelezenteller verandert (inclusief als deze de nul bereikt). Deze wordt aangeroepen via de shell waar %NEW% vervangen wordt door de huidige ongelezen waarde en %OLD% door de vorige (welke dezelfde kan zijn als de huidige).&lt;/p&gt;&lt;p&gt;De meeste gebruikers hebben deze functionaliteit niet nodig dienen het vak leeg te laten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecteer de e-mailmappen die u wilt bijhouden.&lt;br/&gt;&lt;br/&gt;Als het venster een map niet toont, &lt;i&gt;gebruik dan Ctrl + Shift + klik&lt;/i&gt; om een bestandsselectievenster te openen zodat u een mork-bestand kunt toevoegen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -484,6 +472,41 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation>Herstel het pictogram door alle ongelezen e-mails te negeren door te klikken op het Birdtray-pictogram</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dit past de dikte van het lettertype aan - maak het bijv. vetgedrukt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Als dit niet leeggelaten wordt, dan wordt de opdracht aangeroepen telkens als de ongelezenteller verandert (inclusief als deze de nul bereikt). Deze wordt aangeroepen via de shell waar %NEW% vervangen wordt door de huidige ongelezen waarde en %OLD% door de vorige (welke dezelfde kan zijn als de huidige).&lt;/p&gt;&lt;p&gt;De meeste gebruikers hebben deze functionaliteit niet nodig dienen het vak leeg te laten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Controleren op updates tijdens opstarten.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Controleer of er een nieuwe Birdtray-versie beschikbaar is.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Het logboek &apos;%s&apos; kan niet worden geopend: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Onmogelijk</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Fatale fout: %1
+
+Het logboek is opgeslagen als %2</translation>
     </message>
 </context>
 <context>
@@ -546,6 +569,17 @@ Zorg ervoor dat u de juiste profielenmap heeft gekozen.</translation>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Account</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Meldingskleur</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -553,22 +587,7 @@ Zorg ervoor dat u de juiste profielenmap heeft gekozen.</translation>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Onmogelijk</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Het systeemvak van uw besturingssysteem kan niet worden beheerd middels deze add-on.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Het laden van het standaard systeemvakpictogram is mislukt.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Bestand kan niet worden geopend: </translation>
@@ -601,37 +620,9 @@ Zorg ervoor dat u de juiste profielenmap heeft gekozen.</translation>
         <source>Unexpected end of group.</source>
         <translation>Onverwacht groepseinde.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>U had ingesteld dat één of meerdere e-mailmappen bijgehouden moesten worden middels de Sqlite-verwerker, maar deze methode is verwijderd. Uw instellingen zijn gemigreerd naar de Mork-verwerker, maar enkele ingestelde e-mailmappen zijn niet aangetroffen.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Op Sqlite gebaseerde accounts zijn gemigreerd</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>U had ingesteld dat één of meerdere e-mailmappen bijgehouden moesten worden middels de Sqlite-verwerker, maar deze methode is verwijderd. Uw instellingen zijn gemigreerd naar de Mork-verwerker. Controleer of alle accounts juist zijn gemigreerd.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Account</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Meldingskleur</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Fatale fout: %1
-
-Het logboek is opgeslagen als %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Kan instellingen niet opslaan</translation>
@@ -643,8 +634,20 @@ Het logboek is opgeslagen als %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Het logboek &apos;%s&apos; kan niet worden geopend: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Op Sqlite gebaseerde accounts zijn gemigreerd</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>U had ingesteld dat één of meerdere e-mailmappen bijgehouden moesten worden middels de Sqlite-verwerker, maar deze methode is verwijderd. Uw instellingen zijn gemigreerd naar de Mork-verwerker, maar enkele ingestelde e-mailmappen zijn niet aangetroffen.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>U had ingesteld dat één of meerdere e-mailmappen bijgehouden moesten worden middels de Sqlite-verwerker, maar deze methode is verwijderd. Uw instellingen zijn gemigreerd naar de Mork-verwerker. Controleer of alle accounts juist zijn gemigreerd.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Het laden van het standaard systeemvakpictogram is mislukt.</translation>
     </message>
 </context>
 <context>
@@ -699,8 +702,8 @@ Het logboek is opgeslagen als %2</translation>
     </message>
     <message>
         <source>Snooze for ...</source>
-        <translation>Onderdrukken:</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>Onderdrukken:</translation>
     </message>
     <message>
         <source>Unsnooze</source>
@@ -793,12 +796,12 @@ Het logboek is opgeslagen als %2</translation>
         <translation>Deze versie negeren</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Bijwerken en opnieuw starten</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca. %1 mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Bijwerken en opnieuw starten</translation>
     </message>
 </context>
 <context>
@@ -818,10 +821,6 @@ Het logboek is opgeslagen als %2</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Bezig met downloaden van Birdtray-installatiewizard...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Bijwerken en opnieuw starten</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -41,10 +41,6 @@ OpenSSL może nie być zainstalowane.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Darmowe powiadomienia o nowej poczcie dla Thunderbirda</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Wyświetl zawartość bazy danych mork.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>Zapisz log do pliku.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>PLIK</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Darmowe powiadomienia o nowej poczcie dla Thunderbirda.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>plik</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Niestety, tacka systemowa nie oże być kontrolowana przez to rozszerzenie w tym systemie operacyjnym.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL może nie być zainstalowane.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Kolor dla wielu powiadomień:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zmiana grubości czcionki.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>Zmień ikonę w tacce na w</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Sprawdź dostępność aktualizacji podczas uruchamiania Birdtray</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Sprawdź dostępność aktualizacji przy uruchomieniu</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Sprawdź, czy dostępne sa nowe wersje Birdtray</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -436,20 +428,12 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>Wykonaj w przypadku zmiany licznika nieprzeczytanych:</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jeśli niepuste, ta komenda będzie wykonywana z każdą zmianą licznika nieprzeczytanych (włącznie z wyzerowaniem). Skrypt powłoki, z %NEW% zastępowanym przez nową wartość licznika i %OLD% zastępowanym starą wartością licznika (Obie mogą być takie same).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wybierz foldery poczty do śledzenia.&lt;br/&gt;&lt;br/&gt;Jeśli na liście nie ma twojego folderu naciśnij, &lt;i&gt;Ctrl + Shift&lt;/i&gt; aby otworzyć menu wybory pozwalające dodać jakikolwiek plik mork.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation>Nie można załadować ikony z wybranego pliku. Spróbuj otworzyć ikonę w edytorze grafiki i zapisać ją w innym formacie.</translation>
-    </message>
-    <message>
-        <source>CheckBox</source>
-        <translation>Pole wyboru</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -485,7 +469,42 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Przy kliknięciu chowającym Birdtray ignoruj nieprzeczytane wiadomości.</translation>
+        <translation>Przy kliknięciu chowającym Birdtray ignoruj nieprzeczytane wiadomości</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zmiana grubości czcionki.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jeśli niepuste, ta komenda będzie wykonywana z każdą zmianą licznika nieprzeczytanych (włącznie z wyzerowaniem). Skrypt powłoki, z %NEW% zastępowanym przez nową wartość licznika i %OLD% zastępowanym starą wartością licznika (Obie mogą być takie same).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Sprawdź dostępność aktualizacji podczas uruchamiania Birdtray.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Sprawdź, czy dostępne sa nowe wersje Birdtray.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Nie można otworzyć pliku log %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Krytyczny</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Błąd krytyczny: %1
+
+plik log został zapisany %2</translation>
     </message>
 </context>
 <context>
@@ -548,6 +567,17 @@ Upewnij się, że wybrałeś poprawny folder.</translation>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Konto</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Kolor powiadomienia</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -555,22 +585,7 @@ Upewnij się, że wybrałeś poprawny folder.</translation>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Krytyczny</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Niestety, tacka systemowa nie oże być kontrolowana przez to rozszerzenie w tym systemie operacyjnym.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Nie udało się załadować domyślnej ikony tacki systemowej.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Nie można otworzyć pliku: </translation>
@@ -603,37 +618,9 @@ Upewnij się, że wybrałeś poprawny folder.</translation>
         <source>Unexpected end of group.</source>
         <translation>Nieoczekiwany koniec grupy.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Skonfigurowałeś monitorowanie jednego lub wielu folderów przy użyciu parsera Sqlite. Ta metoda została usunięta. Twoja konfiguracja została przeniesiona do parsera Mork, jednak niektóre foldery nie zostały znalezione.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Przeniesiono konta bazujące na Sqlite</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Skonfigurowałeś monitorowanie jednego lub wielu folderów przy użyciu parsera Sqlite. Ta metoda została usunięta. Twoja konfiguracja została przeniesiona do parsera Mork. Sprawdź, czy wszystkie konta zostały zmapowane poprawnie.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Konto</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Kolor powiadomienia</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Błąd krytyczny: %1
-
-plik log został zapisany %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Nie można zapisać ustawień</translation>
@@ -645,8 +632,20 @@ plik log został zapisany %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Nie można otworzyć pliku log %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Przeniesiono konta bazujące na Sqlite</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Skonfigurowałeś monitorowanie jednego lub wielu folderów przy użyciu parsera Sqlite. Ta metoda została usunięta. Twoja konfiguracja została przeniesiona do parsera Mork, jednak niektóre foldery nie zostały znalezione.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Skonfigurowałeś monitorowanie jednego lub wielu folderów przy użyciu parsera Sqlite. Ta metoda została usunięta. Twoja konfiguracja została przeniesiona do parsera Mork. Sprawdź, czy wszystkie konta zostały zmapowane poprawnie.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Nie udało się załadować domyślnej ikony tacki systemowej.</translation>
     </message>
 </context>
 <context>
@@ -794,12 +793,12 @@ plik log został zapisany %2</translation>
         <translation>Zignoruj tę wersję</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Zaktualizauj i uruchom ponownie</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>około %1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Zaktualizauj i uruchom ponownie</translation>
     </message>
 </context>
 <context>
@@ -819,10 +818,6 @@ plik log został zapisany %2</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Pobieranie instalatora Birdtray...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Zaktualizauj i uruchom ponownie</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -41,10 +41,6 @@ OpenSSL não deve estar instalado.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Notificações na Área de Notificação para novas mensagens do Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Exibe o conteúdo do banco de dados mork fornecido.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL não deve estar instalado.</translation>
         <translation>Salva o registro em um arquivo.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>ARQUIVO</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Notificações na Área de Notificação para novas mensagens do Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>arquivo</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Desculpe, a área de notificação do sistema não pode ser controlada através desta extensão em seu sistema operacional.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL não deve estar instalado.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Cor de múltiplas notificações:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Isto altera espessura da fonte. Por exemplo: torna a fonte negrito.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL não deve estar instalado.</translation>
         <translation>Tornar ícone da Área de Notificação</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Verificar por atualizações ao iniciar o Birdtray</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Verificar por atualizações ao iniciar</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Verificar nova versão do Birdtray</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -425,19 +417,15 @@ OpenSSL não deve estar instalado.</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, the Birdtray icon will show the number of unread emails.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If it is unchecked, no count will be shown, and you will only know about unread emails because of the blinking or different icon, depending on your settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;body&gt;&lt;p&gt;Se esta caixa está marcada, o ícone do Birdtray irá exibir o número de mensagens não lidas.&lt;/p&gt;&lt;p&gt;&lt;/br&gt;Se estiver desmarcada, nenhuma contagem é exibida, e você somente saberá sobre mensagens não lidas devido ao piscar ou ícone diferente, dependendo das suas configurações.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se esta caixa está marcada, o ícone do Birdtray irá exibir o número de mensagens não lidas.&lt;/p&gt;&lt;p&gt;&lt;/br&gt;Se estiver desmarcada, nenhuma contagem é exibida, e você somente saberá sobre mensagens não lidas devido ao piscar ou ícone diferente, dependendo das suas configurações.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;body&gt;&lt;p&gt;Se ativada, esta opção adiciona a ação &amp;quot;Ignorar e-mails não lidos&amp;quot; ao menu de contexto. Esta ação permite a você ignorar os e-mails não lidos no momento. O Birdtray então entenderá que não há nenhum e-mail não lido restante, e somente mostrar novos e-mails sobre a contagem de ignorados.&lt;/p&gt;&lt;p&gt;&lt;/br&gt;Por exemplo, se há 10 e-mails não lidos e você clicar na ação &amp;quot;Ignorar&amp;quot;, o Birdtray irá o indicador de nenhum e-mail não lido enquanto o contador de e-mails não lidos permancer em 10. Assim que um novo e-mail é recebido e você ter 11 e-mails não lidos, o Birdtray irá exibir a contagem de novo e-mail como 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se a contagem de e-mails não lidos cair abaixo da quantia &amp;quot;ignorada&amp;quot;, ignorar será redefinida para zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se ativada, esta opção adiciona a ação &amp;quot;Ignorar e-mails não lidos&amp;quot; ao menu de contexto. Esta ação permite a você ignorar os e-mails não lidos no momento. O Birdtray então entenderá que não há nenhum e-mail não lido restante, e somente mostrar novos e-mails sobre a contagem de ignorados.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por exemplo, se há 10 e-mails não lidos e você clicar na ação &amp;quot;Ignorar&amp;quot;, o Birdtray irá o indicador de nenhum e-mail não lido enquanto o contador de e-mails não lidos permancer em 10. Assim que um novo e-mail é recebido e você ter 11 e-mails não lidos, o Birdtray irá exibir a contagem de novo e-mail como 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se a contagem de e-mails não lidos cair abaixo da quantia &amp;quot;ignorada&amp;quot;, ignorar será redefinida para zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Unread change cmd:</source>
         <translation>Comando para mudar não lida:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se não estiver vazio, este comando será invocado sempre que o contador não lido mudar (inclusive quando se tornar zero). Ele é invocado via shell, no estado em que se encontra, com %NEW% substituído pelo novo valor de contagem de não lido e %OLD% substituído pelo antigo valor de contagem não lido (que pode ser igual ao novo).&lt;/p&gt;&lt;p&gt;A maioria dos usuários não precisa dessa funcionalidade e deve deixá-la vazia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -482,6 +470,41 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation>Ao clicar no ícone do Birdtray para ocultar o Thunderbird, redefine o ícone, ignorando todos os e-mails não lidos no momento</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Isto altera espessura da fonte. Por exemplo: torna a fonte negrito.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se não estiver vazio, este comando será invocado sempre que o contador não lido mudar (inclusive quando se tornar zero). Ele é invocado via shell, no estado em que se encontra, com %NEW% substituído pelo novo valor de contagem de não lido e %OLD% substituído pelo antigo valor de contagem não lido (que pode ser igual ao novo).&lt;/p&gt;&lt;p&gt;A maioria dos usuários não precisa dessa funcionalidade e deve deixá-la vazia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Verificar por atualizações ao iniciar o Birdtray.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Verificar nova versão do Birdtray.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Falha ao abrir arquivo de registro %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Erro fatal: %1
+
+Registro salvo no arquivo %2</translation>
     </message>
 </context>
 <context>
@@ -544,6 +567,17 @@ Por favor, certifique-se de ter selecionado a pasta de perfis correta.</translat
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Conta</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Cor da notificação</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -551,22 +585,7 @@ Por favor, certifique-se de ter selecionado a pasta de perfis correta.</translat
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Fatal</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Desculpe, a área de notificação do sistema não pode ser controlada através desta extensão em seu sistema operacional.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Não é possível carregar o ícone padrão da área de notificação do sistema.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Não é possível abrir o arquivo: </translation>
@@ -599,37 +618,9 @@ Por favor, certifique-se de ter selecionado a pasta de perfis correta.</translat
         <source>Unexpected end of group.</source>
         <translation>Fim inesperado do grupo.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Você configurou o monitoramento de uma ou mais pastas de e-mail usando o analisador Sqlite. Este método foi removido. Suas configurações foram migradas para o analisador Mork, mas algumas pastas de e-mail configuradas podem não ser encontradas.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Contas baseadas em Sqlite migradas</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Você configurou o monitoramento de uma ou mais pastas de e-mail usando o analisador Sqlite. Este método foi removido. Suas configurações foram migradas para o analisador Mork. Por favor, verifique que todas as contas foram mapeadas corretamente.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Conta</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Cor da notificação</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Erro fatal: %1
-
-Registro salvo no arquivo %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Não foi possível salvar as configurações</translation>
@@ -641,8 +632,20 @@ Registro salvo no arquivo %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Falha ao abrir arquivo de registro %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Contas baseadas em Sqlite migradas</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Você configurou o monitoramento de uma ou mais pastas de e-mail usando o analisador Sqlite. Este método foi removido. Suas configurações foram migradas para o analisador Mork, mas algumas pastas de e-mail configuradas podem não ser encontradas.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Você configurou o monitoramento de uma ou mais pastas de e-mail usando o analisador Sqlite. Este método foi removido. Suas configurações foram migradas para o analisador Mork. Por favor, verifique que todas as contas foram mapeadas corretamente.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Não é possível carregar o ícone padrão da área de notificação do sistema.</translation>
     </message>
 </context>
 <context>
@@ -790,12 +793,12 @@ Registro salvo no arquivo %2</translation>
         <translation>Ignorar esta versão</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Atualizar e Reiniciar</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>%1 MB</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Atualizar e Reiniciar</translation>
     </message>
 </context>
 <context>
@@ -815,10 +818,6 @@ Registro salvo no arquivo %2</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Baixando instalador do Birdtray...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Atualizar e Reiniciar</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -41,10 +41,6 @@ OpenSSL might not be installed.</source>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Бесплатное уведомление в системном трее о новой почте для Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Показать содержимое данной базы данных mork.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL might not be installed.</source>
         <translation>Записать журнал в файл.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>ФАЙЛ</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Бесплатное уведомление в системном трее о новой почте для Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>файл</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Извините, системный трей нельзя контролировать с помощью этого дополнения в вашей операционной системе.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL might not be installed.</source>
     <message>
         <source>Multiple notification color:</source>
         <translation>Цвет нескольких уведомлений:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это изменяет толщину шрифта, то есть делает шрифт жирным.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL might not be installed.</source>
         <translation>Сделать иконку в системном трее</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Проверка наличия обновлений при запуске Birdtray</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Проверка наличия обновлений при запуске</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Проверка новой версии Birdtray</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -440,10 +432,6 @@ OpenSSL might not be installed.</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Выберите почтовые папки для наблюдения.&lt;br/&gt;&lt;br/&gt;Если диалоговое окно не отображает вашу папку, нажмите &lt;i&gt;Ctrl + Shift&lt;/i&gt;, чтобы открыть диалоговое окно выбора файла, в котором можно добавить любой файл mork.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если не пусто, данная команда будет вызываться каждый раз, когда изменяется счетчик непрочитанных сообщений (в том числе, когда он становится равным нулю). Она вызывается через оболочку, как есть, с заменой% NEW% на новое непрочитанное значение счетчика, а% OLD% заменяется старым непрочитанным значением счетчика (которое может совпадать с новым). &lt;/p&gt;&lt;p&gt;Большинству пользователей эта функциональность не нужна и она должна быть пустой.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation>Не удалось загрузить значок из этого файла. Попробуйте загрузить значок в инструмент редактирования изображений и сохранить его в другом формате.</translation>
     </message>
@@ -482,6 +470,41 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation>При нажатии на значок Birdtray для скрытия Thunderbird, значок обновится, игнорируя все непрочитанные в настоящее время электронные письма</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это изменяет толщину шрифта, то есть делает шрифт жирным.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если не пусто, данная команда будет вызываться каждый раз, когда изменяется счетчик непрочитанных сообщений (в том числе, когда он становится равным нулю). Она вызывается через оболочку, как есть, с заменой% NEW% на новое непрочитанное значение счетчика, а% OLD% заменяется старым непрочитанным значением счетчика (которое может совпадать с новым). &lt;/p&gt;&lt;p&gt;Большинству пользователей эта функциональность не нужна и она должна быть пустой.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Проверка наличия обновлений при запуске Birdtray.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Проверка новой версии Birdtray.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Не удалось открыть файл журнала %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Фатальный</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Фатальная ошибка: %1
+
+Файл журнала записан в файл %2</translation>
     </message>
 </context>
 <context>
@@ -544,6 +567,17 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Учетная запись</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Цвет уведомления</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -551,22 +585,7 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Фатальный</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Извините, системный трей нельзя контролировать с помощью этого дополнения в вашей операционной системе.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Невозможно загрузить значок по умолчанию в системном трее.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Не удалось открыть файл: </translation>
@@ -599,37 +618,9 @@ Please make sure you selected the correct profiles directory.</source>
         <source>Unexpected end of group.</source>
         <translation>Неожиданный конец группы.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Вы настроили мониторинг одной или нескольких почтовых папок с помощью анализатора Sqlite. Этот метод был удален. Ваши конфигурации были перенесены в анализатор Mork, но некоторые настроенные почтовые папки не могут быть найдены.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Аккаунты на основе Sqlite перенесены</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Вы настроили мониторинг одной или нескольких почтовых учетных записей с помощью анализатора Sqlite. Этот метод был удален. Ваши конфигурации были перенесены в анализатор Mork. Пожалуйста, убедитесь, что все учетные записи были сопоставлены правильно.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Учетная запись</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Цвет уведомления</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Фатальная ошибка: %1
-
-Файл журнала записан в файл %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Не удалось сохранить настройки</translation>
@@ -641,8 +632,20 @@ Log file is written into file %2</source>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Не удалось открыть файл журнала %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Аккаунты на основе Sqlite перенесены</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Вы настроили мониторинг одной или нескольких почтовых папок с помощью анализатора Sqlite. Этот метод был удален. Ваши конфигурации были перенесены в анализатор Mork, но некоторые настроенные почтовые папки не могут быть найдены.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Вы настроили мониторинг одной или нескольких почтовых учетных записей с помощью анализатора Sqlite. Этот метод был удален. Ваши конфигурации были перенесены в анализатор Mork. Пожалуйста, убедитесь, что все учетные записи были сопоставлены правильно.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Невозможно загрузить значок по умолчанию в системном трее.</translation>
     </message>
 </context>
 <context>
@@ -790,12 +793,12 @@ Log file is written into file %2</source>
         <translation>Игнорировать эту версию</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Обновить и перезапустить</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca. %1 Мб</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Обновить и перезапустить</translation>
     </message>
 </context>
 <context>
@@ -815,10 +818,6 @@ Log file is written into file %2</source>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Загрузка установщика Birdtray ...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Обновить и перезапустить</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -41,10 +41,6 @@ OpenSSL kanske inte är installerad.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>En fri systemfältsavisering för ny e-post i Thunderbird</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Visa innehållet i den givna mork-databasen.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL kanske inte är installerad.</translation>
         <translation>Skriv loggen till en fil.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>FIL</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>En fri systemfältsavisering för ny e-post i Thunderbird.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>fil</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Systemfältet kan tyvärr inte kontrolleras genom detta tillägg, i ditt operativsystem.</translation>
     </message>
 </context>
 <context>
@@ -172,10 +176,6 @@ OpenSSL kanske inte är installerad.</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Fleraviseringsfärg:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detta ändrar teckentjockleken, gör teckensnittet fett.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -310,16 +310,8 @@ OpenSSL kanske inte är installerad.</translation>
         <translation>Gör systemfältsikonen</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Sök efter uppdateringar när Birdtray startas</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Sök efter uppdateringar vid uppstart</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Sök efter ny Birdtray-version</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -440,10 +432,6 @@ OpenSSL kanske inte är installerad.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -482,6 +470,41 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Ni som uppskattar mitt arbete med Birdtray, som utvecklas på min fritid, kan göra det här: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Tack för ert kontinuerliga stöd!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detta ändrar teckentjockleken, gör teckensnittet fett.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Sök efter uppdateringar när Birdtray startas.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Sök efter ny Birdtray-version.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Kunde inte öppna loggfilen %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Ödesdigert</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Ödesdigert fel: %1
+
+Loggen har skrivits i filen %2</translation>
     </message>
 </context>
 <context>
@@ -544,6 +567,17 @@ Tillse att du har valt rätt profilmapp.</translation>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Konto</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Aviseringsfärg</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -551,22 +585,7 @@ Tillse att du har valt rätt profilmapp.</translation>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Ödesdigert</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Systemfältet kan tyvärr inte kontrolleras genom detta tillägg, i ditt operativsystem.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Kan inte läsa in ordinarie systemfältsikon.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Kunde inte öppna filen: </translation>
@@ -599,37 +618,9 @@ Tillse att du har valt rätt profilmapp.</translation>
         <source>Unexpected end of group.</source>
         <translation>Oväntad &quot;end of group&quot;.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Du hade konfigurerat övervakning av en eller flera e-postmappar med sqlite-tolken. Den metoden har tagits bort. Dina konfigurationer har migrerats till Mork-tolken, men några konfigurerade e-postmappar gick inte att hitta.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Sqlite-baserade konton migrerade</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Du hade konfigurerat övervakning av en eller flera e-postmappar med sqlite-tolken. Den metoden har tagits bort. Dina konfigurationer har migrerats till Mork-tolken. Kontrollera att alla konton har mappats korrekt.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Konto</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Aviseringsfärg</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Ödesdigert fel: %1
-
-Loggen har skrivits i filen %2</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Kunde inte spara inställningarna</translation>
@@ -641,8 +632,20 @@ Loggen har skrivits i filen %2</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Kunde inte öppna loggfilen %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Sqlite-baserade konton migrerade</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Du hade konfigurerat övervakning av en eller flera e-postmappar med sqlite-tolken. Den metoden har tagits bort. Dina konfigurationer har migrerats till Mork-tolken, men några konfigurerade e-postmappar gick inte att hitta.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Du hade konfigurerat övervakning av en eller flera e-postmappar med sqlite-tolken. Den metoden har tagits bort. Dina konfigurationer har migrerats till Mork-tolken. Kontrollera att alla konton har mappats korrekt.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Kan inte läsa in ordinarie systemfältsikon.</translation>
     </message>
 </context>
 <context>
@@ -790,12 +793,12 @@ Loggen har skrivits i filen %2</translation>
         <translation>Ignorera denna version</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Uppdatera och starta om</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>ca: %1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Uppdatera och starta om</translation>
     </message>
 </context>
 <context>
@@ -815,10 +818,6 @@ Loggen har skrivits i filen %2</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Laddar ner Birdtray-installerare...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Uppdatera och starta om</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -41,10 +41,6 @@ OpenSSL yüklenmemiş olabilir.</translation>
 <context>
     <name>BirdtrayApp</name>
     <message>
-        <source>A free system tray notification for new mail for Thunderbird</source>
-        <translation>Thunderbird&apos;den yeni postalar için ücretsiz bir sistem tepsisi bildirim programı</translation>
-    </message>
-    <message>
         <source>Display the contents of the given mork database.</source>
         <translation>Verilen mork veritabanının içeriğini görüntüleyin.</translation>
     </message>
@@ -85,8 +81,16 @@ OpenSSL yüklenmemiş olabilir.</translation>
         <translation>Log&apos;u bir dosyaya yazın.</translation>
     </message>
     <message>
-        <source>FILE</source>
-        <translation>DOSYA</translation>
+        <source>A free system tray notification for new mail for Thunderbird.</source>
+        <translation>Thunderbird&apos;den yeni postalar için ücretsiz bir sistem tepsisi bildirim programı.</translation>
+    </message>
+    <message>
+        <source>file</source>
+        <translation>dosya</translation>
+    </message>
+    <message>
+        <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
+        <translation>Üzgünüz, sistem tepsisi işletim sisteminizdeki bu eklenti üzerinden kontrol edilemez.</translation>
     </message>
 </context>
 <context>
@@ -173,10 +177,6 @@ tuşunu basılı tutarak tıklayın):</translation>
     <message>
         <source>Multiple notification color:</source>
         <translation>Çoklu bildirim rengi:</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Blinking speed:</source>
@@ -311,16 +311,8 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation>Sistem tepsisi simgesini yapın</translation>
     </message>
     <message>
-        <source>Check for new updates when Birdtray starts</source>
-        <translation>Birdtray başladığında yeni güncellemeleri kontrol edin</translation>
-    </message>
-    <message>
         <source>Check for new updates on startup</source>
         <translation>Başlangıçta yeni güncellemeleri kontrol edin</translation>
-    </message>
-    <message>
-        <source>Check for a new Birdtray version</source>
-        <translation>Yeni Birdtray sürümünü kontrol edin</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -437,20 +429,12 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation>Okunmamış değişiklik cmd&apos;si:</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value, and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation>Simge bu dosyadan yüklenemedi. Simgeyi bir görüntü düzenleme aracına yüklemeyi ve farklı bir formatta kaydetmeyi deneyin.</translation>
-    </message>
-    <message>
-        <source>CheckBox</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -473,6 +457,41 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation>Thunderbird&apos;ü gizlemek için Birdtray simgesine tıkladığınızda, şu anda okunmamış tüm e-postaları yok sayarak simgeyi sıfırlayın</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check for new updates when Birdtray starts.</source>
+        <translation>Birdtray başladığında yeni güncellemeleri kontrol edin.</translation>
+    </message>
+    <message>
+        <source>Check for a new Birdtray version.</source>
+        <translation>Yeni Birdtray sürümünü kontrol edin.</translation>
+    </message>
+</context>
+<context>
+    <name>Log</name>
+    <message>
+        <source>Failed to open log file %s: %s</source>
+        <translation>Log dosyası açılamadı %s: %s</translation>
+    </message>
+    <message>
+        <source>Fatal</source>
+        <translation>Kritik</translation>
+    </message>
+    <message>
+        <source>Fatal error: %1
+
+Log file is written into file %2</source>
+        <translation>Kritik hata: %1
+
+Log dosyası %2 dosyasına yazıldı</translation>
     </message>
 </context>
 <context>
@@ -535,6 +554,17 @@ Lütfen doğru profiller dizinini seçtiğinizden emin olun.</translation>
     </message>
 </context>
 <context>
+    <name>ModelAccountTree</name>
+    <message>
+        <source>Account</source>
+        <translation>Hesap</translation>
+    </message>
+    <message>
+        <source>Notification color</source>
+        <translation>Bildirim rengi</translation>
+    </message>
+</context>
+<context>
     <name>ModelNewEmails</name>
     <message>
         <source>Menu entry item</source>
@@ -542,22 +572,7 @@ Lütfen doğru profiller dizinini seçtiğinizden emin olun.</translation>
     </message>
 </context>
 <context>
-    <name>QApplication</name>
-    <message>
-        <source>Fatal</source>
-        <translation>Kritik</translation>
-    </message>
-    <message>
-        <source>Sorry, system tray cannot be controlled through this add-on on your operating system.</source>
-        <translation>Üzgünüz, sistem tepsisi işletim sisteminizdeki bu eklenti üzerinden kontrol edilemez.</translation>
-    </message>
-</context>
-<context>
-    <name>QCoreApplication</name>
-    <message>
-        <source>Cannot load default system tray icon.</source>
-        <translation>Varsayılan sistem tepsisi simgesi yüklenemiyor.</translation>
-    </message>
+    <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
         <translation>Dosya açılamadı: </translation>
@@ -590,37 +605,9 @@ Lütfen doğru profiller dizinini seçtiğinizden emin olun.</translation>
         <source>Unexpected end of group.</source>
         <translation>Grubun beklenmedik sonu.</translation>
     </message>
-    <message>
-        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Sqlite ayrıştırıcısını kullanarak bir veya daha fazla posta klasörünün izlenmesini yapılandırmıştınız. Bu yöntem kaldırılmıştır. Yapılandırmalarınız Mork ayrıştırıcısına taşındı, ancak yapılandırılmış bazı posta klasörleri bulunamadı.</translation>
-    </message>
-    <message>
-        <source>Sqlite based accounts migrated</source>
-        <translation>Sqlite tabanlı hesaplar birleştirildi</translation>
-    </message>
-    <message>
-        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Sqlite ayrıştırıcısını kullanarak bir veya daha fazla posta hesabının izlenmesini yapılandırmıştınız. Bu yöntem kaldırılmıştır. Konfigürasyonlarınız Mork ayrıştırıcısına taşındı. Lütfen tüm hesapların doğru şekilde eşlendiğini doğrulayın.</translation>
-    </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Account</source>
-        <translation>Hesap</translation>
-    </message>
-    <message>
-        <source>Notification color</source>
-        <translation>Bildirim rengi</translation>
-    </message>
-    <message>
-        <source>Fatal error: %1
-
-Log file is written into file %2</source>
-        <translation>Kritik hata: %1
-
-Log dosyası %2 dosyasına yazıldı</translation>
-    </message>
+    <name>Settings</name>
     <message>
         <source>Could not save the settings</source>
         <translation>Ayarlar kaydedilemedi</translation>
@@ -632,8 +619,20 @@ Log dosyası %2 dosyasına yazıldı</translation>
 %2</translation>
     </message>
     <message>
-        <source>Failed to open log file %s: %s</source>
-        <translation>Log dosyası açılamadı %s: %s</translation>
+        <source>Sqlite based accounts migrated</source>
+        <translation>Sqlite tabanlı hesaplar birleştirildi</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
+        <translation>Sqlite ayrıştırıcısını kullanarak bir veya daha fazla posta klasörünün izlenmesini yapılandırmıştınız. Bu yöntem kaldırılmıştır. Yapılandırmalarınız Mork ayrıştırıcısına taşındı, ancak yapılandırılmış bazı posta klasörleri bulunamadı.</translation>
+    </message>
+    <message>
+        <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
+        <translation>Sqlite ayrıştırıcısını kullanarak bir veya daha fazla posta hesabının izlenmesini yapılandırmıştınız. Bu yöntem kaldırılmıştır. Konfigürasyonlarınız Mork ayrıştırıcısına taşındı. Lütfen tüm hesapların doğru şekilde eşlendiğini doğrulayın.</translation>
+    </message>
+    <message>
+        <source>Cannot load default system tray icon.</source>
+        <translation>Varsayılan sistem tepsisi simgesi yüklenemiyor.</translation>
     </message>
 </context>
 <context>
@@ -781,12 +780,12 @@ Log dosyası %2 dosyasına yazıldı</translation>
         <translation>Bu sürümü yok say</translation>
     </message>
     <message>
-        <source>Update and Restart</source>
-        <translation>Güncelle ve Yeniden Başlat</translation>
-    </message>
-    <message>
         <source>ca. %1 Mb</source>
         <translation>%1 Mb</translation>
+    </message>
+    <message>
+        <source>Update and restart</source>
+        <translation>Güncelle ve Yeniden Başlat</translation>
     </message>
 </context>
 <context>
@@ -806,10 +805,6 @@ Log dosyası %2 dosyasına yazıldı</translation>
     <message>
         <source>Downloading Birdtray installer...</source>
         <translation>Birdtray yükleyicisi indiriliyor ...</translation>
-    </message>
-    <message>
-        <source>Update and Restart</source>
-        <translation>Güncelle ve Yeniden Başlat</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -39,7 +39,7 @@ void UpdateDialog::show(const QString &newVersion, const QString &changelog,
     if (estimatedSize == (qulonglong) -1) {
         downloadButton->setText(tr("Download"));
     } else {
-        downloadButton->setText(tr("Update and Restart"));
+        downloadButton->setText(tr("Update and restart"));
     }
     if (estimatedSize == 0 || estimatedSize == (qulonglong) -1) {
         ui->estimatedSizeDescLabel->hide();

--- a/src/updatedownloaddialog.cpp
+++ b/src/updatedownloaddialog.cpp
@@ -46,7 +46,7 @@ void UpdateDownloadDialog::onDownloadComplete() {
     taskBarButton->progress()->setRange(0, 100);
     taskBarButton->progress()->setValue(100);
 #endif
-    actionButton->setText(tr("Update and Restart"));
+    actionButton->setText( QCoreApplication::translate("UpdateDialog", "Update and restart"));
     ui->label->setText(tr("Download finished. Restart and update Birdtray?"));
     show();
     raise();


### PR DESCRIPTION
This pull request improves the translations in a few ways:

* Move translations from the `QCoreApplication`, `QApplication` and `QObject` context into more descriptive contexts.
* Reword some of the English texts, make sure that each sentence displayed in a tool-tip ends with a dot.
* Improve the translation checker:
    - Now also runs for the Spanish translation.
    - Can handle invalid XML better now.
    - Now outputs file and line information in a more human readable format, so it can be used locally on the command line more easily.
* Ignore `unfinished_translation` warnings, to keep the focus on the real warnings.
* Add some additional checks to verify translation filenames and registration in `CMakeLists.txt`.
* Specify the correct line endings for translation files in the `.gitattributes`. The `lupdate` tool always uses `LF`, even if it is run on Windows. On the other hand, the installer translations are for Windows, so they should be `CRLF`.

@gyunaev As this changes C++ code and some of the English source strings I would appreciate if you could have a look at it.