### PR TITLE
Fix inverted blinking speed when fade is enabled

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -333,10 +333,11 @@ void TrayIcon::enableBlinking(bool enabled)
 
         // If we are using the alpha transition, we have to update icon more often
         if (settings->mBlinkingUseAlphaTransition) {
-            mBlinkingDelta = settings->mBlinkSpeed / 100.0;
-            mBlinkingTimeout = 100;
+            mBlinkingDelta = std::min(1.0, (2.0 / settings->mBlinkSpeed));
+            mBlinkingTimeout = settings->mBlinkSpeed == 1 ? 50 : 100;
         } else {
-            // The blinking speed slider is a value from 0 to 30, so we make it 50x
+            // The blinking speed slider is a value from 0 to 30,
+            // so we make it 50x so the maximum is 1500 ms.
             mBlinkingDelta = 0;
             mBlinkingTimeout = settings->mBlinkSpeed * 50;
         }


### PR DESCRIPTION
Fixes #455. Also makes the total time of one blink operation the same regardless of whether fading is enabled or not.
The slowest blink (the duration of one on & off) is 3 seconds for both.