### PR TITLE
Add option to ignore unread emails on showing Thunderbird

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -76,10 +76,11 @@ DialogSettings::DialogSettings( QWidget *parent)
     spinUnreadOpacityLevel->setValue( settings->mUnreadOpacityLevel * 100 );
     spinThunderbirdStartDelay->setValue( settings->mLaunchThunderbirdDelay );
     boxShowUnreadCount->setChecked( settings->mShowUnreadEmailCount );
-    ignoreStartupMailCountBox->setChecked(settings->ignoreStartUnreadCount);
+    ignoreMailCountOnStartupBox->setChecked(settings->ignoreUnreadCountOnStart);
+    ignoreMailCountOnShowBox->setChecked(settings->ignoreUnreadCountOnShow);
+    ignoreMailCountOnHideBox->setChecked(settings->ignoreUnreadCountOnHide);
     onlyShowIconOnNewMail->setChecked(settings->onlyShowIconOnUnreadMessages);
     leProcessRunOnCountChange->setText( settings->mProcessRunOnCountChange );
-    boxIgnoreEmailsOnMinimize->setChecked(settings->mForceIgnoreUnreadEmailsOnMinimize);
     boxSupportNonNetwmCompliant->setChecked( settings->mIgnoreNETWMhints );
 
     if ( settings->mIndexFilesRereadIntervalSec > 0 )
@@ -155,7 +156,6 @@ void DialogSettings::accept()
     settings->mNotificationFontWeight = qMin(99, (int) (notificationFontWeight->value() / 2));
     settings->mExitThunderbirdWhenQuit = boxStopThunderbirdOnExit->isChecked();
     settings->mAllowSuppressingUnreads = boxAllowSuppression->isChecked();
-    settings->mForceIgnoreUnreadEmailsOnMinimize = boxIgnoreEmailsOnMinimize->isChecked();
 
     settings->mMonitorThunderbirdWindow = boxMonitorThunderbirdWindow->isChecked();    
     settings->mNotificationMinimumFontSize = spinMinimumFontSize->value();
@@ -168,7 +168,12 @@ void DialogSettings::accept()
     settings->mUnreadOpacityLevel = (double) spinUnreadOpacityLevel->value() / 100.0;
     settings->mLaunchThunderbirdDelay = spinThunderbirdStartDelay->value();
     settings->mShowUnreadEmailCount = boxShowUnreadCount->isChecked();
-    settings->ignoreStartUnreadCount = ignoreStartupMailCountBox->isChecked();
+    settings->ignoreUnreadCountOnStart = settings->mAllowSuppressingUnreads &&
+            ignoreMailCountOnStartupBox->isChecked();
+    settings->ignoreUnreadCountOnShow = settings->mAllowSuppressingUnreads &&
+            ignoreMailCountOnShowBox->isChecked();
+    settings->ignoreUnreadCountOnHide = settings->mAllowSuppressingUnreads &&
+            ignoreMailCountOnHideBox->isChecked();
     settings->onlyShowIconOnUnreadMessages = onlyShowIconOnNewMail->isChecked();
     settings->mProcessRunOnCountChange = leProcessRunOnCountChange->text();
     settings->mIgnoreNETWMhints = boxSupportNonNetwmCompliant->isChecked();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -349,29 +349,47 @@
             </item>
            </layout>
           </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="boxAllowSuppression">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="title">
+          <string>Allow ignoring the current unread email counter</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
-            <item>
-             <widget class="QCheckBox" name="boxAllowSuppression">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Allow ignoring the current unread email counter</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="ignoreStartupMailCountBox">
-              <property name="toolTip">
-               <string>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</string>
-              </property>
-              <property name="text">
-               <string>Ignore unread emails at startup</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QCheckBox" name="ignoreMailCountOnStartupBox">
+            <property name="toolTip">
+             <string>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</string>
+            </property>
+            <property name="text">
+             <string>At startup</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ignoreMailCountOnHideBox">
+            <property name="text">
+             <string>When hiding Thunderbird</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ignoreMailCountOnShowBox">
+            <property name="text">
+             <string>When showing Thunderbird</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -557,16 +575,6 @@
              </spacer>
             </item>
            </layout>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="boxIgnoreEmailsOnMinimize">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -1086,7 +1094,10 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnAccountEdit</tabstop>
   <tabstop>btnAccountRemove</tabstop>
   <tabstop>boxAllowSuppression</tabstop>
-  <tabstop>ignoreStartupMailCountBox</tabstop>
+  <tabstop>ignoreMailCountOnStartupBox</tabstop>
+  <tabstop>ignoreMailCountOnHideBox</tabstop>
+  <tabstop>ignoreMailCountOnShowBox</tabstop>
+  <tabstop>leProcessRunOnCountChange</tabstop>
   <tabstop>boxLaunchThunderbirdAtStart</tabstop>
   <tabstop>spinThunderbirdStartDelay</tabstop>
   <tabstop>boxHideWindowAtStart</tabstop>
@@ -1105,11 +1116,16 @@ p, li { white-space: pre-wrap; }
   <tabstop>leThunderbirdWindowMatch</tabstop>
   <tabstop>spinMinimumFontSize</tabstop>
   <tabstop>boxBlinkingUsesAlpha</tabstop>
+  <tabstop>boxSupportNonNetwmCompliant</tabstop>
   <tabstop>spinUnreadOpacityLevel</tabstop>
   <tabstop>onlyShowIconOnNewMail</tabstop>
   <tabstop>checkUpdateOnStartup</tabstop>
   <tabstop>checkUpdateButton</tabstop>
+  <tabstop>btnShowLogWindow</tabstop>
+  <tabstop>boxForceReread</tabstop>
+  <tabstop>spinForceRereadSeconds</tabstop>
   <tabstop>browserAbout</tabstop>
+  <tabstop>translatorsButton</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>
@@ -1241,22 +1257,6 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>330</x>
      <y>333</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>boxShowHideThunderbird</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>boxIgnoreEmailsOnMinimize</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>98</x>
-     <y>153</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>80</x>
-     <y>280</y>
     </hint>
    </hints>
   </connection>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -54,7 +54,9 @@ Settings::Settings()
     mAllowSuppressingUnreads = false;
     mLaunchThunderbirdDelay = 0;
     mShowUnreadEmailCount = true;
-    ignoreStartUnreadCount = false;
+    ignoreUnreadCountOnStart = false;
+    ignoreUnreadCountOnShow = false;
+    ignoreUnreadCountOnHide = false;
     showDialogIfNoAccountsConfigured = true;
     mThunderbirdWindowMatch = " Mozilla Thunderbird";
     mNotificationMinimumFontSize = 4;
@@ -67,7 +69,6 @@ Settings::Settings()
     mNewEmailMenuEnabled = false;
     mIndexFilesRereadIntervalSec = 0;
     mThunderbirdCmdLine = Utils::getDefaultThunderbirdCommand();
-    mForceIgnoreUnreadEmailsOnMinimize = false;
     mIgnoreNETWMhints = false;
 }
 
@@ -96,9 +97,10 @@ void Settings::save()
     out[ "common/allowsuppressingunread" ] = mAllowSuppressingUnreads;
     out[ "common/launchthunderbirddelay" ] = mLaunchThunderbirdDelay;
     out[ "common/showunreademailcount" ] = mShowUnreadEmailCount;
-    out[ "common/ignoreStartUnreadCount" ] = ignoreStartUnreadCount;
+    out[ "common/ignoreStartUnreadCount" ] = ignoreUnreadCountOnStart;
+    out[ "common/ignoreShowUnreadCount" ] = ignoreUnreadCountOnShow;
+    out[ "common/forceIgnoreUnreadEmailsOnMinimize" ] = ignoreUnreadCountOnHide;
     out[ "common/showDialogIfNoAccountsConfigured"  ] = showDialogIfNoAccountsConfigured;
-    out[ "common/forceIgnoreUnreadEmailsOnMinimize"  ] = mForceIgnoreUnreadEmailsOnMinimize;
 
     out[ "advanced/tbcmdline" ] = QJsonArray::fromStringList( mThunderbirdCmdLine );
     out[ "advanced/tbwindowmatch" ] = mThunderbirdWindowMatch;
@@ -231,9 +233,13 @@ void Settings::fromJSON( const QJsonObject& settings )
     mAllowSuppressingUnreads = settings.value("common/allowsuppressingunread").toBool();
     mLaunchThunderbirdDelay = settings.value("common/launchthunderbirddelay").toInt();
     mShowUnreadEmailCount = settings.value("common/showunreademailcount").toBool();
-    ignoreStartUnreadCount = settings.value("common/ignoreStartUnreadCount").toBool();
+    ignoreUnreadCountOnStart = mAllowSuppressingUnreads &&
+            settings.value("common/ignoreStartUnreadCount").toBool();
+    ignoreUnreadCountOnShow = mAllowSuppressingUnreads &&
+            settings.value("common/ignoreShowUnreadCount").toBool();
+    ignoreUnreadCountOnHide = mAllowSuppressingUnreads &&
+            settings.value("common/forceIgnoreUnreadEmailsOnMinimize").toBool();
     showDialogIfNoAccountsConfigured = settings.value("common/showDialogIfNoAccountsConfigured").toBool();
