### PR TITLE
Invoke insteed direct call

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -124,8 +124,9 @@ void Log::add(const QString &text)
     mEntries.push_back( logline );
 
     // Add it to the open log window, if any
-    if ( !mDialog.isNull() )
-        mDialog.data()->add( logline );
+    if ( !mDialog.isNull() ) {
+        QMetaObject::invokeMethod(mDialog.data(), "add", logline);
+    }
 
     // if log file is open, append to log file
     if (mOutputFile.isOpen()) {


### PR DESCRIPTION
For multithreading, you need to use invoke.

In the latest version of QT (6.9), the application crashes when adding log events (access violation on module QT6Widgets.dll).