### PR TITLE
Add the ability to start Thunderbird by clicking on the system tray icon

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -69,6 +69,8 @@ DialogSettings::DialogSettings( QWidget *parent)
     spinMinimumFontSize->setMaximum( settings->mNotificationMaximumFontSize - 1 );
     boxHideWindowAtStart->setChecked( settings->mHideWhenStarted );
     boxHideWindowAtRestart->setChecked( settings->mHideWhenRestarted );
+    boxStartThunderbirdOnTrayIconClick->setChecked( settings->startClosedThunderbird );
+    boxHideWindowAfterManualStart->setChecked( settings->hideWhenStartedManually );
     boxEnableNewEmail->setChecked( settings->mNewEmailMenuEnabled );
     boxBlinkingUsesAlpha->setChecked( settings->mBlinkingUseAlphaTransition );
     checkUpdateOnStartup->setChecked( settings->mUpdateOnStartup );
@@ -162,6 +164,8 @@ void DialogSettings::accept()
     settings->mRestartThunderbird = boxRestartThunderbird->isChecked();
     settings->mHideWhenStarted = boxHideWindowAtStart->isChecked();
     settings->mHideWhenRestarted = boxHideWindowAtRestart->isChecked();
+    settings->startClosedThunderbird = boxStartThunderbirdOnTrayIconClick->isChecked();
+    settings->hideWhenStartedManually = boxHideWindowAfterManualStart->isChecked();
     settings->mNewEmailMenuEnabled = boxEnableNewEmail->isChecked();
     settings->mBlinkingUseAlphaTransition = boxBlinkingUsesAlpha->isChecked();
     settings->mUpdateOnStartup = checkUpdateOnStartup->isChecked();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -576,6 +576,40 @@
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <item>
+             <widget class="QCheckBox" name="boxStartThunderbirdOnTrayIconClick">
+              <property name="text">
+               <string>Start Thunderbird by clicking on the tray icon if it was closed</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="boxHideWindowAfterManualStart">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>and hide it</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>
@@ -1107,6 +1141,8 @@ p, li { white-space: pre-wrap; }
   <tabstop>boxMonitorThunderbirdWindow</tabstop>
   <tabstop>boxRestartThunderbird</tabstop>
   <tabstop>boxHideWindowAtRestart</tabstop>
+  <tabstop>boxStartThunderbirdOnTrayIconClick</tabstop>
+  <tabstop>boxHideWindowAfterManualStart</tabstop>
   <tabstop>boxEnableNewEmail</tabstop>
   <tabstop>treeNewEmails</tabstop>
   <tabstop>btnNewEmailAdd</tabstop>
@@ -1139,12 +1175,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>134</x>
-     <y>104</y>
+     <x>119</x>
+     <y>72</y>
     </hint>
     <hint type="destinationlabel">
-     <x>527</x>
-     <y>104</y>
+     <x>483</x>
+     <y>90</y>
     </hint>
    </hints>
   </connection>
@@ -1155,12 +1191,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>134</x>
-     <y>255</y>
+     <x>130</x>
+     <y>227</y>
     </hint>
     <hint type="destinationlabel">
-     <x>340</x>
-     <y>255</y>
+     <x>322</x>
+     <y>227</y>
     </hint>
    </hints>
   </connection>
@@ -1171,12 +1207,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>103</x>
-     <y>48</y>
+     <x>101</x>
+     <y>45</y>
     </hint>
     <hint type="destinationlabel">
-     <x>115</x>
-     <y>84</y>
+     <x>119</x>
+     <y>81</y>
     </hint>
    </hints>
   </connection>
@@ -1187,12 +1223,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>103</x>
-     <y>48</y>
+     <x>101</x>
+     <y>45</y>
     </hint>
     <hint type="destinationlabel">
-     <x>693</x>
-     <y>197</y>
+     <x>687</x>
+     <y>203</y>
     </hint>
    </hints>
   </connection>
@@ -1203,12 +1239,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>103</x>
-     <y>48</y>
+     <x>101</x>
+     <y>45</y>
     </hint>
     <hint type="destinationlabel">
-     <x>693</x>
-     <y>237</y>
+     <x>687</x>
+     <y>233</y>
     </hint>
    </hints>
   </connection>
@@ -1219,12 +1255,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>103</x>
-     <y>48</y>
+     <x>101</x>
+     <y>45</y>
     </hint>
     <hint type="destinationlabel">
-     <x>693</x>
-     <y>277</y>
+     <x>687</x>
+     <y>263</y>
     </hint>
    </hints>
   </connection>
@@ -1235,12 +1271,12 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>576</x>
-     <y>251</y>
+     <x>580</x>
+     <y>211</y>
     </hint>
     <hint type="destinationlabel">
-     <x>686</x>
-     <y>256</y>
+     <x>678</x>
+     <y>212</y>
     </hint>
    </hints>
   </connection>
