### PR TITLE
Make getting unread message count more reliable

### DIFF
--- a/src/morkparser.cpp
+++ b/src/morkparser.cpp
@@ -790,7 +790,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
 
     for ( TableScopeMap::iterator tit = p.mork_.begin(); tit != p.mork_.end(); ++tit )
     {
-        printf("Table scope %02X\n", tit.key() );
+        printf("Table scope %02X (%s)\n", tit.key(), qPrintable(p.getColumn(tit.key())) );
         const MorkTableMap& map = tit.value();
 
         for ( MorkTableMap::const_iterator mit = map.begin(); mit != map.end(); ++mit )
@@ -801,7 +801,7 @@ int MorkParser::dumpMorkFile( const QString& filename )
 
             for ( RowScopeMap::const_iterator rsit = rowscopemap.begin(); rsit != rowscopemap.end(); ++rsit )
             {
-                printf("    Row scope %02X\n", rsit.key() );
+                printf("    Row scope %02X (%s)\n", rsit.key(), qPrintable(p.getColumn(rsit.key())) );
 
                 const MorkRowMap& rows = rsit.value();
 
@@ -827,7 +827,12 @@ int MorkParser::dumpMorkFile( const QString& filename )
 }
 
 unsigned int MailMorkParser::getNumUnreadMessages() {
-    const MorkRowMap* rows = this->rows(0x9F, 1, 0x9F);
+    const int scopeId = this->columns_.key(MorkDbFolderInfoScope);
+    if (!scopeId) {
+        Log::debug("Mork table %s not found", MorkDbFolderInfoScope);
+        return 0;
+    }
+    const MorkRowMap* rows = this->rows(scopeId, 1, scopeId);
     if (rows) {
         for (MorkRowMap::const_iterator rit = rows->begin(); rit != rows->cend(); rit++) {
             MorkCells cells = rit.value();

--- a/src/morkparser.h
+++ b/src/morkparser.h
@@ -54,6 +54,8 @@ const char MorkMagicHeader[] = "// <!-- <mdb:mork:z v=\"1.4\"/> -->";
 
 const char MorkDictColumnMeta[] = "<(a=c)>";
 
+const char MorkDbFolderInfoScope[] = "ns:msg:db:row:scope:dbfolderinfo:all";
+
 // Error codes
 enum MorkErrors
 {


### PR DESCRIPTION
Shoud fix #511.

When getting the unread message count from an `.nsf` file, Birdtray currently looks for a cell named `numNewMsgs` in the first row of the table with scope ID 9E. I noticed that with my version of Thunderbird, the table with the `numNewMsgs` cell has scope ID 9E instead of 9F:

```
$ birdtray --dump-mork INBOX.msf
<...>
Table scope 9E (ns:msg:db:row:scope:dbfolderinfo:all)
  Table ID 1
    Row scope 9E (ns:msg:db:row:scope:dbfolderinfo:all)
      Row id 1
          cell flags, value 88083214
          cell numMsgs, value b96
          cell numNewMsgs, value 0
          cell expungedBytes, value 7b1a9f
          cell highWaterKey, value 2820
          cell mailboxName, value INBOX
          cell UIDValidity, value 4e83a32d
          cell totPendingMsgs, value 0
          cell version, value 1
          cell forceReparse, value 0
          cell fixedBadRefThreading, value 1
          cell onlineName, value INBOX
          cell MRUTime, value 1662055769
          cell sortType, value 12
          cell sortOrder, value 2
          cell viewFlags, value 1
          cell viewType, value 0
          cell sortColumns, value 21
          cell columnStates, value {"selectCol":{"visible":false,"ordinal":"1"},"threadCol":{"visible":true,"ordinal":"3"},"flaggedCol":{"visible":true,"ordinal":"5"},"attachmentCol":{"visible":true,"ordinal":"7"},"subjectCol":{"visible":true,"ordinal":"9"},"unreadButtonColHeader":{"visible":true,"ordinal":"11"},"senderCol":{"visible":false,"ordinal":"13"},"recipientCol":{"visible":false,"ordinal":"15"},"correspondentCol":{"visible":true,"ordinal":"17"},"junkStatusCol":{"visible":true,"ordinal":"19"},"receivedCol":{"visible":false,"ordinal":"21"},"dateCol":{"visible":true,"ordinal":"23"},"statusCol":{"visible":false,"ordinal":"25"},"sizeCol":{"visible":false,"ordinal":"27"},"tagsCol":{"visible":false,"ordinal":"29"},"accountCol":{"visible":false,"ordinal":"31"},"priorityCol":{"visible":false,"ordinal":"33"},"unreadCol":{"visible":false,"ordinal":"35"},"totalCol":{"visible":false,"ordinal":"37"},"locationCol":{"visible":false,"ordinal":"39"},"idCol":{"visible":false,"ordinal":"41"},"deleteCol":{"visible":false,"ordinal":"43"}}
          cell highestModSeq, value 29684
          cell imapFlags, value ee00
          cell highestRecordedUID, value 2820
          cell useServerRetention, value 1
          cell MRMTime, value 1657905010
<...>
```

This PR changes `MailMorkParser::getNumUnreadMessages()` to look for the scope ID of that table by its string value: `ns:msg:db:row:scope:dbfolderinfo:all`. That fixes getting the number of unread messages on my system and should make it more reliable in general.  The patch also modifies `MorkParser::dumpMorkFile()` to dump scope names as strings along integer IDs to make debugging easier.