-    mForceIgnoreUnreadEmailsOnMinimize = settings.value( "common/forceIgnoreUnreadEmailsOnMinimize" ).toBool();
 
     mThunderbirdWindowMatch = settings.value("advanced/tbwindowmatch").toString();
     mNotificationMinimumFontSize = settings.value("advanced/notificationfontminsize").toInt();
@@ -329,8 +335,12 @@ void Settings::fromQSettings( QSettings * psettings )
             "common/launchthunderbirddelay", mLaunchThunderbirdDelay ).toInt();
     mShowUnreadEmailCount = settings.value(
             "common/showunreademailcount", mShowUnreadEmailCount ).toBool();
-    ignoreStartUnreadCount = settings.value(
-            "common/ignoreStartUnreadCount", ignoreStartUnreadCount).toBool();
+    ignoreUnreadCountOnStart = mAllowSuppressingUnreads && settings.value(
+            "common/ignoreStartUnreadCount", ignoreUnreadCountOnStart).toBool();
+    ignoreUnreadCountOnShow = mAllowSuppressingUnreads && settings.value(
+            "common/ignoreShowUnreadCount", ignoreUnreadCountOnShow).toBool();
+    ignoreUnreadCountOnHide = mAllowSuppressingUnreads && settings.value(
+            "common/forceIgnoreUnreadEmailsOnMinimize", ignoreUnreadCountOnHide).toBool();
     showDialogIfNoAccountsConfigured = settings.value(
             "common/showDialogIfNoAccountsConfigured", showDialogIfNoAccountsConfigured).toBool();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -102,14 +102,21 @@ class Settings
 
         // Whether to show the unread email count
         bool    mShowUnreadEmailCount;
-
-        // Whether to ignore all currently unread emails if Thunderbird is hidden by Birdtray
-        bool    mForceIgnoreUnreadEmailsOnMinimize;
         
         /**
          * Ignore the total number of unread emails that are present at startup.
          */
