### PR TITLE
Allow to remove account folder with Delete or Backspace keystroke

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
         src/modelaccounttree.cpp
         src/modelnewemails.cpp
         src/morkparser.cpp
+        src/qtcomponents.cpp
         src/setting_newemail.cpp
         src/settings.cpp
         src/trayicon.cpp
@@ -99,6 +100,7 @@ set(HEADERS
         src/modelaccounttree.h
         src/modelnewemails.h
         src/morkparser.h
+        src/qtcomponents.h
         src/setting_newemail.h
         src/settings.h
         src/trayicon.h

--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -1,3 +1,5 @@
+#include <Qt>
+
 #include <QFileDialog>
 #include <QColorDialog>
 #include <QMessageBox>
@@ -117,6 +119,10 @@ DialogSettings::DialogSettings( QWidget *parent)
     mAccountModel = new ModelAccountTree(this, treeAccounts);
     treeAccounts->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     treeAccounts->setCurrentIndex(mAccountModel->index(0, 0));
+    treeAccounts->onKeyPressed(this, [](void * handle, QKeyEvent * event)
+    {
+        static_cast<DialogSettings*>(handle)->onKeyPressedOnTreeAccount(event);
+    });
 
     // New emails tab
     mModelNewEmails = new ModelNewEmails( this );
@@ -148,6 +154,14 @@ DialogSettings::DialogSettings( QWidget *parent)
     processNameLabel->hide();
     leThunderbirdProcessName->hide();
 #endif
+}
+
+void DialogSettings::onKeyPressedOnTreeAccount(QKeyEvent * event)
+{
+    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace)
+    {
+        accountRemove();
+    }
 }
 
 void DialogSettings::accept()
@@ -285,8 +299,13 @@ void DialogSettings::accountEditIndex(const QModelIndex &index)
 
 void DialogSettings::accountRemove()
 {
-    QModelIndex index = treeAccounts->currentIndex();
+    if ( treeAccounts->currentIndex().isValid() )
+        accountRemoveIndex( treeAccounts->currentIndex() );
+}
 
+
+void DialogSettings::accountRemoveIndex(const QModelIndex &index)
+{
     if ( !index.isValid() )
         return;
 
@@ -311,7 +330,12 @@ void DialogSettings::newEmailEditIndex(const QModelIndex &index)
 
 void DialogSettings::newEmailRemove()
 {
-    mModelNewEmails->remove( treeNewEmails->currentIndex() );
+    newEmailRemoveIndex( treeNewEmails->currentIndex() );
+}
+
+void DialogSettings::newEmailRemoveIndex(const QModelIndex &index)
+{
+    mModelNewEmails->remove( index );
 }
 
 void DialogSettings::onCheckUpdateButton() {

--- a/src/dialogsettings.h
+++ b/src/dialogsettings.h
@@ -2,6 +2,7 @@
 #define SETTINGSDIALOG_H
 
 #include <QDialog>
+#include <QKeyEvent>
 #include <QProgressDialog>
 #include <QPalette>
 #include <QtCore/QStringListModel>
@@ -51,12 +52,14 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
         void    accountEdit();
         void    accountEditIndex( const QModelIndex& index );
         void    accountRemove();
+        void    accountRemoveIndex( const QModelIndex& index );
 
         // New Email buttons
         void    newEmailAdd();
         void    newEmailEdit();
         void    newEmailEditIndex( const QModelIndex& index );
         void    newEmailRemove();
+        void    newEmailRemoveIndex( const QModelIndex& index );
         
         // Advanced buttons
         void    onCheckUpdateButton();
@@ -76,6 +79,8 @@ class DialogSettings : public QDialog, public Ui::DialogSettings
          * Show the translators dialog.
          */
         static void onTranslatorsDialog();
+
+        void onKeyPressedOnTreeAccount(QKeyEvent * event);
 
     private:
         void    changeIcon(QToolButton * button );

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -291,7 +291,7 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QTreeView" name="treeAccounts">
+             <widget class="QTreeViewWithKeyEvents" name="treeAccounts">
               <property name="enabled">
                <bool>true</bool>
               </property>
@@ -1166,6 +1166,11 @@ p, li { white-space: pre-wrap; }
    <class>ColorButton</class>
    <extends>QPushButton</extends>
    <header>colorbutton.h</header>
+  </customwidget>
+  <customwidget>
+    <class>QTreeViewWithKeyEvents</class>
+    <extends>QTreeView</extends>
+    <header>qtcomponents.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/qtcomponents.cpp
+++ b/src/qtcomponents.cpp
@@ -1,0 +1,22 @@
+#include "qtcomponents.h"
+
+QTreeViewWithKeyEvents::QTreeViewWithKeyEvents( QWidget *parent )
+    : QTreeView(parent)
+{
+
+}
+
+void QTreeViewWithKeyEvents::onKeyPressed( void * handle, TreeViewKeyPressedEvent callback)
+{
+    mHandle = handle;
+    mCallback = callback;
+}
+
+void QTreeViewWithKeyEvents::keyPressEvent( QKeyEvent *event )
+{
+    if (mCallback != NULL && mHandle != NULL)
+    {
+        mCallback(mHandle, event);
+    }
+    QTreeView::keyPressEvent(event);
+}

--- a/src/qtcomponents.h
+++ b/src/qtcomponents.h
@@ -1,0 +1,29 @@
+#ifndef QTCOMPONENTS_H
+#define QTCOMPONENTS_H
+
+#include <QKeyEvent>
+#include <QTreeView>
+
+typedef void ( * TreeViewKeyPressedEvent)(void * handle, QKeyEvent * event);
+
+/**
+ * A QTreeView that allow to define listener of keyEvent received
+ */
+class QTreeViewWithKeyEvents : public QTreeView {
+    Q_OBJECT
+
+    public:
+        explicit QTreeViewWithKeyEvents(QWidget *parent = NULL);
+
+    public slots:
+        void onKeyPressed(void * handleUsed, TreeViewKeyPressedEvent callback);
+
+    protected:
+        void keyPressEvent(QKeyEvent * event) override;
+
+    private:
+        TreeViewKeyPressedEvent mCallback;
+        void * mHandle;
+};
+
+#endif // QTCOMPONENTS_H


### PR DESCRIPTION
When you have a large number of accounts/folder to monitor, it's quite useful to enable deletion with a keystroke on the keyboard instead of clicking a button, so this PR is made for that.