### PR TITLE
Detect missing qt ssl feature and fail early

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(Qt6Svg CONFIG REQUIRED)
 find_package(Qt6LinguistTools CONFIG QUIET)
 set(REQUIRED_MODULES Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::Svg)
 
+if(NOT QT_FEATURE_ssl)
+    message(FATAL_ERROR "Birdtray requires Qt with ssl support enabled, see https://doc.qt.io/qt-6/ssl.html")
+endif()
+
 set(PLATFORM_SOURCES)
 set(PLATFORM_HEADERS)
 set(EXECUTABLE_OPTIONS)


### PR DESCRIPTION
This might have helped in #627.

[The `sslConfiguration` member is gated behind a `#if QT_CONFIG(ssl)` check](https://codebrowser.dev/qt6/qtbase/src/network/access/qnetworkreply.h.html#117):
```c++
#if QT_CONFIG(ssl)
QSslConfiguration sslConfiguration() const;
void setSslConfiguration(const QSslConfiguration &configuration);
void ignoreSslErrors(const QList<QSslError> &errors);
#endif
```

According to [the official Qt6 build system documentation](https://wiki.qt.io/Qt6_Build_System#Testing_the_feature_value_in_CMake), we can check for the `ssl` feature by checking the `QT_FEATURE_ssl` variable.