### PR TITLE
Add a setting to change the searched Thunderbird process name on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ if(WIN32)
 
     # Find ssl libraries
     find_package(OpenSSL QUIET)
-    get_filename_component(SSL_PATH ${OPENSSL_SSL_LIBRARY} DIRECTORY)
+    get_filename_component(SSL_PATH "${OPENSSL_SSL_LIBRARY}" DIRECTORY)
     if(SSL_PATH)
         STRING(REGEX REPLACE "/" "\\\\\\\\" SSL_PATH ${SSL_PATH})
     else()

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -64,6 +64,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     boxHideWhenMinimized->setChecked( settings->mHideWhenMinimized );
     boxMonitorThunderbirdWindow->setChecked( settings->mMonitorThunderbirdWindow );
     boxRestartThunderbird->setChecked( settings->mRestartThunderbird );
+    leThunderbirdProcessName->setText( settings->mThunderbirdProcessName );
     leThunderbirdWindowMatch->setText( settings->mThunderbirdWindowMatch  );
     spinMinimumFontSize->setValue( settings->mNotificationMinimumFontSize );
     spinMinimumFontSize->setMaximum( settings->mNotificationMaximumFontSize - 1 );
@@ -154,6 +155,7 @@ void DialogSettings::accept()
     settings->mLaunchThunderbird = boxLaunchThunderbirdAtStart->isChecked();
     settings->mShowHideThunderbird = boxShowHideThunderbird->isChecked();
     settings->mThunderbirdCmdLine = Utils::splitCommandLine( leThunderbirdCmdLine->text() );
+    settings->mThunderbirdProcessName = leThunderbirdProcessName->text();
     settings->mThunderbirdWindowMatch = leThunderbirdWindowMatch->text();
     settings->mHideWhenMinimized = boxHideWhenMinimized->isChecked();
     settings->mNotificationFontWeight = qMin(99, (int) (notificationFontWeight->value() / 2));

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -748,22 +748,6 @@
             <item row="1" column="1" colspan="2">
              <widget class="QLineEdit" name="leThunderbirdWindowMatch"/>
             </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_7">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Thunderbird command line:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_8">
               <property name="sizePolicy">
@@ -780,7 +764,23 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Thunderbird command line:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
              <widget class="QLabel" name="label_11">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -796,7 +796,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1" colspan="2">
+            <item row="3" column="1" colspan="2">
              <widget class="QSpinBox" name="spinMinimumFontSize">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -824,6 +824,19 @@
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="processNameLabel">
+              <property name="text">
+               <string>Thunderbird process name:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1" colspan="2">
+             <widget class="QLineEdit" name="leThunderbirdProcessName"/>
             </item>
            </layout>
           </item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -18,6 +18,12 @@
 #define BORDER_WIDTH_KEY "common/borderwidth"
 #define START_CLOSED_THUNDERBIRD_KEY "common/startClosedThunderbird"
 #define HIDE_WHEN_STARTED_MANUALLY_KEY "common/hideWhenStartedManually"
+#define THUNDERBIRD_PROCESS_NAME_KEY "advanced/tbprocessname"
+#ifdef Q_OS_WIN
+#  define THUNDERBIRD_PROCESS_NAME_DEFAULT "thunderbird.exe"
+#else
+#  define THUNDERBIRD_PROCESS_NAME_DEFAULT "thunderbird"
+#endif /* Q_OS_WIN */
 #define UPDATE_ON_STARTUP_KEY "advanced/updateOnStartup"
 #define ONLY_SHOW_ICON_ON_UNREAD_MESSAGES_KEY "advanced/onlyShowIconOnUnreadMessages"
 #define READ_INSTALL_CONFIG_KEY "hasReadInstallConfig"
@@ -63,6 +69,7 @@ Settings::Settings()
     ignoreUnreadCountOnHide = false;
     showDialogIfNoAccountsConfigured = true;
     mThunderbirdWindowMatch = " Mozilla Thunderbird";
+    mThunderbirdProcessName = THUNDERBIRD_PROCESS_NAME_DEFAULT;
     mNotificationMinimumFontSize = 4;
     mNotificationMaximumFontSize = 512;
     mWatchFileTimeout = 150;
@@ -110,6 +117,7 @@ void Settings::save()
 
     out[ "advanced/tbcmdline" ] = QJsonArray::fromStringList( mThunderbirdCmdLine );
     out[ "advanced/tbwindowmatch" ] = mThunderbirdWindowMatch;
