### PR TITLE
Open the installer download page when the wrong bitness is detected

### DIFF
--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -260,12 +260,14 @@ FunctionEnd
         !if ${PLATFORM} == x86
             MessageBox MB_OKCANCEL|MB_ICONINFORMATION \
                 "$(Install64On32BitWarning)" /SD IDOK IDOK Continue
+            ${OpenURL} ${URL_DOWNLOAD}
             Quit
             Continue:
         !endif
     ${else}
         !if ${PLATFORM} == x64
             MessageBox MB_ICONSTOP "$(Install32On64BitError)" /SD IDOK
+            ${OpenURL} ${URL_DOWNLOAD}
             Quit
         !endif
     ${endif}

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -47,6 +47,7 @@ Var RunningFromInstaller # Installer started uninstaller using /uninstall parame
 !define URL_HELP_LINK "https://github.com/gyunaev/birdtray/wiki" # "Support Information" link
 !define URL_UPDATE_INFO "https://github.com/gyunaev/birdtray/releases" # "Product Updates" link
 !define URL_INFO_ABOUT "https://www.ulduzsoft.com/" # "Publisher" link
+!define URL_DOWNLOAD "https://github.com/gyunaev/birdtray/releases/latest"
 !define MIN_WINDOWS_VER "XP"
 
 # Paths


### PR DESCRIPTION
This is a small improvement to the Windows installer.
When the user downloads the installer with the wrong bitness (e.g. 32 bit installer on 64 bit Windows or vice versa) and they decide to cancel the installation at the warning dialog, the Birdtray GitHub download page for the latest release will automatically open for them in their default browser. This way the user can download the correct installer faster.