-        bool    ignoreStartUnreadCount;
+        bool    ignoreUnreadCountOnStart;
+        
+        /**
+         * Ignore the number of unread emails when showing Thunderbird.
+         */
+        bool    ignoreUnreadCountOnShow;
+    
+        /**
+         * Ignore the number of unread emails when hiding Thunderbird.
+         */
+        bool    ignoreUnreadCountOnHide;
         
         /**
          * Enables or disabled the dialog on startup that shows if no accounts were configured.

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -356,10 +356,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dies ist die komplette Befehlszeile (mit Argumenten), welche zum Starten von Thunderbird genutzt wird. Argumente müssen mit Leerzeichen getrennt werden, allerdings sind Leerzeichen in Anführungszeichen erlaubt. Z. B.: &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ungelesene E-Mails ignorieren, die beim Starten bereits vorhanden sind</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Alle ungelesenen E-Mails ignorieren, die beim Starten von Birdtray bereits vorhanden sind. Nur neue E-Mails werden bei der Berechnung der Anzahl ungelesener E-Mails beachtet.</translation>
     </message>
@@ -399,10 +395,6 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, the Birdtray icon will show the number of unread emails.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If it is unchecked, no count will be shown, and you will only know about unread emails because of the blinking or different icon, depending on your settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Option aktiviert ist, wird die Anzahl der ungelesenen E-Mails im Birdtray-Symbol angezeigt.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Wenn die Option deaktiviert ist, wird keine Anzahl angezeigt. Sie werden dann, abhängig von Ihren Einstellungen, nur noch durch das blinkende oder geänderte Symbol auf neue E-Mails aufmerksam gemacht.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn aktiviert fügt diese Option dem Kontextmenü die Aktion &quot;Ungelesene E-Mails ignorieren&quot; hinzu. Diese Aktion erlaubt das Ignorieren der momentanen ungelesenen E-Mails. Birdtray ignoriert dann alle zu dem Zeitpunkt ungelesene E-Mails und zeigt nur noch neu hinzukommende E-Mails an.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Gibt es zum Beispiel gerade 10 ungelesene E-Mails und Sie klicken auf die Aktion &quot;Ignorieren&quot;, wird Birdtray keinen Indikator für ungelesene E-Mails anzeigen, solange die Anzahl der ungelesenen E-Mails bei 10 bleibt. Sobald eine neue E-Mail empfangen wird und es somit 11 ungelesene E-Mails gibt, zeigt Birdtray eine ungelesene E-Mail an.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Wenn die Anzahl der ungelesenen E-Mails weniger wird als die ursprünglich ignorierte Anzahl, wird die Anzahl ignorierter E-Mails auf null zurückgesetzt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Translations are powered by the community:</source>
@@ -465,10 +457,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Vielen Dank für Ihre Unterstützung!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Ignoriere alle momentan ungelesenen E-Mails, wenn Thunderbird über das Birdtray Symbol augeblendet wird</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das verändert die Schriftdicke, d. h. macht die Schrift fett.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -486,11 +474,27 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Support non-NETWM compliant WMs</source>
-        <translation type="unfinished"></translation>
+        <translation>Unterstütze nicht NETWM konforme Fenstermanager</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ist Ihr Desktop-Manager nicht komplett NETWM konform, müssen Sie diesen Auswahlkasten gegebenenfalls aktivieren, damit Birdtray das Fenster von Thunderbird erkennen, minimieren und verstecken kann.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation>Beim Start</translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation>Beim Verstecken von Thunderbird</translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation>Beim Anzeigen von Thunderbird</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn aktiviert fügt diese Option dem Kontextmenü die Aktion &quot;Ungelesene E-Mails ignorieren&quot; hinzu. Diese Aktion erlaubt das Ignorieren der momentanen ungelesenen E-Mails. Birdtray ignoriert dann alle zu dem Zeitpunkt ungelesene E-Mails und zeigt nur noch neu hinzukommende E-Mails an.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Gibt es zum Beispiel gerade 10 ungelesene E-Mails und Sie klicken auf die Aktion &quot;Ignorieren&quot;, wird Birdtray keinen Indikator für ungelesene E-Mails anzeigen, solange die Anzahl der ungelesenen E-Mails bei 10 bleibt. Sobald eine neue E-Mail empfangen wird und es somit 11 ungelesene E-Mails gibt, zeigt Birdtray eine ungelesene E-Mail an.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -364,10 +364,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -424,10 +420,6 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +432,27 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Support non-NETWM compliant WMs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -462,15 +474,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If not empty, this command will be invoked every time the unread counter changes (including when it becomes zero). It is invoked via shell, as-is, with %NEW% replaced by the new unread count value and %OLD% replaced with the old unread count value (which may be the same as new).&lt;/p&gt;&lt;p&gt;Most users don&apos;t need this functionality and should leave it empty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Support non-NETWM compliant WMs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -356,10 +356,6 @@ OpenSSL podría no estar instalado.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esta es la linea de comando completa (con parámetros) que será usada par iniciar Thunderbird. Los parámetros son separados mediante espacios, pero se permiten espacios entre comillas, como por ejemplo &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; funcionará.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignorar correos no leidos al iniciar</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignorar todos los correos no leidos que estén presentes cuando Birdtray se inice. Solo los nuevos correos seran tenidos en cuenta por el contador de no leídos.</translation>
     </message>
@@ -416,10 +412,6 @@ OpenSSL podría no estar instalado.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si es seleccionado, el icono de Birdtray mostrará el numero de corresos no leídos.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Si es deseleccionado, ningún contador será mostrado, y sólo se sabrá que existe un mensaje no leído por el parpadeo o el direrente color del icono, dependiendo de su configuración.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si se habilita, esta opción añade la acción de &amp;quot;Ignorar correos no leíodos actualmente&amp;quot; al menú contextual. Esta acción le permite ignorar los corresos que actualmente son no leídos&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por ejemplo, si hay 10 correos no leidos, y pulsa en &amp;quot;Ignorar&amp;quot;, Birdtray mostraŕa el indicador de mensajes no leidos mientras el contador de mensajes no leídos permanece en 10. Una vez que un correo nuevo es recibido y tiene 11 correos no leídos totales, Bridtray mostrará el contador de correos nuevos como 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Si el contador de correos corresponde a una cuenta &amp;quot;ignorada&amp;quot;,se reinicia a 0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -429,10 +421,6 @@ OpenSSL podría no estar instalado.</translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si se habilita, esta opción añade la acción de &amp;quot;Ignorar correos no leíodos actualmente&amp;quot; al menú contextual. Esta acción le permite ignorar los corresos que actualmente son no leídos&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por ejemplo, si hay 10 correos no leidos, y pulsa en &amp;quot;Ignorar&amp;quot;, Birdtray mostraŕa el indicador de mensajes no leidos mientras el contador de mensajes no leídos permanece en 10. Una vez que un correo nuevo es recibido y tiene 11 correos no leídos totales, Bridtray mostrará el contador de correos nuevos como 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_fr.ts
+++ b/src/translations/main_fr.ts
@@ -12,22 +12,18 @@ OpenSSL ne semble pas installé.</translation>
     <message>
         <source>Failed to save the Birdtray installer:
 </source>
-        <translation>Impossible de sauvegarder le programme d'installation de Birdtray :
+        <translation>Impossible de sauvegarder le programme d&apos;installation de Birdtray :
 </translation>
     </message>
     <message>
         <source>Failed to download the Birdtray installer:
 </source>
-        <translation>Impossible de télécharger le programme d'installation de Birdtray :
+        <translation>Impossible de télécharger le programme d&apos;installation de Birdtray :
 </translation>
     </message>
     <message>
         <source>Installer download failed</source>
-        <translation>Le téléchargement du programme d'installation a échoué</translation>
-    </message>
-    <message>
-        <source>Invalid redirect: </source>
-        <translation>Redirection invalide : </translation>
+        <translation>Le téléchargement du programme d&apos;installation a échoué</translation>
     </message>
     <message>
         <source>Update failed</source>
@@ -35,7 +31,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Failed to start the Birdtray installer.</source>
-        <translation>Le lancement du programme d'installation a échoué.</translation>
+        <translation>Le lancement du programme d&apos;installation a échoué.</translation>
     </message>
 </context>
 <context>
@@ -90,7 +86,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
-        <translation>Désolé, cette extension ne peut pas contrôler la barre de notification sur ce système d'exploitation.</translation>
+        <translation>Désolé, cette extension ne peut pas contrôler la barre de notification sur ce système d&apos;exploitation.</translation>
     </message>
 </context>
 <context>
@@ -171,7 +167,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This notification color will be used when more than one monitored account has unread emails.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Couleur utilisée lorsqu'il y a des mails non lus sur plusieurs comptes surveillés.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&gt;&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Couleur utilisée lorsqu&apos;il y a des mails non lus sur plusieurs comptes surveillés.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Multiple notification color:</source>
@@ -227,7 +223,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Allow ignoring the current unread email counter</source>
-        <translation>Permettre d'ignorer le nombre de mails non lus actuel</translation>
+        <translation>Permettre d&apos;ignorer le nombre de mails non lus actuel</translation>
     </message>
     <message>
         <source>Hiding</source>
@@ -243,7 +239,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When both Thunderbird and Birdtray are set to start with the operating system, this usually results in two copies of Thunderbird being launched. Here you can add a delay before Thunderbird is launched, to prevent this.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lorsque Thunderbird et Birdtray sont paramétrés pour démarrer automatiquement, il arrive que Thunderbird soit lancé deux fois. Vous pouvez ajouter ici un délai avant le lancement de Thunderbird, pour l'éviter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lorsque Thunderbird et Birdtray sont paramétrés pour démarrer automatiquement, il arrive que Thunderbird soit lancé deux fois. Vous pouvez ajouter ici un délai avant le lancement de Thunderbird, pour l&apos;éviter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source> second delay</source>
@@ -259,11 +255,11 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Terminate Thunderbird when quitting Birdtray</source>
-        <translation>Fermer Thunderbird à l'arrêt de Birdtray</translation>
+        <translation>Fermer Thunderbird à l&apos;arrêt de Birdtray</translation>
     </message>
     <message>
         <source>Hide/show Thunderbird window when clicking on tray icon</source>
-        <translation>Cacher/afficher la fenêtre Thunderbird en cliquant sur l'icône de notification</translation>
+        <translation>Cacher/afficher la fenêtre Thunderbird en cliquant sur l&apos;icône de notification</translation>
     </message>
     <message>
         <source>Hide Thunderbird window when it is minimized</source>
@@ -271,11 +267,11 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Show red X in tray icon if Thunderbird is not running</source>
-        <translation>Affichier un X rouge dans le barre de notification si Thunderbird n'est pas lancé</translation>
+        <translation>Affichier un X rouge dans le barre de notification si Thunderbird n&apos;est pas lancé</translation>
     </message>
     <message>
         <source>Restart Thunderbird if it was closed</source>
-        <translation>Relancer Thunderbird s'il a été fermé</translation>
+        <translation>Relancer Thunderbird s&apos;il a été fermé</translation>
     </message>
     <message>
         <source>New Email</source>
@@ -311,7 +307,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Make the system tray icon</source>
-        <translation>Afficher d'icône dans la barre de notification</translation>
+        <translation>Afficher d&apos;icône dans la barre de notification</translation>
     </message>
     <message>
         <source>Check for new updates when Birdtray starts.</source>
@@ -361,7 +357,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Could not load the icon from this file.</source>
-        <translation>Impossible de récupérer l'icône dans ce fichier.</translation>
+        <translation>Impossible de récupérer l&apos;icône dans ce fichier.</translation>
     </message>
     <message>
         <source>Thunderbird command line:</source>
@@ -370,10 +366,6 @@ OpenSSL ne semble pas installé.</translation>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indiquez ici la commande complète (avec les arguments) à utiliser pour lancer Thunderbird. Utilisez des espaces pour séparer les arguments. Les espaces entre quotes sont autorisées. Par exemple &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; fonctionnera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignorer les mails non lus au démarrage</translation>
     </message>
     <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
@@ -385,7 +377,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>hide it if no new mail is present.</source>
-        <translation>cacher si aucun nouveau mail n'est présent.</translation>
+        <translation>cacher si aucun nouveau mail n&apos;est présent.</translation>
     </message>
     <message>
         <source>Choose one or more MSF files</source>
@@ -405,7 +397,7 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>Force index file re-read every</source>
-        <translation>Forcer la lecture du fichier d'index toutes les</translation>
+        <translation>Forcer la lecture du fichier d&apos;index toutes les</translation>
     </message>
     <message>
         <source> seconds</source>
@@ -429,27 +421,19 @@ OpenSSL ne semble pas installé.</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, the Birdtray icon will show the number of unread emails.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If it is unchecked, no count will be shown, and you will only know about unread emails because of the blinking or different icon, depending on your settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si cette case est cochée, l'icône de Birdtray affichera le nombre de mails non lus.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Sinon, aucun compte ne sera affiché, et vous ne saurez seulement qu'il y a des mails non lus, grâce à l'icône clignotante ou différente, selon vos paramètres.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si activée, cette option ajoute le choix &amp;quot;Ignorer les mails actuellement non lus&amp;quot; Ce choix permet d'ignorer les mails qui n'ont pas encore été lus. Birdtray annoncera alors qu'il ne reste aucun mail non lu, et n'affichera que le nombre de mails en plus du nombre de mails ignorés.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Par exemple, s'il y a 10 mails non lus, et si vous cliquez sur &amp;quot;Ignorer&amp;quot;, Birdtray n'affichera rien, tant que le nombre de mails non lus restera à 10. Si vous recevez un nouveau mail, et donc que vous avez 11 mails non lus au total, Birdtray affichera 1 nouveau mail.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Si le compteur de mails non lus redescend sous le nombre d'&amp;quot;ignorés&amp;quot; amount, le compteur repasse à zéro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si cette case est cochée, l&apos;icône de Birdtray affichera le nombre de mails non lus.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Sinon, aucun compte ne sera affiché, et vous ne saurez seulement qu&apos;il y a des mails non lus, grâce à l&apos;icône clignotante ou différente, selon vos paramètres.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Unread change cmd:</source>
-        <translation>Lors d'un changement du nombre de non lus :</translation>
+        <translation>Lors d&apos;un changement du nombre de non lus :</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sélectionnez les répertoires de mails à surveiller.&lt;br/&gt;&lt;br/&gt;Si vous ne voyez pas votre répertoire, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; ouvrirz une boîte de dialogue permettant d'ajouter des fichiers mork.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sélectionnez les répertoires de mails à surveiller.&lt;br/&gt;&lt;br/&gt;Si vous ne voyez pas votre répertoire, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; ouvrirz une boîte de dialogue permettant d&apos;ajouter des fichiers mork.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
-        <translation>Impossible de récupérer l'icône dans ce fichier. Essayez d'ouvrir l'icône dans un éditeur d'images et de la sauvegarder dans un autre format.</translation>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>En cliquant sur l'icône Birdtray pour cacher Thunderbird, réinitialiser l'icône en ignorant tous les mails actuellement non lus</translation>
+        <translation>Impossible de récupérer l&apos;icône dans ce fichier. Essayez d&apos;ouvrir l&apos;icône dans un éditeur d&apos;images et de la sauvegarder dans un autre format.</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -477,7 +461,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Birdtray est un LOGICIEL LIBRE, sous licence General Public License v3. Plus précisément, toute utilisation, même commerciale, est autorisée, et ce gratuitement. &lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Si vous avez besoin d'aide, d'une fonctionnalité, ou de remonter un bug, utilisez la &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;page Github du projet&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Si vous avez besoin d&apos;aide, d&apos;une fonctionnalité, ou de remonter un bug, utilisez la &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;page Github du projet&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Si vous aimez mon travail sur Birdtray, qui est développé pendant mon temps libre, vous pouvez aller ici : &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
@@ -493,14 +477,30 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si votre gestionnaire de bureau n'est pas totalement compatible NETWM, vous pourriez avoir besoin de cocher cette case pour pouvoir trouver la fenêtre Thunderbird, et ainsi pouvoir la réduire et la cacher.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&gt;&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si votre gestionnaire de bureau n&apos;est pas totalement compatible NETWM, vous pourriez avoir besoin de cocher cette case pour pouvoir trouver la fenêtre Thunderbird, et ainsi pouvoir la réduire et la cacher.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si activée, cette option ajoute le choix &amp;quot;Ignorer les mails actuellement non lus&amp;quot; Ce choix permet d&apos;ignorer les mails qui n&apos;ont pas encore été lus. Birdtray annoncera alors qu&apos;il ne reste aucun mail non lu, et n&apos;affichera que le nombre de mails en plus du nombre de mails ignorés.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Par exemple, s&apos;il y a 10 mails non lus, et si vous cliquez sur &amp;quot;Ignorer&amp;quot;, Birdtray n&apos;affichera rien, tant que le nombre de mails non lus restera à 10. Si vous recevez un nouveau mail, et donc que vous avez 11 mails non lus au total, Birdtray affichera 1 nouveau mail.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
     <name>Log</name>
     <message>
         <source>Failed to open log file %s: %s</source>
-        <translation>Impossible d'ouvrir le fichier journal %s : %s</translation>
+        <translation>Impossible d&apos;ouvrir le fichier journal %s : %s</translation>
     </message>
     <message>
         <source>Fatal</source>
@@ -528,7 +528,7 @@ Le journal a été écrit dans le fichier %2</translation>
     <message>
         <source>No mail folder was selected to monitor.
 Do you want to continue?</source>
-        <translation>Aucun répertoire n'a été sélectionné.
+        <translation>Aucun répertoire n&apos;a été sélectionné.
 Voulez-vous continuer ?</translation>
     </message>
     <message>
@@ -571,7 +571,7 @@ Voulez-vous continuer ?</translation>
         <source>No mail profiles were found.
 Please make sure you selected the correct profiles directory.</source>
         <translation>Aucun compte mail trouvé.
-Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
+Assurez-vous d&apos;avoir sélectionné le bon répertoire.</translation>
     </message>
 </context>
 <context>
@@ -596,7 +596,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     <name>MorkParser</name>
     <message>
         <source>Couldn&apos;t open file: </source>
-        <translation>Impossible d'ouvrir le fichier : </translation>
+        <translation>Impossible d&apos;ouvrir le fichier : </translation>
     </message>
     <message>
         <source>Unsupported version.</source>
@@ -608,7 +608,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     </message>
     <message>
         <source>Parsing error.</source>
-        <translation>Erreur d'analyse.</translation>
+        <translation>Erreur d&apos;analyse.</translation>
     </message>
     <message>
         <source>Unexpected EOF.</source>
@@ -645,15 +645,15 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     </message>
     <message>
         <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>Vous avez configuré la surveillance d'un ou plusieurs réperoires via l'analyseur sqlite. Cette méthode a été supprimée. Vos paramétres ont été migrés vers l'analyseur mork, mais certains répertoires n'ont pas été retrouvés.</translation>
+        <translation>Vous avez configuré la surveillance d&apos;un ou plusieurs réperoires via l&apos;analyseur sqlite. Cette méthode a été supprimée. Vos paramétres ont été migrés vers l&apos;analyseur mork, mais certains répertoires n&apos;ont pas été retrouvés.</translation>
     </message>
     <message>
         <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>Vous avez configuré la surveillance d'un ou plusieurs réperoires via l'analyseur sqlite. Cette méthode a été supprimée. Vos paramétres ont été migrés vers l'analyseur mork. Veuillez vérifier que tous les comptes ont correctement été migrés.</translation>
+        <translation>Vous avez configuré la surveillance d&apos;un ou plusieurs réperoires via l&apos;analyseur sqlite. Cette méthode a été supprimée. Vos paramétres ont été migrés vers l&apos;analyseur mork. Veuillez vérifier que tous les comptes ont correctement été migrés.</translation>
     </message>
     <message>
         <source>Cannot load default system tray icon.</source>
-        <translation>Impossible de charger l'icône de notification par défaut.</translation>
+        <translation>Impossible de charger l&apos;icône de notification par défaut.</translation>
     </message>
 </context>
 <context>
@@ -664,7 +664,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     </message>
     <message>
         <source>You have not yet configured any email folders to monitor. Would you like to do it now?</source>
-        <translation>Vous n'avez pas encore confguré de répertoires mail à surveiller. Voulez-vous le faire maintenant ?</translation>
+        <translation>Vous n&apos;avez pas encore confguré de répertoires mail à surveiller. Voulez-vous le faire maintenant ?</translation>
     </message>
     <message>
         <source>Show Thunderbird</source>
@@ -746,7 +746,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
         <source>Error starting Thunderbird as &apos;%1 %2&apos;:
 
 %3</source>
-        <translation>>Erreur lors du démarrage de Thunderbird en tant que &apos;%1 %2&apos;:
+        <translation>&gt;Erreur lors du démarrage de Thunderbird en tant que &apos;%1 %2&apos;:
 
 %3</translation>
     </message>
@@ -825,7 +825,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     </message>
     <message>
         <source>Downloading Birdtray installer...</source>
-        <translation>Téléchargement du programme d'installation...</translation>
+        <translation>Téléchargement du programme d&apos;installation...</translation>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>
@@ -833,7 +833,7 @@ Assurez-vous d'avoir sélectionné le bon répertoire.</translation>
     </message>
     <message>
         <source>Downloading Birdtray installer... (%1 Mb / %2 Mb).</source>
-        <translation>Téléchargement du programme d'installation... (%1 Mb / %2 Mb).</translation>
+        <translation>Téléchargement du programme d&apos;installation... (%1 Mb / %2 Mb).</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -356,10 +356,6 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa è la riga di comando completa (con argomenti) che verrà utilizzata per avviare Thunderbird. Gli argomenti sono separati da spazi, ma sono consentiti spazi tra virgolette, vale a dire qualcosa di simile a &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; lavorerà.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignora e-mail non lette all&apos;avvio</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignora tutte le e-mail non lette presenti all&apos;avvio di Birdtray. Solo le nuove e-mail verranno prese in considerazione dal contatore non lette.</translation>
     </message>
@@ -400,10 +396,6 @@ OpenSSL potrebbe non essere installato.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se questa casella è selezionata, l&apos;icona Birdtray mostrerà il numero di e-mail non lette.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se è deselezionato, non verrà visualizzato alcun conteggio e conoscerai solo le email non lette a causa dell&apos;icona lampeggiante o diversa, a seconda delle tue impostazioni.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se attivata, questa opzione aggiunge il &amp;quot;Ignora le email attualmente non lette&amp;quot; azione nel menu contestuale. Questa azione ti consente di ignorare le e-mail attualmente non lette. Birdtray fingerebbe quindi che non siano rimaste email non lette e mostrerebbe solo le nuove email nel conteggio ignorato.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ad esempio, se c&apos;erano 10 e-mail non lette e hai fatto clic su &amp;quot;Ignora&amp;quot; azione, Birdtray non mostrerà alcun indicatore di e-mail non lette fino a quando il conteggio delle e-mail non lette rimane a 10. Una volta ricevuta la nuova e-mail e il totale di 11 e-mail non lette, Birdtray mostrerà il conteggio delle nuove e-mail come 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;ISe il conteggio delle e-mail non lette è inferiore a &amp;quot;ignored&amp;quot; in totale, l&apos;ignora si azzera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Translations are powered by the community:</source>
         <translation>Le traduzioni sono fornite dalla community:</translation>
     </message>
@@ -430,10 +422,6 @@ OpenSSL potrebbe non essere installato.</translation>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation>Impossibile caricare l&apos;icona da questo file. Prova a caricare l&apos;icona in uno strumento di modifica delle immagini e a salvarla in un formato diverso.</translation>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Quando si fa clic sull&apos;icona Birdtray per nascondere Thunderbird, reimpostare l&apos;icona ignorando tutte le e-mail attualmente non lette</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se attivata, questa opzione aggiunge il &amp;quot;Ignora le email attualmente non lette&amp;quot; azione nel menu contestuale. Questa azione ti consente di ignorare le e-mail attualmente non lette. Birdtray fingerebbe quindi che non siano rimaste email non lette e mostrerebbe solo le nuove email nel conteggio ignorato.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ad esempio, se c&apos;erano 10 e-mail non lette e hai fatto clic su &amp;quot;Ignora&amp;quot; azione, Birdtray non mostrerà alcun indicatore di e-mail non lette fino a quando il conteggio delle e-mail non lette rimane a 10. Una volta ricevuta la nuova e-mail e il totale di 11 e-mail non lette, Birdtray mostrerà il conteggio delle nuove e-mail come 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -357,10 +357,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;De volledige opdrachtregel (met argumenten) welke worden gebruikt om Thunderbird op te starten. Argumenten dienen spatiegescheiden te zijn, maar spaties tussen dubbele aanhalingstekens zijn toegestaan. Voorbeeld: &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ongelezen e-mails negeren bij opstarten</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Negeer alle ongelezen e-mails die beschikbaar zijn als Birdtray opstart. Alleen nieuwe e-mails worden geteld door de ongelezen e-mail-aanduiding.</translation>
     </message>
@@ -400,10 +396,6 @@ Mogelijk is OpenSSL niet geïnstalleerd.</translation>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, the Birdtray icon will show the number of unread emails.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If it is unchecked, no count will be shown, and you will only know about unread emails because of the blinking or different icon, depending on your settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kruis dit aan om het aantal ongelezen e-mails te tonen op het Birdtray-pictogram.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Als u dit niet aankruist, dan kunt u alleen zien dat er ongelezen e-mails zijn aan het knipperende of anders uitziende pictogram (afhankelijk van uw instellingen).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kruis dit aan om de optie &amp;quot;Huidige ongelezen e-mails negeren &amp;quot; toe te voegen aan het rechtermuisknopmenu. Birdtray doet dan alsof er geen ongelezen e-mails meer zijn totdat er nieuwe e-mails binnenkomen.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Voorbeeld: Als er 11 ongelezen e-mails zijn en u heeft de optie &amp;quot;Negeren&amp;quot; geactiveerd, dan toont Birdtray geen indicator zolang het aantal op 10 blijft. Zodra er weer nieuwe e-mails binnenkomen, toont Birdtray het aantal vanaf dan, beginnende bij 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Als het aantal ongelezen e-mails lager wordt dan het aantal &amp;quot;genegeerde&amp;quot;, dan wordt de teller op 0 gezet.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Translations are powered by the community:</source>
@@ -466,10 +458,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Bedankt voor uw ondersteuning!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Herstel het pictogram door alle ongelezen e-mails te negeren door te klikken op het Birdtray-pictogram</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dit past de dikte van het lettertype aan - maak het bijv. vetgedrukt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -492,6 +480,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kruis dit aan om de optie &amp;quot;Huidige ongelezen e-mails negeren &amp;quot; toe te voegen aan het rechtermuisknopmenu. Birdtray doet dan alsof er geen ongelezen e-mails meer zijn totdat er nieuwe e-mails binnenkomen.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Voorbeeld: Als er 11 ongelezen e-mails zijn en u heeft de optie &amp;quot;Negeren&amp;quot; geactiveerd, dan toont Birdtray geen indicator zolang het aantal op 10 blijft. Zodra er weer nieuwe e-mails binnenkomen, toont Birdtray het aantal vanaf dan, beginnende bij 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -356,10 +356,6 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To jest pełna linia koment (z argumentami), która zostanie użyta do uruchomienia Thunderbirda. Argumenty rozdziela się spacjami, spacje w cudzysłowie są dozwolone, np. coś takiego: &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Zignoruj nieprzeczytane wiadomości podczas uruchamiania</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Zignoruj wszystkie nieprzeczytane wiadomości podczas startu Birdtray. Tylko nowe wiadomości będą brane pod uwagę przez licznik nieprzeczytanych.</translation>
     </message>
@@ -416,10 +412,6 @@ OpenSSL może nie być zainstalowane.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jeśli zaznaczone, ikona Birdtray będzie pokazywała ilość nieprzeczytanych wiadomości.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Jeśli nie zaznaczone, ilość wiadomości nie będzie pokazywana, jedynym powiadomieniem o nieprzeczytanych wiadomościach będzie miganie lub zmiana wyglądu ikony, zależnie od ustawień.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Włączenie tej opcji spowoduje dodanie opcji &amp;quot;Ignoruj nieprzeczytane wiadomości&amp;quot; do menu kontekstowego. Opcja ta pozwala na zignorowanie aktualnie nieprzeczytanych wiadomości, Birdtray nie będzie brał tych wiadomości pod uwagę i uwzględni jedynie nowe nieprzeczytane wiadomości.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
         <translation>Wykonaj w przypadku zmiany licznika nieprzeczytanych:</translation>
     </message>
@@ -464,10 +456,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Dziękuję za wasze ciągłe wsparcie!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Przy kliknięciu chowającym Birdtray ignoruj nieprzeczytane wiadomości</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zmiana grubości czcionki.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Włączenie tej opcji spowoduje dodanie opcji &amp;quot;Ignoruj nieprzeczytane wiadomości&amp;quot; do menu kontekstowego. Opcja ta pozwala na zignorowanie aktualnie nieprzeczytanych wiadomości, Birdtray nie będzie brał tych wiadomości pod uwagę i uwzględni jedynie nowe nieprzeczytane wiadomości.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -356,10 +356,6 @@ OpenSSL não deve estar instalado.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esta é a linha de comando completa (com argumentos) que será usada para iniciar o Thunderbird. Argumentos são separados por espaços, mas espaços entre aspas são permitidos, por exemplo: algo como &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; irá funcionar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignorar e-mails não lidos ao iniciar</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignora todos os e-mails não lidos presentes ao iniciar o Birdtray. Somente novas mensagens serão levadas em conta pelo contador de não lidos.</translation>
     </message>
@@ -416,10 +412,6 @@ OpenSSL não deve estar instalado.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se esta caixa está marcada, o ícone do Birdtray irá exibir o número de mensagens não lidas.&lt;/p&gt;&lt;p&gt;&lt;/br&gt;Se estiver desmarcada, nenhuma contagem é exibida, e você somente saberá sobre mensagens não lidas devido ao piscar ou ícone diferente, dependendo das suas configurações.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se ativada, esta opção adiciona a ação &amp;quot;Ignorar e-mails não lidos&amp;quot; ao menu de contexto. Esta ação permite a você ignorar os e-mails não lidos no momento. O Birdtray então entenderá que não há nenhum e-mail não lido restante, e somente mostrar novos e-mails sobre a contagem de ignorados.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por exemplo, se há 10 e-mails não lidos e você clicar na ação &amp;quot;Ignorar&amp;quot;, o Birdtray irá o indicador de nenhum e-mail não lido enquanto o contador de e-mails não lidos permancer em 10. Assim que um novo e-mail é recebido e você ter 11 e-mails não lidos, o Birdtray irá exibir a contagem de novo e-mail como 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Se a contagem de e-mails não lidos cair abaixo da quantia &amp;quot;ignorada&amp;quot;, ignorar será redefinida para zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
         <translation>Comando para mudar não lida:</translation>
     </message>
@@ -464,10 +456,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Obrigado pelo seu suporte contínuo!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Ao clicar no ícone do Birdtray para ocultar o Thunderbird, redefine o ícone, ignorando todos os e-mails não lidos no momento</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Isto altera espessura da fonte. Por exemplo: torna a fonte negrito.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se ativada, esta opção adiciona a ação &amp;quot;Ignorar e-mails não lidos&amp;quot; ao menu de contexto. Esta ação permite a você ignorar os e-mails não lidos no momento. O Birdtray então entenderá que não há nenhum e-mail não lido restante, e somente mostrar novos e-mails sobre a contagem de ignorados.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por exemplo, se há 10 e-mails não lidos e você clicar na ação &amp;quot;Ignorar&amp;quot;, o Birdtray irá o indicador de nenhum e-mail não lido enquanto o contador de e-mails não lidos permancer em 10. Assim que um novo e-mail é recebido e você ter 11 e-mails não lidos, o Birdtray irá exibir a contagem de novo e-mail como 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -356,10 +356,6 @@ OpenSSL might not be installed.</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это полная командная строка (с аргументами), которая будет использоваться для запуска Thunderbird. Аргументы разделены пробелами, но допускаются пробелы в кавычках, т.е. &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; будет работать.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Игнорировать непрочитанные письма при запуске</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Игнорировать все непрочитанные письма, которые присутствуют при запуске Birdtray. Только новые письма будут учтены счётчиком непрочитанных сообщений.</translation>
     </message>
@@ -416,10 +412,6 @@ OpenSSL might not be installed.</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если этот флажок установлен, значок Birdtray будет отображать количество непрочитанных писем.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Если этот флажок снят, счетчик не будет отображаться, и вы будете знать о непрочитанных письмах из-за мигания или другого значка, в зависимости от ваших настроек.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если этот параметр включен, этот параметр добавляет &amp;quot;Игнорировать непрочитанные в настоящий момент электронные письма&amp;quot; действие в контекстном меню. Это действие позволяет вам игнорировать электронные письма, которые в данный момент не прочитаны. После этого Birdtray будет делать вид, что не осталось непрочитанных писем, и будет показывать только новые письма.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Например, если было 10 непрочитанных писем, и вы нажали &amp;quot;Игнорировать&amp;quot; В этом случае Birdtray не будет показывать индикатор непрочитанных сообщений, если количество непрочитанных сообщений остается на уровне 10. После получения нового сообщения и наличия у вас всего 11 непрочитанных сообщений Birdtray будет отображать количество новых сообщений как 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Если количество непрочитанных писем ниже значения &amp;quot;игнорирования&amp;quot;, игнорирование сбрасывается до нуля.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
         <translation>Выполнить при изменении:</translation>
     </message>
@@ -464,10 +456,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Спасибо за вашу постоянную поддержку!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>При нажатии на значок Birdtray для скрытия Thunderbird, значок обновится, игнорируя все непрочитанные в настоящее время электронные письма</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это изменяет толщину шрифта, то есть делает шрифт жирным.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если этот параметр включен, этот параметр добавляет &amp;quot;Игнорировать непрочитанные в настоящий момент электронные письма&amp;quot; действие в контекстном меню. Это действие позволяет вам игнорировать электронные письма, которые в данный момент не прочитаны. После этого Birdtray будет делать вид, что не осталось непрочитанных писем, и будет показывать только новые письма.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Например, если было 10 непрочитанных писем, и вы нажали &amp;quot;Игнорировать&amp;quot; В этом случае Birdtray не будет показывать индикатор непрочитанных сообщений, если количество непрочитанных сообщений остается на уровне 10. После получения нового сообщения и наличия у вас всего 11 непрочитанных сообщений Birdtray будет отображать количество новых сообщений как 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -356,10 +356,6 @@ OpenSSL kanske inte är installerad.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detta är hela kommandoraden (inkl. argument) som kommer att användas för att starta Thunderbird. Argumenten separeras med blanksteg, men blanksteg inom citationstecken är tillåtna, något som &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; bör t.ex. fungera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Ignorera oläst e-post vid uppstart</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Ignorera all oläst e-post som finns när Birdtray startas. Endast nya e-postmeddelanden kommer att beaktas av räknaren för olästa meddelanden.</translation>
     </message>
@@ -416,10 +412,6 @@ OpenSSL kanske inte är installerad.</translation>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Om den här rutan är markerad visar Birdtray-ikonen antalet olästa e-postmeddelanden.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Om det är avmarkerat visas inget antal, och du känner bara till olästa e-postmeddelanden på grund av blinkandet eller den egenkonfigurerade ikonen, beroende på dina inställningar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Om det är aktiverat, lägger det här alternativet till &amp;quot;Ignorera för närvarande olästa e-postmeddelanden&amp;quot; i snabbmenyn. Den här åtgärden låter dig ignorera de e-postmeddelanden som för närvarande är olästa. Birdtray kommer då att låtsas att det inte finns några olästa e-postmeddelanden kvar och bara visa nya meddelanden som inkommer efter det ignorerade antalet.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Om det till exempel finns 10 olästa e-postmeddelanden och du klickar på &amp;quot;Ignorera&amp;quot;, visar Birdtray ingen oläst e-post så länge antalet olästa e-postmeddelanden ligger kvar på 10. När sedan ny e-post tas emot och du har totalt 11 olästa e-postmeddelanden, kommer Birdtray att visa 1 på räkneverket.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Om antalet olästa e-postmeddelanden går under det &amp;quot;ignorerade&amp;quot; antalet, återställs antalet ignorerade till noll&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -429,10 +421,6 @@ OpenSSL kanske inte är installerad.</translation>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -490,6 +478,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Om det är aktiverat, lägger det här alternativet till &amp;quot;Ignorera för närvarande olästa e-postmeddelanden&amp;quot; i snabbmenyn. Den här åtgärden låter dig ignorera de e-postmeddelanden som för närvarande är olästa. Birdtray kommer då att låtsas att det inte finns några olästa e-postmeddelanden kvar och bara visa nya meddelanden som inkommer efter det ignorerade antalet.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Om det till exempel finns 10 olästa e-postmeddelanden och du klickar på &amp;quot;Ignorera&amp;quot;, visar Birdtray ingen oläst e-post så länge antalet olästa e-postmeddelanden ligger kvar på 10. När sedan ny e-post tas emot och du har totalt 11 olästa e-postmeddelanden, kommer Birdtray att visa 1 på räkneverket.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -357,10 +357,6 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>Başlangıçta okunmamış e-postaları yoksay</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
         <translation>Birdtray başladığında mevcut olan tüm okunmamış e-postaları yoksayın. Okunmamış sayaç tarafından yalnızca yeni e-postalar dikkate alınacaktır.</translation>
     </message>
@@ -417,10 +413,6 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
         <translation>Okunmamış değişiklik cmd&apos;si:</translation>
     </message>
@@ -431,28 +423,6 @@ tuşunu basılı tutarak tıklayın):</translation>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
         <translation>Simge bu dosyadan yüklenemedi. Simgeyi bir görüntü düzenleme aracına yüklemeyi ve farklı bir formatta kaydetmeyi deneyin.</translation>
-    </message>
-    <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Birdtray version [VERSION] compiled at [DATE] using Qt [QT_VERSION].&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Copyright (C) 2018 by George Yunaev, &lt;/span&gt;&lt;a href=&quot;mailto:gyunaev@ulduzsoft.com&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;gyunaev@ulduzsoft.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Birdtray is FREE SOFTWARE, which is licensed under General Public License v3. To clarify further, you can use it for any purpose, including commercial, without paying anything. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;To ask for help, request a feature or report a bug use the &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;Github project page&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For those of you who appreciate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>Thunderbird&apos;ü gizlemek için Birdtray simgesine tıkladığınızda, şu anda okunmamış tüm e-postaları yok sayarak simgeyi sıfırlayın</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -476,6 +446,40 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Birdtray version [VERSION] compiled at [DATE] using Qt [QT_VERSION].&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Copyright (C) 2018 by George Yunaev, &lt;/span&gt;&lt;a href=&quot;mailto:gyunaev@ulduzsoft.com&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;gyunaev@ulduzsoft.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Birdtray is FREE SOFTWARE, which is licensed under General Public License v3. To clarify further, you can use it for any purpose, including commercial, without paying anything. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;To ask for help, request a feature or report a bug use the &lt;/span&gt;&lt;a href=&quot;https://github.com/gyunaev/birdtray&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;Github project page&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For those of you who appreciate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_zh_cn.ts
+++ b/src/translations/main_zh_cn.ts
@@ -6,23 +6,23 @@
     <message>
         <source>No ssl configuration!
 OpenSSL might not be installed.</source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>未找到SSL配置！
 可能是没有安装OpenSSL。</translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
     <message>
         <source>Failed to save the Birdtray installer:
 </source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>安装文件写入失败：
 </translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
     <message>
         <source>Failed to download the Birdtray installer:
 </source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>安装文件下载失败：
 </translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
     <message>
         <source>Installer download failed</source>
@@ -34,21 +34,21 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Failed to start the Birdtray installer.</source>
-        <translation>启动Birdtray安装文件失败。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>启动Birdtray安装文件失败。</translation>
     </message>
 </context>
 <context>
     <name>BirdtrayApp</name>
     <message>
         <source>A free system tray notification for new mail for Thunderbird.</source>
-        <translation>一个提供Thunderbird最小化到系统托盘及新邮件提醒功能的自由软件。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>一个提供Thunderbird最小化到系统托盘及新邮件提醒功能的自由软件。</translation>
     </message>
     <message>
         <source>Display the contents of the given mork database.</source>
-        <translation>显示指定Mork数据库的内容。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>显示指定Mork数据库的内容。</translation>
     </message>
     <message>
         <source>databaseFile</source>
@@ -56,8 +56,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Decode an IMAP Utf7 string.</source>
-        <translation>解码UTF7编码的IMAP字符串。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>解码UTF7编码的IMAP字符串。</translation>
     </message>
     <message>
         <source>string</source>
@@ -65,33 +65,33 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Show the settings.</source>
-        <translation>显示配置项。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>显示配置项。</translation>
     </message>
     <message>
         <source>Reset the settings to the defaults.</source>
-        <translation>重置为默认设置。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>重置为默认设置。</translation>
     </message>
     <message>
         <source>Toggle the Thunderbird window.</source>
-        <translation>显示/隐藏Thunderbird窗口。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>显示/隐藏Thunderbird窗口。</translation>
     </message>
     <message>
         <source>Show the Thunderbird window.</source>
-        <translation>显示Thunderbird窗口。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>显示Thunderbird窗口。</translation>
     </message>
     <message>
         <source>Hide the Thunderbird window.</source>
-        <translation>隐藏Thunderbird窗口。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>隐藏Thunderbird窗口。</translation>
     </message>
     <message>
         <source>Write log to a file.</source>
-        <translation>将日志写入文件。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>将日志写入文件。</translation>
     </message>
     <message>
         <source>file</source>
@@ -99,8 +99,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Sorry, the system tray cannot be controlled by this add-on on your operating system.</source>
-        <translation>抱歉，您的操作系统不支持通过程序控制系统托盘。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>抱歉，您的操作系统不支持通过程序控制系统托盘。</translation>
     </message>
 </context>
 <context>
@@ -111,8 +111,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Name:</source>
-        <translation>名称：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>名称：</translation>
     </message>
     <message>
         <source>(Optional) Prefilled fields</source>
@@ -120,18 +120,18 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Email subject:</source>
-        <translation>邮件主题：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>邮件主题：</translation>
     </message>
     <message>
         <source>Email message text:</source>
-        <translation>邮件正文：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>邮件正文：</translation>
     </message>
     <message>
         <source>Email recipient:</source>
-        <translation>收件人：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>收件人：</translation>
     </message>
     <message>
         <source>No name specified</source>
@@ -139,8 +139,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>The name cannot be empty.</source>
-        <translation>模板名称不能为空。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>模板名称不能为空。</translation>
     </message>
 </context>
 <context>
@@ -170,8 +170,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Different icon when unread:</source>
-        <translation>有未读邮件时使用图标：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>有未读邮件时使用图标：</translation>
     </message>
     <message>
         <source>Off</source>
@@ -183,8 +183,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Icon (Ctrl-click to reset):</source>
-        <translation>图标（按住Ctrl点击重置）：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>图标（按住Ctrl点击重置）：</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This notification color will be used when more than one monitored account has unread emails.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -192,8 +192,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Multiple notification color:</source>
-        <translation>多信箱未读通知颜色：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>多信箱未读通知颜色：</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the font thickness, i.e. makes the font bold.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -201,28 +201,28 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Blinking speed:</source>
-        <translation>图标闪烁速度：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>图标闪烁速度：</translation>
     </message>
     <message>
         <source>Font style:</source>
-        <translation>字体：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>字体：</translation>
     </message>
     <message>
         <source>Bold:</source>
-        <translation>加粗：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>加粗：</translation>
     </message>
     <message>
         <source>Notification border color:</source>
-        <translation>通知消息边框颜色：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>通知消息边框颜色：</translation>
     </message>
     <message>
         <source>Width:</source>
-        <translation>宽度：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>宽度：</translation>
     </message>
     <message>
         <source>None</source>
@@ -314,18 +314,18 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Please do not change these settings unless you understand what you&apos;re doing.</source>
-        <translation>修改以下配置前请确保您明白是否真的需要修改它们。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>修改以下配置前请确保您明白是否真的需要修改它们。</translation>
     </message>
     <message>
         <source>Thunderbird window name pattern:</source>
-        <translation>Thunderbird窗口标题模板：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>Thunderbird窗口标题模板：</translation>
     </message>
     <message>
         <source>Minimum notification font size:</source>
-        <translation>通知消息字体不小于：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>通知消息字体不小于：</translation>
     </message>
     <message>
         <source> points</source>
@@ -341,8 +341,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Check for new updates when Birdtray starts.</source>
-        <translation>当Birdtray启动时检查是否有新版本。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>当Birdtray启动时检查是否有新版本。</translation>
     </message>
     <message>
         <source>Check for new updates on startup</source>
@@ -350,8 +350,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Check for a new Birdtray version.</source>
-        <translation>检测是否有新版本。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>检测是否有新版本。</translation>
     </message>
     <message>
         <source>Check now</source>
@@ -368,9 +368,9 @@ OpenSSL might not be installed.</source>
     <message>
         <source>Failed to check for a new Birdtray version:
 </source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>检查版本更新失败：
 </translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
     <message>
         <source>Checking...</source>
@@ -390,36 +390,32 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Could not load the icon from this file.</source>
-        <translation>无法加载图标。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无法加载图标。</translation>
     </message>
     <message>
         <source>Thunderbird command line:</source>
-        <translation>Thunderbird启动命令：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>Thunderbird启动命令：</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;启动Thunderbird的完整命令，将以此启动Thunderbird。启动参数以空格分隔，若参数本身包含空格则必须用引号包裹参数。例如：&lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>Ignore unread emails at startup</source>
-        <translation>启动时忽略未读邮件</translation>
-    </message>
-    <message>
         <source>Ignore all unread email that are present when Birdtray starts. Only new emails will be taken into account by the unread counter.</source>
-        <translation>Birdtray启动时忽略当前的未读邮件，未读计数将仅计算新收到的邮件。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>Birdtray启动时忽略当前的未读邮件，未读计数将仅计算新收到的邮件。</translation>
     </message>
     <message>
         <source>opaque when new mail is present,</source>
-        <translation>的透明度显示图标，</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>的透明度显示图标，</translation>
     </message>
     <message>
         <source>hide it if no new mail is present.</source>
-        <translation>没有未读邮件时隐藏托盘图标。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>没有未读邮件时隐藏托盘图标。</translation>
     </message>
     <message>
         <source>Choose one or more MSF files</source>
@@ -447,8 +443,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Translations are powered by the community:</source>
-        <translation>翻译工作由社区支持：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>翻译工作由社区支持：</translation>
     </message>
     <message>
         <source>Translators</source>
@@ -467,13 +463,9 @@ OpenSSL might not be installed.</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;如果勾选此项，将在图标上显示未读邮件数。&lt;/p&gt;&lt;p&gt;&lt;br/&gt;如果取消勾选，则您只能通过图标闪烁或不同样式的图标来判断是否有新邮件，这取决于你的配置。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;If the unread email count goes below the &amp;quot;ignored&amp;quot; amount, the ignore resets to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;如果启用此项,将添加“忽略当前未读”到托盘图标菜单，此操作允许您忽略当前未读邮件。您执行此操作后，Birdtray将认为当前没有未读邮件，并且仅对新到达的邮件进行提示。&lt;/p&gt;&lt;p&gt;&lt;br/&gt;例如，如果您当前有10封未读邮件，然后您点击“忽略当前未读”菜单，Birdtray将指示没有未读邮件（如图标不会闪烁），但未读计数保持10不变。一旦您收到新的邮件，未读邮件数变为11，Birdtray将以1封新邮件的通知方式通知。&lt;/p&gt;&lt;p&gt;&lt;br/&gt;当实际未读邮件数低于被“忽略”的未读数时，被“忽略”的邮件数重置为0。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
         <source>Unread change cmd:</source>
-        <translation>未读邮件变化时执行脚本：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>未读邮件变化时执行脚本：</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select mail folders for watching.&lt;br/&gt;&lt;br/&gt;If the dialog doesn&apos;t show your folder, &lt;i&gt;Ctrl + Shift click&lt;/i&gt; to open a file selection dialog that allows adding any mork file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -481,12 +473,8 @@ OpenSSL might not be installed.</source>
     </message>
     <message>
         <source>Could not load the icon from this file. Try loading the icon in an image editing tool and saving it in a different format.</source>
-        <translation>无法加载图标。可尝试将其转换为其他格式再试。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
-    </message>
-    <message>
-        <source>When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails</source>
-        <translation>隐藏Thunderbird窗口后忽略当前未读邮件并重置未读计数</translation>
+        <translation>无法加载图标。可尝试将其转换为其他格式再试。</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -532,6 +520,22 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your desktop manager is not fully NETWM compliant, you may need to check this checkbox so it can detect Thunderbird window and is able to minimise and hide it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;如果您的桌面环境不是NETWM兼容的，您可能需要勾选此项我们才能正确探测到Thunderbird，并能够将其最小化和隐藏。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When hiding Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When showing Thunderbird</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>
@@ -565,9 +569,9 @@ Log file is written into file %2</source>
     <message>
         <source>No mail folder was selected to monitor.
 Do you want to continue?</source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>未选择任何要监听的邮件目录。
 是否继续？</translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
     <message>
         <source>Select Accounts</source>
@@ -575,8 +579,8 @@ Do you want to continue?</source>
     </message>
     <message>
         <source>Select the directory that contains the Thunderbird profiles.</source>
-        <translation>请选择Thunderbird数据目录。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>请选择Thunderbird数据目录。</translation>
     </message>
     <message>
         <source>Thunderbird Profiles Directory</source>
@@ -588,8 +592,8 @@ Do you want to continue?</source>
     </message>
     <message>
         <source>Select the mail accounts you want to monitor.</source>
-        <translation>选择您要监听的信箱。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>选择您要监听的信箱。</translation>
     </message>
     <message>
         <source>Email Folder</source>
@@ -601,8 +605,8 @@ Do you want to continue?</source>
     </message>
     <message>
         <source>If you monitor multiple folders, the default notification color is used to show the sum of all unread mails.</source>
-        <translation>如果您选择了多个目录，将使用默认颜色显示未读邮件总数。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>如果您选择了多个目录，将使用默认颜色显示未读邮件总数。</translation>
     </message>
     <message>
         <source>%1 (Profile)</source>
@@ -611,9 +615,9 @@ Do you want to continue?</source>
     <message>
         <source>No mail profiles were found.
 Please make sure you selected the correct profiles directory.</source>
+        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>未找到Thunderbird配置。
 请检查您选择的Thunderbird数据目录是否正确。</translation>
-        <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
     </message>
 </context>
 <context>
@@ -642,38 +646,38 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
     <message>
         <source>Unsupported version.</source>
-        <translation>抱歉，该版本不受支持。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>抱歉，该版本不受支持。</translation>
     </message>
     <message>
         <source>Invalid format.</source>
-        <translation>无效的格式。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无效的格式。</translation>
     </message>
     <message>
         <source>Parsing error.</source>
-        <translation>匹配出错。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>匹配出错。</translation>
     </message>
     <message>
         <source>Unexpected EOF.</source>
-        <translation>未预期的文件结束标志符（EOF）。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>未预期的文件结束标志符（EOF）。</translation>
     </message>
     <message>
         <source>Invalid comment.</source>
-        <translation>无效的注释。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无效的注释。</translation>
     </message>
     <message>
         <source>Format error.</source>
-        <translation>格式错误。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>格式错误。</translation>
     </message>
     <message>
         <source>Unexpected end of group.</source>
-        <translation>未预期的end-group。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>未预期的end-group。</translation>
     </message>
 </context>
 <context>
@@ -694,31 +698,31 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
     <message>
         <source>You had configured monitoring of one or more mail folders using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser, but some configured mail folders could not be found.</source>
-        <translation>您正在侦听使用Sqlite解析器的信箱，但该解析器已被弃用。已自动使用Mork解析器，但一些已配置的信箱无法找到。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>您正在侦听使用Sqlite解析器的信箱，但该解析器已被弃用。已自动使用Mork解析器，但一些已配置的信箱无法找到。</translation>
     </message>
     <message>
         <source>You had configured monitoring of one or more mail accounts using the Sqlite parser. This method has been removed. Your configurations has been migrated to the Mork parser. Please verify that all accounts were mapped correctly.</source>
-        <translation>您正在侦听使用Sqlite解析器的邮箱帐号，但该解析器已被弃用。已自动使用Mork解析器，请确认您所有的帐号映射是否正确。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>您正在侦听使用Sqlite解析器的邮箱帐号，但该解析器已被弃用。已自动使用Mork解析器，请确认您所有的帐号映射是否正确。</translation>
     </message>
     <message>
         <source>Cannot load default system tray icon.</source>
-        <translation>无法加载系统默认托盘图标。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无法加载系统默认托盘图标。</translation>
     </message>
 </context>
 <context>
     <name>TrayIcon</name>
     <message>
         <source>Would you like to set up Birdtray?</source>
-        <translation>您要对Birdtray进行配置吗？</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>您要对Birdtray进行配置吗？</translation>
     </message>
     <message>
         <source>You have not yet configured any email folders to monitor. Would you like to do it now?</source>
-        <translation>您尚未配置任何要监听的信箱，是否现在配置？</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>您尚未配置任何要监听的信箱，是否现在配置？</translation>
     </message>
     <message>
         <source>Show Thunderbird</source>
@@ -774,8 +778,8 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
     <message>
         <source>Settings...</source>
-        <translation>设置...</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>设置...</translation>
     </message>
     <message>
         <source>Quit</source>
@@ -818,13 +822,13 @@ Please make sure you selected the correct profiles directory.</source>
     <name>UnreadMonitor</name>
     <message>
         <source>Unable to watch %1 for changes.</source>
-        <translation>无法监听%1。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无法监听%1。</translation>
     </message>
     <message>
         <source>Unable to read from %1.</source>
-        <translation>无法读取%1。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>无法读取%1。</translation>
     </message>
 </context>
 <context>
@@ -835,23 +839,23 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
     <message>
         <source>Current version:</source>
-        <translation>当前版本：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>当前版本：</translation>
     </message>
     <message>
         <source>A new version of Birdtray is available.</source>
-        <translation>有新版本可用。</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>有新版本可用。</translation>
     </message>
     <message>
         <source>New version:</source>
-        <translation>新版本：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>新版本：</translation>
     </message>
     <message>
         <source>Download size:</source>
-        <translation>下载文件大小：</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>下载文件大小：</translation>
     </message>
     <message>
         <source>Download</source>
@@ -890,13 +894,13 @@ Please make sure you selected the correct profiles directory.</source>
     </message>
     <message>
         <source>Download finished. Restart and update Birdtray?</source>
-        <translation>下载完成。是否立即重启以应用更新？</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>下载完成。是否立即重启以应用更新？</translation>
     </message>
     <message>
         <source>Downloading Birdtray installer... (%1 Mb / %2 Mb).</source>
-        <translation>正在下载文件...（%1 Mb / %2 Mb）</translation>
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
+        <translation>正在下载文件...（%1 Mb / %2 Mb）</translation>
     </message>
 </context>
 </TS>

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -114,11 +114,29 @@ class TrayIcon : public QSystemTrayIcon
          * @param errorMessage A message indicating an error during the check, or a null string.
          */
         void    onAutoUpdateCheckFinished(bool foundUpdate, const QString& errorMessage);
