### PR TITLE
Search for Thunderbird in %ProgramFiles% before %ProgramFiles(x86)%

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -198,6 +198,10 @@ QStringList Utils::getDefaultThunderbirdCommand() {
 #if defined (OPT_THUNDERBIRD_CMDLINE)
     return Utils::splitCommandLine( OPT_THUNDERBIRD_CMDLINE );
 #elif defined (Q_OS_WIN)
+    if (QFile::exists(Utils::expandPath(
+            R"("%ProgramFiles%\Mozilla Thunderbird\thunderbird.exe")"))) {
+        return {R"("%ProgramFiles%\Mozilla Thunderbird\thunderbird.exe")"};
+    }
     return {R"("%ProgramFiles(x86)%\Mozilla Thunderbird\thunderbird.exe")"};
 #else
     return { "/usr/bin/thunderbird" };


### PR DESCRIPTION
Thunderbird started distributing 64 bit versions a while ago. This adds support for the additional Thunderbird executable location.