### PR TITLE
Fix stance on Wayland Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This can often be fixed by using the `Repair` functionality in Thunderbird in th
 
 Generally Birdtray expects a spec-compliant desktop manager. If you're using a barebone or non-standard/light/simple desktop manager, it is very likely that some features of Birdtray will not work properly. Most likely candidates are hiding and restoring Thunderbird window(s) - including their position and state. But sometimes even a system tray icon isn't shown. Linux Mint with Cinnamon seem to be one particularly troublesome distro which reports many issues.
 
-Working with Wayland: at this moment Birdtray partially works with Wayland - email monitoring functionality works, but show/hide does not. Please track the issue https://github.com/gyunaev/birdtray/issues/426 to see the current status. Please do not report Wayland-related issues unless you built Birdtray from source yourself.
+Working with Wayland: I do not want to personally support Wayland. Please fork the project and add support if you would like Wayland support. If you still choose to use Birdtray on Wayland the email monitoring functionality works, but show/hide does not. Please track the issue https://github.com/gyunaev/birdtray/issues/426 to see the current status. Please do not report Wayland-related issues unless there has been an accepted pull request with Wayland support.
 
 ## Submitting bugs and feature requests
 


### PR DESCRIPTION
This Pull Request rewords the README.md to note that the author has no intention whatsoever of supporting Wayland themselves, and lets the end user know in no uncertain terms that if they use Wayland they will not receive any kind of support.