### PR TITLE
Update Qt to 5.15.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,14 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x64]
-        qt_version: [5.9.9, 5.14.1]
+        qt_version: [5.9.9, 5.15.2]
         include:
           - os: windows-latest
             arch: x86
-            qt_compile_suite: win32_msvc2017
+            qt_compile_suite: win32_msvc2019
           - os: windows-latest
             arch: x64
-            qt_compile_suite: win64_msvc2017_64
+            qt_compile_suite: win64_msvc2019_64
         exclude:
           # We only want to test for the latest version of Qt on Windows
           - os: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,9 +180,11 @@ endif()
 option(COMPILER_WARNINGS_AS_ERRORS "Fail the build on compiler warnings" OFF)
 if(COMPILER_WARNINGS_AS_ERRORS)
     if(MSVC)
-        target_compile_options(birdtray_lib PUBLIC /W4 /WX)
+        target_compile_options(birdtray_lib PUBLIC /W4 /WX
+                /wd4996) # We ignore deprecated warnings for now
     else()
-        target_compile_options(birdtray_lib PUBLIC -Wall -Wextra -Wpedantic -Werror)
+        target_compile_options(birdtray_lib PUBLIC -Wall -Wextra -Wpedantic -Werror
+                -Wno-deprecated-declarations) # We ignore deprecated warnings for now
     endif()
 endif()
 


### PR DESCRIPTION
This updates the newest Qt version we support to 5.15.2, and update the CI to build with it.
As shown in #434, there are some functions and features that are deprecated that are not trivial to replace.
In the interest of saving time, those deprecated warnings are just ignored for now.

This update fixes #510.