### PR TITLE
Specify the exact Qt version to build with for GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x64]
-        qt_version: [5.9, 5.14.1]
+        qt_version: [5.9.9, 5.14.1]
         include:
           - os: windows-latest
             arch: x86
@@ -21,7 +21,7 @@ jobs:
         exclude:
           # We only want to test for the latest version of Qt on Windows
           - os: windows-latest
-            qt_version: 5.9
+            qt_version: 5.9.9
           # We only compile for the current architecture of the runner for Linux
           - os: ubuntu-latest
             arch: x86


### PR DESCRIPTION
The `jurplel/install-qt-action@v2` action seems to require this now.

This fixes the currently failing GitHub actions workflow.