+    out[ THUNDERBIRD_PROCESS_NAME_KEY ] = mThunderbirdProcessName;
     out[ "advanced/notificationfontminsize" ] = static_cast<int>( mNotificationMinimumFontSize );
     out[ "advanced/notificationfontmaxsize" ] = static_cast<int>( mNotificationMaximumFontSize );
     out[ "advanced/watchfiletimeout" ] = static_cast<int>( mWatchFileTimeout );
@@ -250,6 +258,7 @@ void Settings::fromJSON( const QJsonObject& settings )
     showDialogIfNoAccountsConfigured = settings.value("common/showDialogIfNoAccountsConfigured").toBool();
 
     mThunderbirdWindowMatch = settings.value("advanced/tbwindowmatch").toString();
+    mThunderbirdProcessName = settings.value(THUNDERBIRD_PROCESS_NAME_KEY).toString(mThunderbirdProcessName);
     mNotificationMinimumFontSize = settings.value("advanced/notificationfontminsize").toInt();
     mNotificationMaximumFontSize = settings.value("advanced/notificationfontmaxsize").toInt();
     mWatchFileTimeout = settings.value("advanced/watchfiletimeout").toInt();
@@ -361,6 +370,7 @@ void Settings::fromQSettings( QSettings * psettings )
     }
     mThunderbirdWindowMatch = settings.value(
             "advanced/tbwindowmatch", mThunderbirdWindowMatch ).toString();
+    mThunderbirdProcessName = settings.value(THUNDERBIRD_PROCESS_NAME_KEY, mThunderbirdProcessName ).toString();
     mNotificationMinimumFontSize = settings.value(
             "advanced/notificationfontminsize", mNotificationMinimumFontSize ).toInt();
     mNotificationMaximumFontSize = settings.value(

--- a/src/settings.h
+++ b/src/settings.h
@@ -58,6 +58,9 @@ class Settings
         // The command to start Thunderbird. The first element is the executable to launch.
         QStringList mThunderbirdCmdLine;
 
+        // The name of the Thunderbird process.
+        QString mThunderbirdProcessName;
+
         // Thunderbird window match
         QString mThunderbirdWindowMatch;
 

--- a/src/translations/main_cs.ts
+++ b/src/translations/main_cs.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; text-decoration: underline; color:#2980b9;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style= &quot; font-size:8pt;&quot;&gt;Děkuji za vaši nepřetržitou podporu!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -510,7 +510,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>before updating the unread counter.</source>
-        <translation> bevor die Anzahl ungelesener E-Mails aktualisiert wird.</translation>
+        <translation>bevor die Anzahl ungelesener E-Mails aktualisiert wird.</translation>
+    </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation>Thunderbird Prozessname:</translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_el.ts
+++ b/src/translations/main_el.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -476,6 +476,10 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_fr.ts
+++ b/src/translations/main_fr.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -513,6 +513,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -511,6 +511,10 @@ p, li { white-space: pre-wrap; }
         <source>before updating the unread counter.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -481,6 +481,10 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/translations/main_zh_cn.ts
+++ b/src/translations/main_zh_cn.ts
@@ -553,6 +553,10 @@ p, li { white-space: pre-wrap; }
         <translatorcomment>checkTranslation ignore: punctuation_end_differ</translatorcomment>
         <translation>后再更新未读邮件计数器。</translation>
     </message>
+    <message>
+        <source>Thunderbird process name:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -96,7 +96,8 @@ bool WindowTools_Win::lookup() {
         return thunderbirdWindow;
     }
     
-    DWORD thunderbirdProcessId = getProcessId(L"thunderbird.exe");
+    DWORD thunderbirdProcessId = getProcessId(Utils::qToStdWString(
+            BirdtrayApp::get()->getSettings()->mThunderbirdProcessName).c_str());
     if (thunderbirdProcessId == 0) {
         return false;
     }


### PR DESCRIPTION
This setting is only useful on Windows and allows to change the name of the process that is searched to detect if Thunderbird is running. Closes #545.

Changing the setting will take effect when saving, except for if Birdtray already found a process with the old settings.
In that case, Birdtray has to be restarted or the currently tracked process has to exit.
I think that is acceptable, since this is an advanced feature.

![New setting](https://user-images.githubusercontent.com/6966049/232333261-465981a3-eb4a-4f43-8041-a174dd3ef218.png)