+        
+        /**
+         * Called when the Thunderbird window is shown.
+         */
+        void    onThunderbirdWindowShown();
+        
+        /**
+         * Called when the Thunderbird window is hidden.
+         */
+        void    onThunderbirdWindowHidden();
 
     private:
         void    createMenu();
         void    createUnreadCounterThread();
-        void    updateIgnoredUnreads();
+        
+        /**
+         * update the number of ignored mails.
+         *
+         * @param ignoredMails The new number of ignored mails.
+         * @param updateIcon Whether a change in the number of ignored mails
+         *                   should result in an update of the tray icon.
+         */
+        void    setIgnoredUnreadMails(unsigned int ignoredMails, bool updateIcon = true);
         
         /**
          * Do an automatic check for a new version of Birdtray.
@@ -144,11 +162,6 @@ class TrayIcon : public QSystemTrayIcon
         // Current unread messages count and color
         unsigned int    mUnreadCounter;
         QColor          mUnreadColor;
-        
-        /**
-         * The number of unread emails at Birdtray startup.
-         */
-        long            unreadEmailsAtStart = -1;
 
         // Show/hide Thunderbird menu item (we modify its text)
         QAction *       mMenuShowHideThunderbird;
@@ -179,8 +192,10 @@ class TrayIcon : public QSystemTrayIcon
         // If true, it will hide Thunderbird window as soon as its shown
         bool            mThunderbirdWindowHide;
 
