### PR TITLE
Fix not finding OpenSSL library dlls for the installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,11 @@ if(WIN32)
 
     # Find ssl libraries
     find_package(OpenSSL QUIET)
-    get_filename_component(SSL_PATH "${OPENSSL_SSL_LIBRARY}" DIRECTORY)
+    get_filename_component(SSL_LIB_DIR "${OPENSSL_SSL_LIBRARY}" DIRECTORY)
+    # Sometimes, the .lib files are in a lib directory and the .dll files are in the parent directory
+    get_filename_component(SSL_PARENT_DIR "${SSL_LIB_DIR}" DIRECTORY)
+    find_library(SSL_LIB_PATH ssl PATHS "${SSL_LIB_DIR}" "${SSL_PARENT_DIR}")
+    get_filename_component(SSL_PATH "${SSL_LIB_PATH}" DIRECTORY)
     if(SSL_PATH)
         STRING(REGEX REPLACE "/" "\\\\\\\\" SSL_PATH ${SSL_PATH})
     else()


### PR DESCRIPTION
The install layout of the OpenSSL package on CI has changed a bit. `find_package(OpenSSL)` now finds finds `.lib` files in `<...>/OpenSSL/lib`, but we need `.dll` files which are in `<...>/OpenSSL`.

To fix this we just search for the `dll` directly using `find_library` in directory returned by `find_package` and the parent directory.

I have tested that after pushing a `v1.10.1` tag the compilers were build successfully and a release was created. People have been requesting a new release for a while, do we want to notify the active translation maintainers to get the process started?