### PR TITLE
Add some steps to verify the appdata metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -qq;
-            sudo apt install -qq libx11-dev libx11-xcb-dev desktop-file-utils
+            sudo apt install -qq libx11-dev libx11-xcb-dev desktop-file-utils appstream-util
           elif [ "$RUNNER_OS" == "Windows" ]; then
             choco install -y --force openssl.light --version=1.1.1
             echo "C:\\Program Files\\OpenSSL" >> $GITHUB_PATH
@@ -62,7 +62,7 @@ jobs:
       - name: Tests
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release --target tests && cmake --build . --config Release --target run_tests
-      - name: Validate desktop file
+      - name: Validate desktop file and app metadata
         working-directory: ${{ github.workspace }}
         if: runner.os == 'Linux'
         shell: bash
@@ -72,6 +72,7 @@ jobs:
             echo "$output";
             exit 1;
           fi
+          appstream-util validate src/res/com.ulduzsoft.Birdtray.appdata.xml
       - name: Check if this is a deployment build
         id: check-deploy
         shell: bash
@@ -125,6 +126,10 @@ jobs:
             echo "Tag does not match: ${{ github.event.ref }}"
             exit 1
           fi
+      - name: Verify that the app metadata contains the release
+        shell: bash
+        run: |
+          grep "version=\"${{ steps.deploy_check.outputs.version }}\"" src/res/com.ulduzsoft.Birdtray.appdata.xml -q || (echo "Version not found in src/res/com.ulduzsoft.Birdtray.appdata.xml"; exit 1)
       - name: Download installer (x64)
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This depends on #580, because with the current screenshot the verification fails with the following error:
```
src/res/com.ulduzsoft.Birdtray.appdata.xml: FAILED:
• attribute-invalid     : <screenshot> width too large [https://raw.githubusercontent.com/gyunaev/birdtray/master/screenshots/birdtray-settings.png] maximum is 1600px
• attribute-invalid     : <screenshot> height too large [https://raw.githubusercontent.com/gyunaev/birdtray/master/screenshots/birdtray-settings.png] maximum is 900px
• style-invalid         : <image> has vertical padding [https://raw.githubusercontent.com/gyunaev/birdtray/master/screenshots/birdtray-settings.png]
• style-invalid         : <image> has horizontal padding [https://raw.githubusercontent.com/gyunaev/birdtray/master/screenshots/birdtray-settings.png]
Validation of files failed
```

The errors disappear with the new screenshot, see the CI on commit 540baeefd6ac4a14c0042dae61748470a4b0a04e.