-        // Number of suppressed unread emails, if nonzero
-        unsigned int    mIgnoredUnreadEmails;
+        /**
+         * The number of unread emails that Birdtray is ignoring.
+         */
+        unsigned int    ignoredUnreadEmails = 0;
 
         // Window tools (show/hide)
         WindowTools *   mWinTools;
@@ -210,6 +225,11 @@ class TrayIcon : public QSystemTrayIcon
          * A manager to check for network connectivity.
          */
         QNetworkConfigurationManager* networkConnectivityManager = nullptr;
+        
+        /**
+         * Whether we have received data about unread emails yet.
+         */
+        bool haveUnreadMailsData = false;
 };
 
 #endif // TRAYICON_H

--- a/src/windowtools.h
+++ b/src/windowtools.h
@@ -29,6 +29,17 @@ class WindowTools : public QObject
         // Return true if Thunderbird window is valid (hidden or shown)
         virtual bool    isValid() = 0;
 
+    signals:
+        /**
+         * Called when the Thunderbird window is hidden.
+         */
+        void onWindowHidden();
+    
+        /**
+         * Called when the Thunderbird window is shown.
+         */
+        void onWindowShown();
+        
     protected:
         WindowTools();
         virtual ~WindowTools();

--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -123,14 +123,22 @@ bool WindowTools_Win::show() {
     if (IsIconic(this->thunderbirdWindow)) {
         ShowWindow(this->thunderbirdWindow, SW_RESTORE);
     }
-    return SetForegroundWindow(this->thunderbirdWindow) == TRUE;
+    if (SetForegroundWindow(this->thunderbirdWindow) == TRUE) {
+        emit onWindowShown();
+        return true;
+    }
+    return false;
 }
 
 bool WindowTools_Win::hide() {
     if (!checkWindow()) {
         return false;
     }
-    return ShowWindow(this->thunderbirdWindow, SW_HIDE) > 0;
+    if (ShowWindow(this->thunderbirdWindow, SW_HIDE) > 0) {
+        emit onWindowHidden();
+        return true;
+    }
+    return false;
 }
 
 bool WindowTools_Win::isHidden() {

--- a/src/windowtools_x11.cpp
+++ b/src/windowtools_x11.cpp
@@ -411,6 +411,7 @@ bool WindowTools_X11::show()
     XSetInputFocus(display, mWinId, RevertToParent, CurrentTime);
 
     mHiddenStateCounter = 0;
+    emit onWindowShown();
     return true;
 }
 
