### PR TITLE
Fix abort on Birdtray exit

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -99,9 +99,11 @@ TrayIcon::~TrayIcon() {
         networkConnectivityManager->deleteLater();
         networkConnectivityManager = nullptr;
     }
-    if (mUnreadMonitor != nullptr && mUnreadMonitor->isRunning()) {
-        mUnreadMonitor->quit();
-        mUnreadMonitor->wait();
+    if (mUnreadMonitor != nullptr) {
+        if (mUnreadMonitor->isRunning()) {
+            mUnreadMonitor->quit();
+            mUnreadMonitor->wait();
+        }
         mUnreadMonitor->deleteLater();
         mUnreadMonitor = nullptr;
     }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -99,7 +99,9 @@ TrayIcon::~TrayIcon() {
         networkConnectivityManager->deleteLater();
         networkConnectivityManager = nullptr;
     }
-    if (mUnreadMonitor != nullptr) {
+    if (mUnreadMonitor != nullptr && mUnreadMonitor->isRunning()) {
+        mUnreadMonitor->quit();
+        mUnreadMonitor->wait();
         mUnreadMonitor->deleteLater();
         mUnreadMonitor = nullptr;
     }

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -37,13 +37,6 @@ UnreadMonitor::UnreadMonitor( TrayIcon * parent )
     }
 }
 
-UnreadMonitor::~UnreadMonitor() {
-    if (isRunning()) {
-        quit();
-        wait();
-    }
-}
-
 void UnreadMonitor::run()
 {
     // Start it as soon as thread starts its event loop

--- a/src/unreadmonitor.h
+++ b/src/unreadmonitor.h
@@ -17,7 +17,6 @@ class UnreadMonitor : public QThread
 
     public:
         UnreadMonitor( TrayIcon * parent );
-        virtual ~UnreadMonitor();
 
         // Thread run function
         virtual void run() override;


### PR DESCRIPTION
Commit b789761 moved the `UnreadMonitor` thread object to itself. This caused the wait in the destructor to fail:
```
warning: QThread::wait: Thread tried to wait on itself
```
resulting in the thread being destructed while it still running and Birdtray aborting:
```
warning: QThread: Destroyed while thread is still running
```
This resolves the issue by waiting for and destroying the `UnreadMonitor` on the main thread in the `TrayIcon`.