### PR TITLE
Minimize the Thunderbird window before hiding

### DIFF
--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -136,7 +136,7 @@ bool WindowTools_Win::hide() {
     if (!checkWindow()) {
         return false;
     }
-    ShowWindow(this->thunderbirdWindow, SW_FORCEMINIMIZE);
+    ShowWindow(this->thunderbirdWindow, SW_MINIMIZE);
     if (ShowWindow(this->thunderbirdWindow, SW_HIDE) > 0) {
         emit onWindowHidden();
         return true;

--- a/src/windowtools_win.cpp
+++ b/src/windowtools_win.cpp
@@ -136,6 +136,7 @@ bool WindowTools_Win::hide() {
     if (!checkWindow()) {
         return false;
     }
+    ShowWindow(this->thunderbirdWindow, SW_FORCEMINIMIZE);
     if (ShowWindow(this->thunderbirdWindow, SW_HIDE) > 0) {
         emit onWindowHidden();
         return true;


### PR DESCRIPTION
This hopefully fixes some weird behaviour where other windows would "freeze" until interacted with. Hopefully fixes #613. Leaving as a draft until we have confirmation or decide it's fine.