@@ -1251,12 +1287,28 @@ p, li { white-space: pre-wrap; }
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>143</x>
-     <y>328</y>
+     <x>165</x>
+     <y>272</y>
     </hint>
     <hint type="destinationlabel">
-     <x>330</x>
-     <y>333</y>
+     <x>302</x>
+     <y>273</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>boxStartThunderbirdOnTrayIconClick</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>boxHideWindowAfterManualStart</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>319</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>402</x>
+     <y>247</y>
     </hint>
    </hints>
   </connection>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -16,6 +16,8 @@
 
 #define BORDER_COLOR_KEY "common/bordercolor"
 #define BORDER_WIDTH_KEY "common/borderwidth"
+#define START_CLOSED_THUNDERBIRD_KEY "common/startClosedThunderbird"
+#define HIDE_WHEN_STARTED_MANUALLY_KEY "common/hideWhenStartedManually"
 #define UPDATE_ON_STARTUP_KEY "advanced/updateOnStartup"
 #define ONLY_SHOW_ICON_ON_UNREAD_MESSAGES_KEY "advanced/onlyShowIconOnUnreadMessages"
 #define READ_INSTALL_CONFIG_KEY "hasReadInstallConfig"
@@ -51,6 +53,8 @@ Settings::Settings()
     mRestartThunderbird = false;
     mHideWhenStarted = false;
     mHideWhenRestarted = false;
+    startClosedThunderbird = false;
+    hideWhenStartedManually = false;
     mAllowSuppressingUnreads = false;
     mLaunchThunderbirdDelay = 0;
     mShowUnreadEmailCount = true;
@@ -94,6 +98,8 @@ void Settings::save()
     out[ "common/monitorthunderbirdwindow" ] = mMonitorThunderbirdWindow;
     out[ "common/hidewhenstarted" ] = mHideWhenStarted;
     out[ "common/hidewhenrestarted" ] = mHideWhenRestarted;
+    out[ START_CLOSED_THUNDERBIRD_KEY ] = startClosedThunderbird;
+    out[ HIDE_WHEN_STARTED_MANUALLY_KEY ] = hideWhenStartedManually;
     out[ "common/allowsuppressingunread" ] = mAllowSuppressingUnreads;
     out[ "common/launchthunderbirddelay" ] = mLaunchThunderbirdDelay;
     out[ "common/showunreademailcount" ] = mShowUnreadEmailCount;
@@ -230,6 +236,8 @@ void Settings::fromJSON( const QJsonObject& settings )
     mRestartThunderbird = settings.value("common/restartthunderbird").toBool();
     mHideWhenStarted = settings.value("common/hidewhenstarted").toBool();
     mHideWhenRestarted = settings.value("common/hidewhenrestarted").toBool();
+    startClosedThunderbird = settings.value(START_CLOSED_THUNDERBIRD_KEY).toBool();
+    hideWhenStartedManually = settings.value(HIDE_WHEN_STARTED_MANUALLY_KEY).toBool();
     mAllowSuppressingUnreads = settings.value("common/allowsuppressingunread").toBool();
     mLaunchThunderbirdDelay = settings.value("common/launchthunderbirddelay").toInt();
     mShowUnreadEmailCount = settings.value("common/showunreademailcount").toBool();
@@ -329,6 +337,8 @@ void Settings::fromQSettings( QSettings * psettings )
             "common/restartthunderbird", mRestartThunderbird ).toBool();
     mHideWhenStarted = settings.value("common/hidewhenstarted", mHideWhenStarted ).toBool();
     mHideWhenRestarted = settings.value("common/hidewhenrestarted", mHideWhenRestarted ).toBool();
