### PR TITLE
Fix Windows installer build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
           fi
       - name: Install installer dependencies
         if: steps.check-deploy.outputs.is_deploy == 'true'
-        run: choco install -y nsis;
+        run: choco install -y nsis --version=3.6;
       - name: Create installer
         if: steps.check-deploy.outputs.is_deploy == 'true'
         working-directory: ${{ runner.workspace }}/build

--- a/installer/Utils.nsh
+++ b/installer/Utils.nsh
@@ -4,9 +4,9 @@
 !include StrFunc.nsh
 ${StrLoc}
 
-!define ERROR_ALREADY_EXISTS 0x000000b7
-!define ERROR_ACCESS_DENIED 0x5
-!define ERROR_SIGNAL_REFUSED 0x9C
+!define /ifndef ERROR_ALREADY_EXISTS 0x000000b7
+!define /ifndef ERROR_ACCESS_DENIED 0x5
+!define /ifndef ERROR_SIGNAL_REFUSED 0x9C
 
 # === Functions === #
 


### PR DESCRIPTION
This pins the NSIS version, because newer version break our nsis scripts. I tested that this works on a fork.

After merging this we should either create a new version or delete the tag of the current latest version and push a new tag.

Fixes #560.