### PR TITLE
Add Qt 5.15.1 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,14 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x64]
-        qt_version: [5.9.9, 5.14.1]
+        qt_version: [5.9.9, 5.15.1]
         include:
           - os: windows-latest
             arch: x86
-            qt_compile_suite: win32_msvc2017
+            qt_compile_suite: win32_msvc2019
           - os: windows-latest
             arch: x64
-            qt_compile_suite: win64_msvc2017_64
+            qt_compile_suite: win64_msvc2019_64
         exclude:
           # We only want to test for the latest version of Qt on Windows
           - os: windows-latest

--- a/src/autoupdater.cpp
+++ b/src/autoupdater.cpp
@@ -229,7 +229,7 @@ void AutoUpdater::onInstallerDownloadFinished(QNetworkReply* result) {
             if (downloadProcessDialog->exec() == QDialog::Rejected
                 || downloadProcessDialog->wasCanceled()) {
                 installerFile.remove();
-            } else if (!QProcess::startDetached(installerFile.fileName())) {
+            } else if (!QProcess::startDetached(installerFile.fileName(), {})) {
                 QMessageBox::critical(
                         nullptr, tr("Update failed"),
                         tr("Failed to start the Birdtray installer."),

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -6,7 +6,9 @@
 #include <QUrl>
 #include <QFile>
 QT_WARNING_PUSH
-QT_WARNING_DISABLE_DEPRECATED
+#ifdef QT_WARNING_DISABLE_DEPRECATED
+  QT_WARNING_DISABLE_DEPRECATED
+#endif
 #include <QNetworkAccessManager>
 QT_WARNING_POP
 #include "updatedialog.h"

--- a/src/autoupdater.h
+++ b/src/autoupdater.h
@@ -1,11 +1,14 @@
 #ifndef AUTO_UPDATER_H
 #define AUTO_UPDATER_H
 
-#include <QNetworkAccessManager>
 #include <QRegularExpression>
 #include <QtWidgets/QProgressDialog>
 #include <QUrl>
 #include <QFile>
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+#include <QNetworkAccessManager>
+QT_WARNING_POP
 #include "updatedialog.h"
 #include "updatedownloaddialog.h"
 

--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -650,7 +650,7 @@ void MorkParser::parseGroup()
     QString endAbort = "@$$}~abort~" + id + "}@";
 
     // Find the end of this group
-    int ofst = morkData_.indexOf( endAbort, morkPos_ );
+    int ofst = morkData_.indexOf( endAbort.toUtf8(), morkPos_ );
 
     if ( ofst != -1 )
     {
@@ -660,7 +660,7 @@ void MorkParser::parseGroup()
     }
 
     // Now look up for success
-    ofst = morkData_.indexOf( endCommit, morkPos_ );
+    ofst = morkData_.indexOf( endCommit.toUtf8(), morkPos_ );
 
     if (ofst == -1) {
         throw MorkParserException(QCoreApplication::translate(

--- a/src/setting_newemail.cpp
+++ b/src/setting_newemail.cpp
@@ -2,6 +2,9 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QTemporaryFile>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#  include <QCborValue>
+#endif
 
 #include "setting_newemail.h"
 #include "dialogaddeditnewemail.h"

--- a/src/setting_newemail.cpp
+++ b/src/setting_newemail.cpp
@@ -50,12 +50,20 @@ QJsonObject Setting_NewEmail::toJSON() const
 
 Setting_NewEmail Setting_NewEmail::fromByteArray(const QByteArray &str)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    QCborParserError parserError;
+    QCborValue object = QCborValue::fromCbor(str, &parserError);
+    if (parserError.error != QCborError::NoError) {
+        return Setting_NewEmail();
+    }
+    return fromJSON(object.toJsonValue().toObject());
+#else
+    // QJsonDocument is deprecated since Qt 5.15
     QJsonDocument doc = QJsonDocument::fromBinaryData( str );
-
     if ( !doc.isObject() )
         return Setting_NewEmail();
-
     return fromJSON( doc.object() );
+#endif
 }
 
 bool Setting_NewEmail::edit()

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -692,10 +692,7 @@ void TrayIcon::startThunderbird()
 
     mThunderbirdProcess = new QProcess();
     connect( mThunderbirdProcess, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(tbProcessFinished(int,QProcess::ExitStatus)) );
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     connect( mThunderbirdProcess, &QProcess::errorOccurred, this, &TrayIcon::tbProcessError );
-#endif
 
     mThunderbirdProcess->start(executable, args);
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -142,7 +142,7 @@ void TrayIcon::unreadCounterUpdate( unsigned int total, QColor color )
         // Replace the %OLD% with the old unread count
         cmdline.replace( "%OLD%", QString::number( mUnreadCounter ) );
 
-        if ( !QProcess::startDetached( cmdline ) )
+        if ( !QProcess::startDetached( cmdline, {} ) ) // FIXME: Arguments
             Log::debug( "Failed to execute hook command %s", qPrintable( cmdline ) );
         else
             Log::debug( "Executing hook command %s", qPrintable( cmdline ) );

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -7,7 +7,6 @@
 #include <QImage>
 #include <QProcess>
 #include <QSystemTrayIcon>
-#include <QtNetwork/QNetworkConfigurationManager>
 #ifdef Q_OS_WIN
 #  include "processhandle.h"
 #endif /* Q_OS_WIN */

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -220,11 +220,8 @@ class TrayIcon : public QSystemTrayIcon
         // A reference to a Thunderbird updater process.
         ProcessHandle* mThunderbirdUpdaterProcess;
 #endif /* Q_OS_WIN */
-        
-        /**
-         * A manager to check for network connectivity.
-         */
-        QNetworkConfigurationManager* networkConnectivityManager = nullptr;
+        // A timer that is used to retry for automatic update checks if they fail.
+        QTimer updateRetryTimer;
         
         /**
          * Whether we have received data about unread emails yet.


### PR DESCRIPTION
This pull request adds support for Qt `5.15.1`.
There is still a big problem that we need to discuss:

`QProcess::startDetached(command)` has become deprecated and might be removed in future Qt versions. We need to use `QProcess::startDetached(executable, arguments[])`. This prevents us from passing in the whole shell command as a whole, we are required to at least split the executable path from the arguments. This is especially problematic for the new unread counter change hook, because we allow entering the full shell command: https://github.com/gyunaev/birdtray/blob/9ff57bb54c8e09c0a4300d4906e1b09ccd184b8c/src/trayicon.cpp#L136-L144

We need to be able to differentiate between the executable and the arguments. I propose adding a custom widget like this:

![The proposed new widget](https://user-images.githubusercontent.com/6966049/97817161-d9d3a680-1c9a-11eb-83e3-b72f4626a13d.PNG)

A click on the configure button opens a dialog that allows to configure arguments and environment variables. I based the dialog on UI elements from the JetBrains Products, which I find very intuitive to use. This would also allow us to implement #313. We could use the same widget in the `Advanced` settings tab for the Thunderbird command.

@gyunaev What are your thoughts on this? I know you want to keep things as simple as possible and I think I can implement this without to much complexity. The alternative would be to just use `Utils::splitCommandLine` and hope the user doesn't input anything crazy.
