### PR TITLE
Fix/openssl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
             else
               echo "CMAKE_PLATFORM_ARG=-A x64" >> $GITHUB_ENV
             fi
-            choco install -y --force $archParam openssl.light
+            choco install -y --force $archParam openssl.light --version=1.1.1
             echo "C:\\Program Files\\OpenSSL" >> $GITHUB_PATH
           else
             echo "$RUNNER_OS not supported"

--- a/src/version.h
+++ b/src/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 11
-#define VERSION_PATCH 3
+#define VERSION_PATCH 4
 
 #endif // VERSION_H


### PR DESCRIPTION
We use Qt5.15, which only supports OpenSSL 1.1.1. The latest installer included OpenSSL 3.1.2, which unfortunately broke the auto updater for Windows, because Qt couldn't use the bundled OpenSSL library.

I apologize for the flurry of requests for releases, but I really think it would be best to make a `v1.11.4` release as soon as this is merged, because the previous releases break the automatic updating for all Windows installations. Therefore I would like to ask you to create another release with these changes once this is merged, I already bumped the version number and I marked the `1.11.3` release as a prerelease.

Fixes #566.