### PR TITLE
update appdata

### DIFF
--- a/src/res/com.ulduzsoft.Birdtray.appdata.xml
+++ b/src/res/com.ulduzsoft.Birdtray.appdata.xml
@@ -41,6 +41,9 @@
   <launchable type="desktop-id">com.ulduzsoft.Birdtray.desktop</launchable>
 
   <releases>
+      <release date="2023-09-04" version="1.11.4" urgency="low"/>
+      <release date="2023-09-01" version="1.11.3" urgency="low"/>
+      <release date="2023-08-31" version="1.11.2" urgency="medium"/>
       <release date="2020-10-20" version="1.9.0" urgency="medium"/>
       <release date="2020-04-29" version="1.8.1" urgency="medium"/>
       <release date="2020-04-18" version="1.8.0" urgency="medium"/>


### PR DESCRIPTION
Fixes issues #574 and #576

Flatpak relies on appstream data in order to show versions. @Abestanis would it be easy for you to update the `src/res/com.ulduzsoft.Birdtray.appdata.xml` file and add a release line before a github release in the future?

After an appdata.xml edit it would be wise to run the following command in order to ensure no mistakes (https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/):
```
flatpak run org.freedesktop.appstream-glib validate com.ulduzsoft.Birdtray.appdata.xml
```
