### PR TITLE
Improve how the list of watched mork files is stored at runtime

### DIFF
--- a/src/modelaccounttree.cpp
+++ b/src/modelaccounttree.cpp
@@ -13,9 +13,9 @@ ModelAccountTree::ModelAccountTree(QObject* parent, QTreeView* treeView)
         : QAbstractItemModel(parent), QStyledItemDelegate(parent) {
     Settings* settings = BirdtrayApp::get()->getSettings();
     // Get the current settings in proper(stored) order
-    for (const QString& path : settings->mFolderNotificationList) {
+    for (const QString& path : settings->watchedMorkFiles.orderedKeys()) {
         mAccounts.push_back(path);
-        mColors.push_back(settings->mFolderNotificationColors[path]);
+        mColors.push_back(settings->watchedMorkFiles[path]);
     }
     treeView->setModel(this);
     treeView->setItemDelegateForColumn(1, this);
@@ -164,11 +164,8 @@ void ModelAccountTree::clear()
 
 void ModelAccountTree::applySettings() {
     Settings* settings = BirdtrayApp::get()->getSettings();
-    settings->mFolderNotificationColors.clear();
-    settings->mFolderNotificationList.clear();
-
+    settings->watchedMorkFiles.clear();
     for (int i = 0; i < mAccounts.size(); i++) {
-        settings->mFolderNotificationList.push_back(mAccounts[i]);
-        settings->mFolderNotificationColors[mAccounts[i]] = mColors[i];
+        settings->watchedMorkFiles[mAccounts[i]] = mColors[i];
     }
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -9,6 +9,7 @@
 #include <QSettings>
 
 #include "setting_newemail.h"
+#include "utils.h"
 
 class QSettings;
 
@@ -131,10 +132,11 @@ class Settings
         bool    mNewEmailMenuEnabled;
         QList< Setting_NewEmail >   mNewEmailData;
 
-        // Maps the folder path to the notification color.
-        // The original order of strings is stored in mFolderNotificationList (to show in UI)
-        QMap< QString, QColor >   mFolderNotificationColors;
-        QStringList               mFolderNotificationList;
+        /**
+         * A mapping of watched mork files to their notification color
+         * in the order the user added them.
+         */
+        OrderedMap<QString, QColor> watchedMorkFiles;
 
         // If non-zero, specifies an interval in seconds for rereading index files even if they didn't change. 0 disables.
         unsigned int    mIndexFilesRereadIntervalSec;

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -65,13 +65,13 @@ TrayIcon::TrayIcon(bool showSettings)
         doAutoUpdateCheck();
     }
     
-    if (settings->mFolderNotificationList.isEmpty()) {
+    if (settings->watchedMorkFiles.isEmpty()) {
         unreadEmailsAtStart = 0;
     }
     
     // If the settings are not yet configure, pop up the message
     if (!showSettings && settings->showDialogIfNoAccountsConfigured
-        && settings->mFolderNotificationColors.isEmpty()) {
+        && settings->watchedMorkFiles.isEmpty()) {
         QMessageBox questionDialog(QMessageBox::Question, tr("Would you like to set up Birdtray?"),
                 tr("You have not yet configured any email folders to monitor. "
                    "Would you like to do it now?"), QMessageBox::Yes | QMessageBox::No);

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -52,10 +52,11 @@ const QMap<QString, QString> &UnreadMonitor::getWarnings() const {
 
 void UnreadMonitor::slotSettingsChanged()
 {
+    Settings* settings = BirdtrayApp::get()->getSettings();
     // And activate it if settings specify so
-    if ( BirdtrayApp::get()->getSettings()->mIndexFilesRereadIntervalSec > 0 )
+    if ( settings->mIndexFilesRereadIntervalSec > 0 )
     {
-        mForceUpdateTimer.setInterval( BirdtrayApp::get()->getSettings()->mIndexFilesRereadIntervalSec * 1000 );
+        mForceUpdateTimer.setInterval( settings->mIndexFilesRereadIntervalSec * 1000 );
         mForceUpdateTimer.start();
     }
     else
@@ -64,7 +65,7 @@ void UnreadMonitor::slotSettingsChanged()
     // We reinitialize everything because the settings changed
     mMorkUnreadCounts.clear();
 
-    QStringList accountsList = BirdtrayApp::get()->getSettings()->mFolderNotificationList;
+    const QStringList &accountsList = settings->watchedMorkFiles.orderedKeys();
     for (const QString &path : warnings.keys()) {
         if (!accountsList.contains(path)) {
             clearWarning(path);
@@ -101,7 +102,7 @@ void UnreadMonitor::updateUnread()
 
 void UnreadMonitor::forceUpdateUnread()
 {
-    mChangedMSFfiles = BirdtrayApp::get()->getSettings()->mFolderNotificationColors.keys();
+    mChangedMSFfiles = BirdtrayApp::get()->getSettings()->watchedMorkFiles.orderedKeys();
     updateUnread();
 }
 
@@ -123,7 +124,7 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
     if ( rescanall )
     {
         mMorkUnreadCounts.clear();
-        for (const QString &path : settings->mFolderNotificationColors.keys()) {
+        for (const QString &path : settings->watchedMorkFiles.orderedKeys()) {
             mMorkUnreadCounts[path] = getMorkUnreadCount(path);
             if (!mDBWatcher.files().contains(path) && !mDBWatcher.addPath(path)) {
                 setWarning(tr("Unable to watch %1 for changes.")
@@ -148,11 +149,11 @@ void UnreadMonitor::getUnreadCount_Mork(int &count, QColor &color)
             count += mMorkUnreadCounts[ tpath ];
 
             if ( chosenColor.isValid() ) {
-                if (chosenColor != settings->mFolderNotificationColors[tpath]) {
+                if (chosenColor != settings->watchedMorkFiles[tpath]) {
                     chosenColor = settings->mNotificationDefaultColor;
                 }
             } else {
-                chosenColor = settings->mFolderNotificationColors[ tpath ];
+                chosenColor = settings->watchedMorkFiles[tpath];
             }
         }
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,6 @@
-#ifndef UTILS_H
-#define UTILS_H
+#pragma once
 
+#include <QMap>
 #include <QString>
 #include <QtCore/QFileInfo>
 
@@ -100,4 +100,78 @@ class Utils
         static QPixmap pixmapFromString(const QString &data);
 };
 
-#endif // UTILS_H
+
+/**
+ * A map that keeps track of the insertion order it's elements.
+ *
+ * @tparam Key The type of the map keys.
+ * @tparam T The type of the element values.
+ */
+template<class Key, class T>
+class OrderedMap {
+public:
+    
+    /**
+     * Access an element of the map by it's key or create a new entry.
+     * @param key The key of the (new) element.
+     * @return The value stored in the map for the given key.
+     */
+    T &operator[](const Key &key) {
+        if (!storage.contains(key)) {
+            order.push_back(key);
+        }
+        return storage[key];
+    }
+    
+    /**
+     * Access an element of the map by it's key.
+     * @param key The key of the element.
+     * @return The value stored in the map for the given key.
+     */
+    T operator[](const Key &key) const {
+        return storage[key];
+    }
+    
+    /**
+     * @return The keys of all elements stored in the map in the order they were inserted.
+     */
+    const QList<Key> &orderedKeys() const {
+        return order;
+    }
+    
+    /**
+     * Clear all elements from the map.
+     */
+    void clear() {
+        storage.clear();
+        order.clear();
+    }
+    
+    /**
+     * Remove an element from the map.
+     *
+     * @param key The key of the element to remove.
+     */
+    void remove(Key key) {
+        storage.remove(key);
+        order.removeOne(key);
+    }
+    
+    /**
+     * @return Whether or not the map is empty.
+     */
+    bool isEmpty() const {
+        return storage.isEmpty();
+    }
+
+private:
+    /**
+     * A list storing the keys of the values in the map in insertion order.
+     */
+    QList<Key> order = {};
+    
+    /**
+     * The actual map that sores the key - value pairs.
+     */
+    QMap<Key, T> storage = {};
+};

--- a/tests/src/test_utils.cpp
+++ b/tests/src/test_utils.cpp
@@ -92,7 +92,7 @@ TEST(UtilsTest, orderedMapOrder) {
         map[valuePair[0]] = valuePair[1];
     }
     const QList<int> &orderedKeys = map.orderedKeys();
-    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+    EXPECT_EQ(numUniqueValues, (size_t) orderedKeys.size())
                     << "Expected the orderedKeys attribute of the OrderedMap to contain "
                        "the same number of keys as the list of unique key-value pairs";
     for (size_t i = 0; i < numUniqueValues; i++) {
@@ -102,7 +102,7 @@ TEST(UtilsTest, orderedMapOrder) {
     }
     map.remove(3);
     numUniqueValues--;
-    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+    EXPECT_EQ(numUniqueValues, (size_t) orderedKeys.size())
                     << "Expected removing an element from the OrderedMap "
                        "to also remove one element from the orderedKeys attribute";
     EXPECT_FALSE(std::any_of(orderedKeys.begin(), orderedKeys.end(),
@@ -115,7 +115,7 @@ TEST(UtilsTest, orderedMapOrder) {
     EXPECT_EQ(indexBefore, indexAfter)
                     << "Expected overwriting an element from the OrderedMap "
                        "to not change it's index in the orderedKeys attribute";
-    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+    EXPECT_EQ(numUniqueValues, (size_t) orderedKeys.size())
                     << "Expected overwriting an element from the OrderedMap "
                        "not to add a new element to the orderedKeys attribute";
 }

--- a/tests/src/test_utils.cpp
+++ b/tests/src/test_utils.cpp
@@ -67,3 +67,73 @@ TEST(UtilsTest, formatGithubMarkdown_links) {
     }
 }
 
+TEST(UtilsTest, orderedMapStorage) {
+    const int values[][2] = {{1, 2}, {3, 4}, {5, 5}, {6, 7}};
+    OrderedMap<int, int> map;
+    for (auto &valuePair : values) {
+        map[valuePair[0]] = valuePair[1];
+    }
+    for (auto &valuePair : values) {
+        EXPECT_EQ(map[valuePair[0]], valuePair[1])
+                        << "Expected the OrderedMap to store the entry with the key "
+                        << valuePair[0];
+    }
+    map[1] = 3;
+    EXPECT_EQ(map[1], 3) << "Expected the OrderedMap to update an existing entry";
+    const int value = map[1];
+    EXPECT_EQ(value, 3) << "Expected the OrderedMap to allow access with the const operator";
+}
+
+TEST(UtilsTest, orderedMapOrder) {
+    const int values[][2] = {{6, 2}, {3, 4}, {5, 5}, {1, 7}};
+    size_t numUniqueValues = GTEST_ARRAY_SIZE_(values);
+    OrderedMap<int, int> map;
+    for (auto &valuePair : values) {
+        map[valuePair[0]] = valuePair[1];
+    }
+    const QList<int> &orderedKeys = map.orderedKeys();
+    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+                    << "Expected the orderedKeys attribute of the OrderedMap to contain "
+                       "the same number of keys as the list of unique key-value pairs";
+    for (size_t i = 0; i < numUniqueValues; i++) {
+        EXPECT_EQ(values[i][0], orderedKeys[i])
+                        << "Expected the keys in the orderedKeys attribute of the "
+                           "OrderedMap to be in the order they where inserted.";
+    }
+    map.remove(3);
+    numUniqueValues--;
+    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+                    << "Expected removing an element from the OrderedMap "
+                       "to also remove one element from the orderedKeys attribute";
+    EXPECT_FALSE(std::any_of(orderedKeys.begin(), orderedKeys.end(),
+            [](int element) { return element == 3; }))
+                    << "Expected removing an element from the OrderedMap "
+                       "to also remove it from the orderedKeys attribute";
+    size_t indexBefore = std::find(orderedKeys.begin(), orderedKeys.end(), 6) - orderedKeys.begin();
+    map[6] = 1;
+    size_t indexAfter = std::find(orderedKeys.begin(), orderedKeys.end(), 6) - orderedKeys.begin();
+    EXPECT_EQ(indexBefore, indexAfter)
+                    << "Expected overwriting an element from the OrderedMap "
+                       "to not change it's index in the orderedKeys attribute";
+    EXPECT_EQ(numUniqueValues, orderedKeys.size())
+                    << "Expected overwriting an element from the OrderedMap "
+                       "not to add a new element to the orderedKeys attribute";
+}
+
+TEST(UtilsTest, orderedMapClear) {
+    const int values[][2] = {{6, 2}, {3, 4}, {5, 5}, {1, 7}};
+    OrderedMap<int, int> map;
+    for (auto &valuePair : values) {
+        map[valuePair[0]] = valuePair[1];
+    }
+    EXPECT_FALSE(map.isEmpty())
+                    << "Expected the OrderedMap not to be empty after adding some values";
+    EXPECT_FALSE(map.orderedKeys().isEmpty())
+                    << "Expected the the orderedKeys attribute of the OrderedMap "
+                       "not to be empty after adding some values to the OrderedMap";
+    map.clear();
+    EXPECT_TRUE(map.isEmpty()) << "Expected the OrderedMap to be empty after being cleared";
+    EXPECT_TRUE(map.orderedKeys().isEmpty())
+                    << "Expected the the orderedKeys attribute of the OrderedMap "
+                       "to be empty after the OrderedMap cleared";
+}


### PR DESCRIPTION
This merges the `mFolderNotificationColors` and `mFolderNotificationList` into one variable called `watchedMorkFiles`; an ordered map.
This avoids inconsistencies between the two and fixes a potential bug where we would duplicate each watched mork file in the `mFolderNotificationList` if we reloaded the settings (which is not possible at the moment, so not a problem yet).

I also added tests for the OrderedMap.
If you prefer it, I can move the OrderedMap into a new header file.