@@ -488,8 +489,10 @@ void WindowTools_X11::doHide()
     // Increase the counter but do not exceed 2
     mHiddenStateCounter++;
 
-    if ( mHiddenStateCounter == 2 )
+    if ( mHiddenStateCounter == 2 ) {
         Log::debug("Window removed from taskbar");
+        emit onWindowHidden();
+    }
 }
 
 void WindowTools_X11::timerWindowState()


### PR DESCRIPTION
This adds the option to ignore all currently unread emails when showing the Thunderbird window.
It also moves all ignored emails related settings into one tab (removes the `When clicking on Birdtray icon to hide Thunderbird, reset the icon by ignoring all currently unread emails` option in the `Hiding` tab):

![The monitoring settings tab with the new options](https://user-images.githubusercontent.com/6966049/104820628-75a29680-5836-11eb-8323-0c94efe01b76.png)

Further changes:
* The number of ignored emails is no longer reset to 0 if an email is marked as read and the unread email count drops below the original ignored email count. Instead, the number of ignored unread emails is simply decreased to match the number of currently unread emails.
* When Thunderbird minimized and then hidden, the `ignore unread emails when hiding` option will work now.
* Fixes a bug where the context menu would not display the number of ignored mails after leaving the settings dialog.
* The ignored email count and the `Show\Hide Thunderbird` menu entries are no longer updated, if the windowtools fail to hide/show a window.
* Fixed tab ordering in the settings dialog.

@gyunaev Can you please make sure that the changes in the X11 windowtools work on Linux?

Closes #447.