### PR TITLE
Directly restore a hidden and minimized Thunderbird window

### DIFF
--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -119,9 +119,10 @@ bool WindowTools_Win::show() {
     if (!checkWindow()) {
         return false;
     }
-    ShowWindow(this->thunderbirdWindow, SW_SHOW);
     if (IsIconic(this->thunderbirdWindow)) {
         ShowWindow(this->thunderbirdWindow, SW_RESTORE);
+    } else {
+        ShowWindow(this->thunderbirdWindow, SW_SHOW);
     }
     if (SetForegroundWindow(this->thunderbirdWindow) == TRUE) {
         emit onWindowShown();


### PR DESCRIPTION
This seems to fix the white spaces that could be seen when restoring a Thunderbird window that was manually minimized. Hopefully fixes #487.

I tested that all normal hide/restore functionality still works as expected, but I would like to get some feedback from the submitter of #487, to make sure that this is effective, because I couldn't 100% reproduce the problem.
I will merge this, once we get some feedback.