### PR TITLE
Update the CodeQl workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,17 +25,21 @@ jobs:
       with:
         languages: ${{ matrix.language }}
     - name: Install additional dependencies
+      if: matrix.language == 'cpp'
       shell: bash
       run: |
         sudo apt-get update -qq;
         sudo apt install -qq qt5-default libqt5x11extras5-dev qttools5-dev libx11-dev libqt5svg5-dev libx11-xcb-dev
     - name: Create build environment
+      if: matrix.language == 'cpp'
       run: cmake -E make_directory ${{ runner.workspace }}/build
     - name: Configure CMake
+      if: matrix.language == 'cpp'
       shell: bash
       working-directory: ${{ runner.workspace }}/build
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
     - name: Build
+      if: matrix.language == 'cpp'
       working-directory: ${{ runner.workspace }}/build
       run: cmake --build . --config Release --target birdtray
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:


### PR DESCRIPTION
This avoids the following warning which is currently generated for pull requests:
![1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.](https://user-images.githubusercontent.com/6966049/104821259-e0ee6780-583a-11eb-971d-be751491c3bb.png)

We also skip the build steps now when analyzing the Python files, because it is not needed.
@gyunaev Since this is somewhat security related, I'd like a second pair of eyes.