### PR TITLE
Use the FollowRedirectsAttribute to automatically follow http redirects

### DIFF
--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -143,7 +143,9 @@ void AutoUpdater::startDownload() {
             downloadProcessDialog->reset();
         }
         downloadProcessDialog->show();
-        QNetworkReply* reply = networkAccessManager->get(QNetworkRequest(downloadUrl));
+        QNetworkRequest request(downloadUrl);
+        request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+        QNetworkReply* reply = networkAccessManager->get(request);
         connect(reply, &QNetworkReply::downloadProgress, this,
                 [=](qint64 bytesReceived, qint64 bytesTotal) {
                     AutoUpdater::onDownloadProgress(reply, bytesReceived, bytesTotal);
@@ -209,20 +211,7 @@ void AutoUpdater::onReleaseInfoRequestFinished(QNetworkReply* result) {
 }
 
 void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
-    QVariant redirectionTarget = result->attribute(QNetworkRequest::RedirectionTargetAttribute);
-    if (!redirectionTarget.isNull()) {
-        QUrl newUrl = resolveRedirectDownloadUrl(redirectionTarget.toUrl());
-        if (newUrl.isValid()) {
-            downloadUrl = newUrl;
-            startDownload();
-            return;
-        } else {
-            QMessageBox::critical(
-                    nullptr, tr("Installer download failed"),
-                    tr("Failed to download the Birdtray installer:\n") + tr("Invalid redirect: ")
-                    + redirectionTarget.toString(), QMessageBox::StandardButton::Abort);
-        }
-    } else if (installerFile.write(result->readAll()) == -1) {
+    if (installerFile.write(result->readAll()) == -1) {
         QString errorMessage(tr("Failed to save the Birdtray installer:\n")
                              + installerFile.errorString());
         installerFile.remove();
@@ -267,19 +256,6 @@ void AutoUpdater::onDownloadProgress(QNetworkReply* result, qint64 bytesReceived
             downloadProcessDialog->onDownloadProgress(bytesReceived, bytesTotal);
         }
     }
-}
-
-QUrl AutoUpdater::resolveRedirectDownloadUrl(const QUrl &redirectUrl) const {
-    QUrl newUrl;
-    if (redirectUrl.isRelative()) {
-        newUrl = downloadUrl.resolved(redirectUrl);
-    } else {
-        newUrl = redirectUrl;
-    }
-    if (!newUrl.isEmpty() && newUrl != downloadUrl) {
-        return newUrl;
-    }
-    return QUrl();
 }
 
 bool AutoUpdater::versionGrater(const int (&version)[3], const int (&other)[3]) {

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -91,15 +91,6 @@ private:
     void onInstallerDownloadFinished(QNetworkReply* result);
     
     /**
-     * Resolve a redirect url while downloading the installer.
-     * Blocks redirect loops.
-     *
-     * @param redirectUrl The new redirect url.
-     * @return The resolved url to redirect to or an invalid url, if the redirect is not valid.
-     */
-    QUrl resolveRedirectDownloadUrl(const QUrl &redirectUrl) const;
-    
-    /**
      * Check if the first version is greater than the second version
      * according to semantic versioning.
      *

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -26,10 +26,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>Herunterladen der Installationsdatei ist fehlgeschlagen</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Ungültige Weiterleitung: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Aktualisierung fehlgeschlagen</translation>
     </message>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -23,10 +23,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -26,10 +26,6 @@ OpenSSL podría no estar instalado.</translation>
         <translation>La descarga del instaldor ha fallado</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Redireccionamiento inválido: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>La actualización ha fallado</translation>
     </message>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -26,10 +26,6 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>Download del programma di installazione non riuscito</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Reindirizzamento non valido: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Aggiornamento non riuscito</translation>
     </message>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -26,10 +26,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
         <translation>Downloaden mislukt</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Ongeldige doorverwijzing: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Update mislukt</translation>
     </message>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -26,10 +26,6 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>Pobieranie instalatora nie powiodło się</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Nieprawidłowe przekierowanie: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Aktualizacja nieudana</translation>
     </message>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -26,10 +26,6 @@ OpenSSL não deve estar instalado.</translation>
         <translation>Falha ao baixar instalador</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Redirecionamento inválido: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Falha na atualização</translation>
     </message>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -26,10 +26,6 @@ OpenSSL might not be installed.</source>
         <translation>Ошибка загрузки установщика</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Ошибка перенаправления: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Ошибка обновления</translation>
     </message>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -26,10 +26,6 @@ OpenSSL kanske inte är installerad.</translation>
         <translation>Kunde inte ladda ner installationsprogrammet</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Ogiltig omdirigering: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Uppdatering misslyckades</translation>
     </message>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -26,10 +26,6 @@ OpenSSL yüklenmemiş olabilir.</translation>
         <translation>Yükleyici indirilemedi</translation>
     </message>
     <message>
-        <source>Invalid redirect: </source>
-        <translation>Geçersiz yönlendirme: </translation>
-    </message>
-    <message>
         <source>Update failed</source>
         <translation>Güncelleştirme başarısız</translation>
     </message>


### PR DESCRIPTION
We explicitly don't allow redirects on the initial request to the GitHub API endpoint, because we can assume that never changes.