### PR TITLE
Update and improve the GitHub Actions CI

### DIFF
--- a/.github/problem-matchers/compiler.json
+++ b/.github/problem-matchers/compiler.json
@@ -1,0 +1,32 @@
+{
+  "__comment": "Matches warnings and errors from the compiler",
+  "problemMatcher": [
+    {
+      "owner": "compiler-gcc",
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    },
+    {
+      "owner": "compiler-msvc",
+      "pattern": [
+        {
+          "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(?:fatal\\s+)?(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "code": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,35 +12,29 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['cpp', 'python']
+    permissions:
+      security-events: write
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
+        languages: cpp, python
     - name: Install additional dependencies
-      if: matrix.language == 'cpp'
       shell: bash
       run: |
         sudo apt-get update -qq;
         sudo apt install -qq qt5-default libqt5x11extras5-dev qttools5-dev libx11-dev libqt5svg5-dev libx11-xcb-dev
     - name: Create build environment
-      if: matrix.language == 'cpp'
       run: cmake -E make_directory ${{ runner.workspace }}/build
     - name: Configure CMake
-      if: matrix.language == 'cpp'
       shell: bash
       working-directory: ${{ runner.workspace }}/build
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
     - name: Build
-      if: matrix.language == 'cpp'
       working-directory: ${{ runner.workspace }}/build
       run: cmake --build . --config Release --target birdtray
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,11 +22,17 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: cpp, python
+    - name: Install Qt ${{ matrix.qt_version }}
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: 5.14.1
+        cache: true
+        dir: ${{ runner.temp }}/Qt
     - name: Install additional dependencies
       shell: bash
       run: |
         sudo apt-get update -qq;
-        sudo apt install -qq qt5-default libqt5x11extras5-dev qttools5-dev libx11-dev libqt5svg5-dev libx11-xcb-dev
+        sudo apt install -qq libx11-dev libqt5svg5-dev libx11-xcb-dev
     - name: Create build environment
       run: cmake -E make_directory ${{ runner.workspace }}/build
     - name: Configure CMake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,10 +131,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Check if this is a deployment build
+        id: deploy_check
         shell: bash
         run: |
-          if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Creating release ${{ github.ref }}..."
+          if [[ '${{ github.event.ref }}' =~ ^refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Creating release ${BASH_REMATCH[1]}..."
+            echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           else
             echo "Tag does not match: ${{ github.event.ref }}"
             exit 1
@@ -152,7 +154,7 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          name: Release ${{ github.ref }}
+          name: Release ${{ steps.deploy_check.outputs.version }}
           draft: true
           artifacts: installer*/Birdtray-*.exe
           artifactContentType: application/x-msdownload

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,62 +139,22 @@ jobs:
             echo "Tag does not match: ${{ github.event.ref }}"
             exit 1
           fi
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download installer (x86)
+        uses: actions/download-artifact@v3
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: installer-Windows-x86-${{ github.sha }}
+          path: installer-x86
+      - name: Download installer (x64)
+        uses: actions/download-artifact@v3
+        with:
+          name: installer-Windows-x64-${{ github.sha }}
+          path: installer-x64
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref }}
           draft: true
-          prerelease: false
-      - name: Write upload url file
-        run: echo "${{ steps.create_release.outputs.upload_url }}" > upload_url.txt
-      - name: Cache upload url
-        uses: actions/upload-artifact@v3
-        with:
-          name: upload_url
-          path: upload_url.txt
-
-  deploy:
-    name: Deploy
-    needs: [build, release]
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        arch: [x86, x64]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Download installer
-        uses: actions/download-artifact@v3
-        with:
-          name: installer-${{ runner.os }}-${{ matrix.arch }}-${{ github.sha }}
-          path: installer
-      - name: Find installer
-        id: find_installer_file
-        shell: bash
-        run: |
-          value=`find installer -name "Birdtray-*.exe" -exec basename {} \;`
-          echo "installer_file=$value" >> $GITHUB_OUTPUT
-      - name: Fetch the upload url
-        uses: actions/download-artifact@v3
-        with:
-          name: upload_url
-      - name: Read the upload url
-        id: get_upload_url
-        shell: bash
-        run: |
-          value=`cat upload_url/upload_url.txt`
-          echo "upload_url=$value" >> $GITHUB_OUTPUT
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-          asset_path: ./installer/${{ steps.find_installer_file.outputs.installer_file }}
-          asset_name: ${{ steps.find_installer_file.outputs.installer_file }}
-          asset_content_type: application/x-msdownload
+          artifacts: installer*/Birdtray-*.exe
+          artifactContentType: application/x-msdownload
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,9 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
         run: cmake $GITHUB_WORKSPACE $CMAKE_PLATFORM_ARG -DCMAKE_BUILD_TYPE=Release -DCOMPILER_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_TESTS=ON -DDONT_EXECUTE_INSTALLER=ON
       - name: Register build problem matchers
-        run: echo "::add-matcher::.github/problem-matchers/linguist.json"
+        run: |
+          echo "::add-matcher::.github/problem-matchers/linguist.json"
+          echo "::add-matcher::.github/problem-matchers/compiler.json"
       - name: Build
         working-directory: ${{ runner.workspace }}/build
         run: cmake --build . --config Release --target birdtray
@@ -71,6 +73,8 @@ jobs:
         run: |
           echo "::remove-matcher owner=linguist::"
           echo "::remove-matcher owner=linguist-old::"
+          echo "::remove-matcher owner=compiler-gcc::"
+          echo "::remove-matcher owner=compiler-msvc::"
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target tests && cmake --build . --config Release --target run_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,19 +27,13 @@ jobs:
             arch: x86
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Cache Qt ${{ matrix.qt_version }}
-        id: cache-qt
-        uses: actions/cache@v1
-        with:
-          path: ${{ runner.temp }}/Qt
-          key: ${{ runner.os }}-${{ matrix.arch }}-Qt-${{ matrix.qt_version }}
+        uses: actions/checkout@v3
       - name: Install Qt ${{ matrix.qt_version }}
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt_version }}
           arch: ${{ matrix.qt_compile_suite }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
           dir: ${{ runner.temp }}/Qt
       - name: Install additional dependencies
         shell: bash
@@ -118,7 +112,7 @@ jobs:
           mkdir installer/cache
           mv installer/$installerFile installer/cache
       - name: Cache installer
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: steps.check-deploy.outputs.is_deploy == 'true'
         with:
           name: installer-${{ runner.os }}-${{ matrix.arch }}-${{ github.sha }}
@@ -131,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check if this is a deployment build
         shell: bash
         run: |
@@ -154,7 +148,7 @@ jobs:
       - name: Write upload url file
         run: echo "${{ steps.create_release.outputs.upload_url }}" > upload_url.txt
       - name: Cache upload url
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: upload_url
           path: upload_url.txt
@@ -168,9 +162,9 @@ jobs:
         arch: [x86, x64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download installer
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: installer-${{ runner.os }}-${{ matrix.arch }}-${{ github.sha }}
           path: installer
@@ -181,7 +175,7 @@ jobs:
           value=`find installer -name "Birdtray-*.exe" -exec basename {} \;`
           echo ::set-output name=installer_file::$value
       - name: Fetch the upload url
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: upload_url
       - name: Read the upload url

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           if [[ '${{ github.event.ref }}' =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ && "$RUNNER_OS" == "Windows" ]]; then
-            echo ::set-output name=is_deploy::true
+            echo "is_deploy=true" >> $GITHUB_OUTPUT
             echo "Deployment build detected"
           else
             echo "Not a deployment build, skipping deploy steps"
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           installerFile=`find . -name "Birdtray-*.exe" -exec basename {} \;`
-          echo ::set-output name=installer_file::$installerFile
+          echo "installer_file=$installerFile" >> $GITHUB_OUTPUT
           echo "Found installer: $installerFile"
           mkdir installer/cache
           mv installer/$installerFile installer/cache
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         run: |
           value=`find installer -name "Birdtray-*.exe" -exec basename {} \;`
-          echo ::set-output name=installer_file::$value
+          echo "installer_file=$value" >> $GITHUB_OUTPUT
       - name: Fetch the upload url
         uses: actions/download-artifact@v3
         with:
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           value=`cat upload_url/upload_url.txt`
-          echo ::set-output name=upload_url::$value
+          echo "upload_url=$value" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,9 +12,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Check translation filenames


### PR DESCRIPTION
This updates the actions used in our GitHub Actions CI. This actually seems to have speed up the CI a bit, and it gets rid of these warnings:
![GitHub Action warnings](https://user-images.githubusercontent.com/6966049/201690624-a8ea7bdd-408e-483c-b11a-0d2169529e5c.png)

This meant we had to switch away from the old and now unmaintained action to create a release and switch to another. This has simplified the release workflow and it also has some cool new features like automatically generating a changelog:
![Example release](https://user-images.githubusercontent.com/6966049/201690468-a0badeee-56a0-48f2-8d81-b5c55bb4a0e4.png)

Now you'll notice that there is not really anything there, it's because I run this on my fork and all the other releases there are just drafts, so the action didn't have a base line, I think. But it should work for the main repository when you create the release, it should include a list of commits since the last release, and all contributors that have committed since the last release.
The release will still be a draft and you can then edit it and the changelog as normal, just like before.

Additionally, I added some matchers for compiler warnings and errors, so these will now show up on GitHub directly at the line in the code that caused them, if someone submits a PR:
![Compiler errors](https://user-images.githubusercontent.com/6966049/201690483-034ff8a9-1276-4189-89d3-a0e96c708bc5.png)