### PR TITLE
Don't test compilation with Qt5.6 anymore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x64]
-        qt_version: [5.6, 5.9, 5.14.1]
+        qt_version: [5.9, 5.14.1]
         include:
           - os: windows-latest
             arch: x86
@@ -20,8 +20,6 @@ jobs:
             qt_compile_suite: win64_msvc2017_64
         exclude:
           # We only want to test for the latest version of Qt on Windows
-          - os: windows-latest
-            qt_version: 5.6
           - os: windows-latest
             qt_version: 5.9
           # We only compile for the current architecture of the runner for Linux


### PR DESCRIPTION
Support for Qt5.6 ended in March 2019. The Qt team has now removed it from the [online repository](https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/), so it's no longer possible to automatically download it on the GitHub Actions runner.

This fixes the failing build.

The next course of action is to raise the minimum Qt version to 5.9. Is that ok with you, @gyunaev?