### PR TITLE
Add a setting to the setting dialog for advanced/watchfiletimeout

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -92,6 +92,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     }
     else
         boxForceReread->setChecked( false );
+    spinWatchFileTimerMilliseconds->setValue( static_cast<int>(settings->mWatchFileTimeout) );
 
     // Form the proper command-line (with escaped arguments if they contain spaces
     QString tbcmdline;
@@ -193,6 +194,8 @@ void DialogSettings::accept()
         settings->mIndexFilesRereadIntervalSec = spinForceRereadSeconds->value();
     else
         settings->mIndexFilesRereadIntervalSec = 0;
+    
+    settings->mWatchFileTimeout = spinWatchFileTimerMilliseconds->value();
 
     mModelNewEmails->applySettings();
     mAccountModel->applySettings();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -996,6 +996,50 @@
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <item>
+             <widget class="QLabel" name="label_5">
+              <property name="text">
+               <string>When detecting a change, wait</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinWatchFileTimerMilliseconds">
+              <property name="suffix">
+               <string> milliseconds</string>
+              </property>
+              <property name="maximum">
+               <number>99999</number>
+              </property>
+              <property name="value">
+               <number>150</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_12">
+              <property name="text">
+               <string>before updating the unread counter.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>
@@ -1160,6 +1204,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnShowLogWindow</tabstop>
   <tabstop>boxForceReread</tabstop>
   <tabstop>spinForceRereadSeconds</tabstop>
+  <tabstop>spinWatchFileTimerMilliseconds</tabstop>
   <tabstop>browserAbout</tabstop>
   <tabstop>translatorsButton</tabstop>
  </tabstops>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -500,6 +500,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation>Thunderbird mit einem Klick auf das Systemleistensymbol starten, wenn es geschlossen wurde</translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation>Wenn eine Änderung erkannt wird, warte</translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation> Millisekunden</translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation> bevor die Anzahl ungelesener E-Mails aktualisiert wird.</translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_el.ts
+++ b/src/translations/main_el.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -464,6 +464,18 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_fr.ts
+++ b/src/translations/main_fr.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -501,6 +501,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -499,6 +499,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -469,6 +469,18 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_zh_cn.ts
+++ b/src/translations/main_zh_cn.ts
@@ -540,6 +540,18 @@ p, li { white-space: pre-wrap; }
         <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When detecting a change, wait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> milliseconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>before updating the unread counter.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/unreadmonitor.cpp
+++ b/src/unreadmonitor.cpp
@@ -62,6 +62,8 @@ void UnreadMonitor::slotSettingsChanged()
     }
     else
         mForceUpdateTimer.stop();
+    
+    mChangedMSFtimer.setInterval(static_cast<int>(settings->mWatchFileTimeout));
 
     // We reinitialize everything because the settings changed
     mMorkUnreadCounts.clear();


### PR DESCRIPTION
This allows the user to change this setting in the settings dialog instead of having to go to the settings file directly. Closes #508, sort of.

![The new setting in the advanced tab](https://user-images.githubusercontent.com/6966049/202903442-7d02d067-19ac-4f4a-a097-701d7b78e564.png)
