### PR TITLE
Allow to configure an offset of the unread counter on the icon

### DIFF
--- a/src/dialogsettings.cpp
+++ b/src/dialogsettings.cpp
@@ -34,7 +34,7 @@ DialogSettings::DialogSettings( QWidget *parent)
     connect( btnNotificationIcon, &QPushButton::clicked, this, &DialogSettings::buttonChangeIcon );
     connect( btnNotificationIconUnread, &QPushButton::clicked, this, &DialogSettings::buttonChangeUnreadIcon );
     connect(borderWidthSlider, &QSlider::valueChanged, this, &DialogSettings::onBorderWidthChanged);
-connect(spinMaximumFontSize, &QSpinBox::valueChanged, this, &DialogSettings::onMaximumFontSizeChanged);
+    connect(spinMaximumFontSize, &QSpinBox::valueChanged, this, &DialogSettings::onMaximumFontSizeChanged);
     connect(spinMinimumFontSize, &QSpinBox::valueChanged, this, &DialogSettings::onMinimumFontSizeChanged);
 
     connect( treeAccounts, &QTreeView::doubleClicked, this, &DialogSettings::accountEditIndex  );
@@ -61,6 +61,8 @@ connect(spinMaximumFontSize, &QSpinBox::valueChanged, this, &DialogSettings::onM
     btnNotificationColor->setColor( settings->mNotificationDefaultColor );
     borderColorButton->setColor(settings->mNotificationBorderColor);
     borderWidthSlider->setValue(static_cast<int>(settings->mNotificationBorderWidth) * 2);
+    spinHorizontalUnreadCountOffset->setValue(settings->horizontalUnreadCountOffset * 100.0);
+    spinVerticalUnreadCountOffset->setValue(settings->verticalUnreadCountOffset * 100.0);
     notificationFont->setCurrentFont( settings->mNotificationFont );
     notificationFontWeight->setValue( settings->mNotificationFontWeight * 2 );
     sliderBlinkingSpeed->setValue( settings->mBlinkSpeed == 0 ?
@@ -74,7 +76,7 @@ connect(spinMaximumFontSize, &QSpinBox::valueChanged, this, &DialogSettings::onM
     leThunderbirdWindowMatch->setText( settings->mThunderbirdWindowMatch  );
     spinMinimumFontSize->setValue( settings->mNotificationMinimumFontSize );
     spinMinimumFontSize->setMaximum( settings->mNotificationMaximumFontSize - 1 );
-spinMaximumFontSize->setValue( settings->mNotificationMaximumFontSize );
+    spinMaximumFontSize->setValue( settings->mNotificationMaximumFontSize );
     spinMaximumFontSize->setMinimum( settings->mNotificationMinimumFontSize + 1 );
     boxHideWindowAtStart->setChecked( settings->mHideWhenStarted );
     boxHideWindowAtRestart->setChecked( settings->mHideWhenRestarted );
@@ -175,6 +177,8 @@ void DialogSettings::accept()
     // A width of 100 is way to much, nobody will want to go beyond 50.
     settings->mNotificationBorderWidth = qRound(borderWidthSlider->value() / 2.0);
     settings->mNotificationFont = notificationFont->currentFont();
+    settings->horizontalUnreadCountOffset = spinHorizontalUnreadCountOffset->value() / 100.0;
+    settings->verticalUnreadCountOffset = spinVerticalUnreadCountOffset->value() / 100.0;
     settings->mBlinkSpeed = sliderBlinkingSpeed->value() == 0 ?
             0 : sliderBlinkingSpeed->maximum() + 1 - sliderBlinkingSpeed->value();
     settings->mLaunchThunderbird = boxLaunchThunderbirdAtStart->isChecked();

--- a/src/dialogsettings.ui
+++ b/src/dialogsettings.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <property name="tabBarAutoHide">
       <bool>false</bool>
@@ -152,7 +152,7 @@
              <string>Multiple notification color:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -188,7 +188,7 @@
              <string>Blinking speed:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -218,7 +218,7 @@
              <string>Notification border color:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -242,7 +242,7 @@
              <number>100</number>
             </property>
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -747,36 +747,29 @@
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1,0,0">
-            <item row="1" column="0">
-             <widget class="QLabel" name="labelWindowNamePattern">
+           <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0">
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="spinMinimumFontSize">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>1</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="text">
-               <string>Thunderbird window name pattern:</string>
+              <property name="suffix">
+               <string> points</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <property name="prefix">
+               <string>Minimum: </string>
               </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_7">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+              <property name="minimum">
+               <number>1</number>
               </property>
-              <property name="text">
-               <string>Thunderbird command line:</string>
+              <property name="maximum">
+               <number>512</number>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <property name="value">
+               <number>4</number>
               </property>
              </widget>
             </item>
@@ -796,55 +789,36 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="processNameLabel">
-              <property name="text">
-               <string>Thunderbird process name:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" colspan="3">
-             <widget class="QLineEdit" name="leThunderbirdProcessName"/>
-            </item>
-            <item row="1" column="1" colspan="3">
-             <widget class="QLineEdit" name="leThunderbirdWindowMatch"/>
-            </item>
-            <item row="0" column="1" colspan="3">
+            <item row="0" column="1" colspan="2">
              <widget class="QLineEdit" name="leThunderbirdCmdLine">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the full command-line (with arguments) which will be used to start Thunderbird. Arguments are space-separated, but spaces in quotes are allowed, i.e. something like &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;C:\Program Files\tb.exe&amp;quot; --profile test&lt;/span&gt; will work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
-             <widget class="QSpinBox" name="spinMinimumFontSize">
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelWindowNamePattern">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>1</horstretch>
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="suffix">
-               <string> points</string>
+              <property name="text">
+               <string>Thunderbird window name pattern:</string>
               </property>
-<property name="prefix">
-               <string>Minimum: </string>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>512</number>
-              </property>
-              <property name="value">
-               <number>4</number>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
              </widget>
             </item>
-            <item row="3" column="2" colspan="2">
+            <item row="2" column="1" colspan="2">
+             <widget class="QLineEdit" name="leThunderbirdProcessName"/>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="QLineEdit" name="leThunderbirdWindowMatch"/>
+            </item>
+            <item row="3" column="2">
              <widget class="QSpinBox" name="spinMaximumFontSize">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -852,7 +826,7 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-                           <property name="suffix">
+              <property name="suffix">
                <string> points</string>
               </property>
               <property name="prefix">
@@ -866,7 +840,75 @@
               </property>
              </widget>
             </item>
-                       </layout>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Thunderbird command line:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="processNameLabel">
+              <property name="text">
+               <string>Thunderbird process name:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>Count offset from center:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QDoubleSpinBox" name="spinVerticalUnreadCountOffset">
+              <property name="prefix">
+               <string>Vertical: </string>
+              </property>
+              <property name="suffix">
+               <string> %</string>
+              </property>
+              <property name="minimum">
+               <double>-100.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QDoubleSpinBox" name="spinHorizontalUnreadCountOffset">
+              <property name="prefix">
+               <string>Horizontal: </string>
+              </property>
+              <property name="suffix">
+               <string> %</string>
+              </property>
+              <property name="minimum">
+               <double>-100.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_8">
@@ -1255,7 +1297,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>translatorsButton</tabstop>
  </tabstops>
  <resources>
-    <include location="resources.qrc"/>
+  <include location="resources.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -16,6 +16,8 @@
 
 #define BORDER_COLOR_KEY "common/bordercolor"
 #define BORDER_WIDTH_KEY "common/borderwidth"
+#define HORIZONTAL_UNREAD_COUNT_OFFSET_KEY "advanced/horizontalUnreadCountOffset"
+#define VERTICAL_UNREAD_COUNT_OFFSET_KEY "advanced/verticalUnreadCountOffset"
 #define START_CLOSED_THUNDERBIRD_KEY "common/startClosedThunderbird"
 #define HIDE_WHEN_STARTED_MANUALLY_KEY "common/hideWhenStartedManually"
 #define THUNDERBIRD_PROCESS_NAME_KEY "advanced/tbprocessname"
@@ -49,6 +51,8 @@ Settings::Settings()
     mNotificationDefaultColor = QColor("#0000FF");
     mNotificationBorderColor = QColor("#FFFFFF");
     mNotificationBorderWidth = 15;
+    horizontalUnreadCountOffset = 0.0;
+    verticalUnreadCountOffset = 0.0;
     mBlinkSpeed = 0;
     mShowHideThunderbird = false;
     mLaunchThunderbird = false;
@@ -95,6 +99,8 @@ void Settings::save()
     out[ "common/defaultcolor" ] = mNotificationDefaultColor.name();
     out[ BORDER_COLOR_KEY ] = mNotificationBorderColor.name();
     out[ BORDER_WIDTH_KEY ] = static_cast<int>( mNotificationBorderWidth );
+    out[ HORIZONTAL_UNREAD_COUNT_OFFSET_KEY ] = horizontalUnreadCountOffset;
+    out[ VERTICAL_UNREAD_COUNT_OFFSET_KEY ] = verticalUnreadCountOffset;
     out[ "common/blinkspeed" ] = static_cast<int>( mBlinkSpeed );
     out[ "common/showhidethunderbird" ] = mShowHideThunderbird;
     out[ "common/launchthunderbird" ] = mLaunchThunderbird;
@@ -234,6 +240,8 @@ void Settings::fromJSON( const QJsonObject& settings )
     if ( settings.contains( "common/defaultcolor") )
         mNotificationBorderWidth = settings.value( BORDER_WIDTH_KEY ).toInt();
 
+    horizontalUnreadCountOffset = std::clamp(settings.value(HORIZONTAL_UNREAD_COUNT_OFFSET_KEY).toDouble(), -1.0, 1.0);
+    verticalUnreadCountOffset = std::clamp(settings.value(VERTICAL_UNREAD_COUNT_OFFSET_KEY).toDouble(), -1.0, 1.0);
     mBlinkSpeed = settings.value("common/blinkspeed").toInt();
     mShowHideThunderbird = settings.value("common/showhidethunderbird").toBool();
     mLaunchThunderbird = settings.value("common/launchthunderbird").toBool();
@@ -331,6 +339,10 @@ void Settings::fromQSettings( QSettings * psettings )
     mNotificationBorderWidth = settings.value( // Disable border on existing installations
             BORDER_WIDTH_KEY, settings.value("common/defaultcolor").isNull() ?
                               0 : mNotificationBorderWidth).toUInt();
+    horizontalUnreadCountOffset = settings.value(
+        HORIZONTAL_UNREAD_COUNT_OFFSET_KEY, horizontalUnreadCountOffset).toDouble();
+    verticalUnreadCountOffset = settings.value(
+        VERTICAL_UNREAD_COUNT_OFFSET_KEY, verticalUnreadCountOffset).toDouble();
     mBlinkSpeed = settings.value("common/blinkspeed", mBlinkSpeed ).toInt();
     mShowHideThunderbird = settings.value(
             "common/showhidethunderbird", mShowHideThunderbird ).toBool();

--- a/src/settings.h
+++ b/src/settings.h
@@ -49,6 +49,12 @@ class Settings
          */
         unsigned int mNotificationBorderWidth;
 
+        // Percentage horizontal offset from the center for drawing the unread count onto the icon. [-1.0,1.0]
+        double horizontalUnreadCountOffset;
+
+        // Percentage vertical offset from the center for drawing the unread count onto the icon. [-1.0,1.0]
+        double verticalUnreadCountOffset;
+
         // Blinking speed
         unsigned int    mBlinkSpeed;
 

--- a/src/translations/main_cs.ts
+++ b/src/translations/main_cs.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_de.ts
+++ b/src/translations/main_de.ts
@@ -289,7 +289,7 @@ Möglicherweise ist OpenSSL nicht installiert.</translation>
         <source>Thunderbird window name pattern:</source>
         <translation>Namensschema des Thunderbird-Fensters:</translation>
     </message>
-        <message>
+    <message>
         <source> points</source>
         <translation> Punkte</translation>
     </message>
@@ -527,6 +527,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Maximum: </source>
         <translation>Maximum: </translation>
+    </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation>Zählerversatz zur Mitte:</translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation>Horizontal: </translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation> %</translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation>Vertikal: </translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_el.ts
+++ b/src/translations/main_el.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_en.ts
+++ b/src/translations/main_en.ts
@@ -290,7 +290,7 @@ OpenSSL might not be installed.</source>
         <source>Thunderbird window name pattern:</source>
         <translation type="unfinished"></translation>
     </message>
-        <message>
+    <message>
         <source> points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,6 +492,22 @@ OpenSSL might not be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -509,7 +525,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
-    </context>
+</context>
 <context>
     <name>Log</name>
     <message>

--- a/src/translations/main_es.ts
+++ b/src/translations/main_es.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_fr.ts
+++ b/src/translations/main_fr.ts
@@ -293,7 +293,7 @@ OpenSSL ne semble pas installé.</translation>
         <source>Thunderbird window name pattern:</source>
         <translation>Modèle de nom de la fenêtre Thunderbird :</translation>
     </message>
-        <message>
+    <message>
         <source> points</source>
         <translation> points</translation>
     </message>
@@ -526,6 +526,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Maximum: </source>
         <translation>Maximum : </translation>
+    </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation>Horizontal : </translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation> %</translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation>Vertical : </translation>
     </message>
 </context>
 <context>

--- a/src/translations/main_it.ts
+++ b/src/translations/main_it.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_nl.ts
+++ b/src/translations/main_nl.ts
@@ -533,6 +533,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pl.ts
+++ b/src/translations/main_pl.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_pt.ts
+++ b/src/translations/main_pt.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_ru.ts
+++ b/src/translations/main_ru.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_sv.ts
+++ b/src/translations/main_sv.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>

--- a/src/translations/main_tr.ts
+++ b/src/translations/main_tr.ts
@@ -501,6 +501,22 @@ tuşunu basılı tutarak tıklayın):</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -518,7 +534,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Thank you for your continuous support!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
-    </context>
+</context>
 <context>
     <name>Log</name>
     <message>

--- a/src/translations/main_zh_cn.ts
+++ b/src/translations/main_zh_cn.ts
@@ -531,6 +531,22 @@ p, li { white-space: pre-wrap; }
         <source>Maximum: </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count offset from center:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Horizontal: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Log</name>


### PR DESCRIPTION
This allows to move the counter in the tray icon, **if the maximum font size is small enough that the counter can move**.
The offset is given as a positive or negative percentage, where 0% represents the center and +-100% the maximum offset.
The maximum offset takes the actual text, font size and border into account and makes sure that the number is always within the icon and never cut off.

An offset of horizontal: `100%`, vertical `-100%` and a maximum font size of `100pt` looks like this:
![Tray icon with the counter at the bottom right](https://github.com/user-attachments/assets/c30fca69-d4ed-43f0-a1ca-f92bc6bac564)

An offset of horizontal: `-100%`, vertical `100%` and a maximum font size of `50pt` looks like this:
![Tray icon with the counter at the top left](https://github.com/user-attachments/assets/53e5e371-fe31-4cb2-b176-e0e0e0790ab0)

The default is no offset, so this won't change existing setups.

I put the settings in the general tab:
![image](https://github.com/user-attachments/assets/1fbfbfc2-b11a-4d66-bc9f-8bdb9cc2efe9)

Closes #617.

------

*This is a draft because it is build on top of the unmerged #609.*