+    startClosedThunderbird = settings.value(START_CLOSED_THUNDERBIRD_KEY, startClosedThunderbird ).toBool();
+    hideWhenStartedManually = settings.value(HIDE_WHEN_STARTED_MANUALLY_KEY, hideWhenStartedManually ).toBool();
     mAllowSuppressingUnreads = settings.value(
             "common/allowsuppressingunread", mAllowSuppressingUnreads ).toBool();
     mLaunchThunderbirdDelay = settings.value(

--- a/src/settings.h
+++ b/src/settings.h
@@ -85,6 +85,12 @@ class Settings
         // Whether to hide Thunderbird window after restarting
         bool    mHideWhenRestarted;
 
+        // Whether to start Thunderbird if it is closed and the user clicks on the tray icon
+        bool    startClosedThunderbird;
+    
+        // Whether to hide Thunderbird window after starting it via the system tray icon
+        bool    hideWhenStartedManually;
+
         // Whether to monitor Thunderbird running
         bool    mMonitorThunderbirdWindow;
 

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -496,6 +496,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn aktiviert fügt diese Option dem Kontextmenü die Aktion &quot;Ungelesene E-Mails ignorieren&quot; hinzu. Diese Aktion erlaubt das Ignorieren der momentanen ungelesenen E-Mails. Birdtray ignoriert dann alle zu dem Zeitpunkt ungelesene E-Mails und zeigt nur noch neu hinzukommende E-Mails an.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Gibt es zum Beispiel gerade 10 ungelesene E-Mails und Sie klicken auf die Aktion &quot;Ignorieren&quot;, wird Birdtray keinen Indikator für ungelesene E-Mails anzeigen, solange die Anzahl der ungelesenen E-Mails bei 10 bleibt. Sobald eine neue E-Mail empfangen wird und es somit 11 ungelesene E-Mails gibt, zeigt Birdtray eine ungelesene E-Mail an.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation>Thunderbird mit einem Klick auf das Systemleistensymbol starten, wenn es geschlossen wurde</translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_el.ts
+++ b/src/translations/main_el.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Αυτή είναι η πλήρης γραμμή της εντολής (με τα ορίσματα) για την εκκίνηση του Thunderbird. Τα ορίσματα διαχωρίζονται με κενά, αλλά επιτρέπεται η χρήση κενών μέσα σε εισαγωγικά, π.χ.αυτή η εντολή &lt;span style=&quot; font-weight:600;&quot;&gt;&quot;C:\Program Files\tb.exe&quot; --profile test&lt;/span&gt; είναι έγκυρη.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -456,6 +456,14 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -471,10 +479,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For those of you who appreciate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si se habilita, esta opción añade la acción de &amp;quot;Ignorar correos no leíodos actualmente&amp;quot; al menú contextual. Esta acción le permite ignorar los corresos que actualmente son no leídos&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por ejemplo, si hay 10 correos no leidos, y pulsa en &amp;quot;Ignorar&amp;quot;, Birdtray mostraŕa el indicador de mensajes no leidos mientras el contador de mensajes no leídos permanece en 10. Una vez que un correo nuevo es recibido y tiene 11 correos no leídos totales, Bridtray mostrará el contador de correos nuevos como 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_fr.ts
+++ b/src/translations/main_fr.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Si activée, cette option ajoute le choix &amp;quot;Ignorer les mails actuellement non lus&amp;quot; Ce choix permet d&apos;ignorer les mails qui n&apos;ont pas encore été lus. Birdtray annoncera alors qu&apos;il ne reste aucun mail non lu, et n&apos;affichera que le nombre de mails en plus du nombre de mails ignorés.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Par exemple, s&apos;il y a 10 mails non lus, et si vous cliquez sur &amp;quot;Ignorer&amp;quot;, Birdtray n&apos;affichera rien, tant que le nombre de mails non lus restera à 10. Si vous recevez un nouveau mail, et donc que vous avez 11 mails non lus au total, Birdtray affichera 1 nouveau mail.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se attivata, questa opzione aggiunge il &amp;quot;Ignora le email attualmente non lette&amp;quot; azione nel menu contestuale. Questa azione ti consente di ignorare le e-mail attualmente non lette. Birdtray fingerebbe quindi che non siano rimaste email non lette e mostrerebbe solo le nuove email nel conteggio ignorato.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ad esempio, se c&apos;erano 10 e-mail non lette e hai fatto clic su &amp;quot;Ignora&amp;quot; azione, Birdtray non mostrerà alcun indicatore di e-mail non lette fino a quando il conteggio delle e-mail non lette rimane a 10. Una volta ricevuta la nuova e-mail e il totale di 11 e-mail non lette, Birdtray mostrerà il conteggio delle nuove e-mail come 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -497,6 +497,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kruis dit aan om de optie &amp;quot;Huidige ongelezen e-mails negeren &amp;quot; toe te voegen aan het rechtermuisknopmenu. Birdtray doet dan alsof er geen ongelezen e-mails meer zijn totdat er nieuwe e-mails binnenkomen.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Voorbeeld: Als er 11 ongelezen e-mails zijn en u heeft de optie &amp;quot;Negeren&amp;quot; geactiveerd, dan toont Birdtray geen indicator zolang het aantal op 10 blijft. Zodra er weer nieuwe e-mails binnenkomen, toont Birdtray het aantal vanaf dan, beginnende bij 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Włączenie tej opcji spowoduje dodanie opcji &amp;quot;Ignoruj nieprzeczytane wiadomości&amp;quot; do menu kontekstowego. Opcja ta pozwala na zignorowanie aktualnie nieprzeczytanych wiadomości, Birdtray nie będzie brał tych wiadomości pod uwagę i uwzględni jedynie nowe nieprzeczytane wiadomości.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se ativada, esta opção adiciona a ação &amp;quot;Ignorar e-mails não lidos&amp;quot; ao menu de contexto. Esta ação permite a você ignorar os e-mails não lidos no momento. O Birdtray então entenderá que não há nenhum e-mail não lido restante, e somente mostrar novos e-mails sobre a contagem de ignorados.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Por exemplo, se há 10 e-mails não lidos e você clicar na ação &amp;quot;Ignorar&amp;quot;, o Birdtray irá o indicador de nenhum e-mail não lido enquanto o contador de e-mails não lidos permancer em 10. Assim que um novo e-mail é recebido e você ter 11 e-mails não lidos, o Birdtray irá exibir a contagem de novo e-mail como 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Если этот параметр включен, этот параметр добавляет &amp;quot;Игнорировать непрочитанные в настоящий момент электронные письма&amp;quot; действие в контекстном меню. Это действие позволяет вам игнорировать электронные письма, которые в данный момент не прочитаны. После этого Birdtray будет делать вид, что не осталось непрочитанных писем, и будет показывать только новые письма.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Например, если было 10 непрочитанных писем, и вы нажали &amp;quot;Игнорировать&amp;quot; В этом случае Birdtray не будет показывать индикатор непрочитанных сообщений, если количество непрочитанных сообщений остается на уровне 10. После получения нового сообщения и наличия у вас всего 11 непрочитанных сообщений Birdtray будет отображать количество новых сообщений как 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -495,6 +495,10 @@ p, li { white-space: pre-wrap; }
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Om det är aktiverat, lägger det här alternativet till &amp;quot;Ignorera för närvarande olästa e-postmeddelanden&amp;quot; i snabbmenyn. Den här åtgärden låter dig ignorera de e-postmeddelanden som för närvarande är olästa. Birdtray kommer då att låtsas att det inte finns några olästa e-postmeddelanden kvar och bara visa nya meddelanden som inkommer efter det ignorerade antalet.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Om det till exempel finns 10 olästa e-postmeddelanden och du klickar på &amp;quot;Ignorera&amp;quot;, visar Birdtray ingen oläst e-post så länge antalet olästa e-postmeddelanden ligger kvar på 10. När sedan ny e-post tas emot och du har totalt 11 olästa e-postmeddelanden, kommer Birdtray att visa 1 på räkneverket.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -461,6 +461,14 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -476,10 +484,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For those of you who appreciate my work on Birdtray, which is being developed in my free time, you can do it here: &lt;/span&gt;&lt;a href=&quot;https://paypal.me/ulduzsoft&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;https://paypal.me/ulduzsoft&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, this option adds the &amp;quot;Ignore currently unread emails&amp;quot; action to the context menu. This action allows you to ignore the emails which are currently unread. Birdtray would then pretend there are no unread emails left, and would only show new emails over the ignored count.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;For example, if there were 10 unread emails, and you clicked on &amp;quot;Ignore&amp;quot; action, Birdtray will show no unread email indicator as long as unread email count remains at 10. Once new email is received and you have 11 total unread emails, Birdtray will show the new email count as 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/main_zh_cn.ts
+++ b/src/translations/main_zh_cn.ts
@@ -536,6 +536,10 @@ p, li { white-space: pre-wrap; }
         <source>When showing Thunderbird</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Start Thunderbird by clicking on the tray icon if it was closed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -495,10 +495,17 @@ void TrayIcon::actionActivate()
     if ( !mWinTools )
         return;
 
-    if ( mWinTools->isHidden() )
+    Settings* settings = BirdtrayApp::get()->getSettings();
+    if ( settings->startClosedThunderbird && !mWinTools->lookup() ) {
+        startThunderbird();
+        if (settings->hideWhenStartedManually) {
+            mThunderbirdWindowHide = true;
+        }
+    } else if ( mWinTools->isHidden() ) {
         showThunderbird();
-    else
+    } else {
         hideThunderbird();
+    }
 }
 
 void TrayIcon::actionSnoozeFor()
@@ -560,7 +567,8 @@ void TrayIcon::actionIgnoreEmails()
 
 void TrayIcon::actionSystrayIconActivated(QSystemTrayIcon::ActivationReason reason) {
     if (reason == QSystemTrayIcon::Trigger) {
-        if (BirdtrayApp::get()->getSettings()->mShowHideThunderbird) {
+        Settings* settings = BirdtrayApp::get()->getSettings();
+        if (settings->mShowHideThunderbird || (!mThunderbirdWindowExists && settings->startClosedThunderbird)) {
             actionActivate();
         }
     }


### PR DESCRIPTION
When Thunderbird is not running, the user can now start it by clicking the Birdtray system tray icon. Thunderbird is then optionally hidden. Two settings were added in the `Hiding` tab to control this behaviour.

For details about the feature see #420. This closes #420.

![image](https://user-images.githubusercontent.com/6966049/202903831-6dad37f1-d0f1-43b9-8938-12e08cb5cbb6.png)
