### PR TITLE
Allow showing/hiding Thunderbird when launched using Wayland platform

### DIFF
--- a/src/windowtools_x11.h
+++ b/src/windowtools_x11.h
@@ -47,6 +47,12 @@ class WindowTools_X11 : public WindowTools
         // Makes sure our window ID is still valid, or reinitializes it
         bool    checkWindow();
 
+        // The display handle to use to talk to the X server
+        Display     *display;
+
+        // The root window ID
+        Window      root;
+
         // Our Window ID
         Window      mWinId;
 


### PR DESCRIPTION
If the Wayland platform is in use, simply connect to the XWayland server directly, and perform queries using that connection.

As long as Thunderbird is running under XWayland, this allows Birdtray to find the window and show/hide it no matter what platform Birdtray is using.

This fixes _some_ of the problems described in e.g. #426, but it is not full Wayland support.