### PR TITLE
Avoid starting Thunderbird if we already started it

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -496,7 +496,7 @@ void TrayIcon::actionActivate()
         return;
 
     Settings* settings = BirdtrayApp::get()->getSettings();
-    if ( settings->startClosedThunderbird && !mWinTools->lookup() ) {
+    if ( settings->startClosedThunderbird && !mWinTools->lookup() && mThunderbirdProcess == nullptr ) {
         startThunderbird();
         if (settings->hideWhenStartedManually) {
             mThunderbirdWindowHide = true;
@@ -681,6 +681,11 @@ void TrayIcon::createUnreadCounterThread()
 
 void TrayIcon::startThunderbird()
 {
+    if ( mThunderbirdProcess ) {
+        Log::debug("Not starting Thunderbird because we already started it and it is still running" );
+        return;
+    }
+
     QString executable;
     QStringList args;
 
@@ -691,9 +696,6 @@ void TrayIcon::startThunderbird()
     }
 
     Log::debug("Starting Thunderbird as '%s %s'", qPrintable(executable), qPrintable(args.join(' ')));
-
-    if ( mThunderbirdProcess )
-        mThunderbirdProcess->deleteLater();
 
     mThunderbirdProcess = new QProcess();
     connect( mThunderbirdProcess, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(tbProcessFinished(int,QProcess::ExitStatus)) );


### PR DESCRIPTION
This fixes #625 by ignoring attempts to start Thunderbird if we already started it before.

Launching a new Thunderbird process while the other one was still running never really worked, because we would then delete the first process and immediately overwrite `mThunderbirdProcess` with a reference to the new process here:
https://github.com/gyunaev/birdtray/blob/6c31f6117dfc3b884e7f483adedb1c9a862187ec/src/trayicon.cpp#L696-L698

Deleting a `QProcess` stop the underlying process, and then `TrayIcon::tbProcessFinished` would be called, which then deleted and stopped the new process because `mThunderbirdProcess` already points to the new process:
https://github.com/gyunaev/birdtray/blob/6c31f6117dfc3b884e7f483adedb1c9a862187ec/src/trayicon.cpp#L738

I tested this locally on Windows and confirmed that I couldn't reproduce the bug anymore, but I'm marking this as a draft while waiting for a verification from the reporter that this really fixes the problem for them.